### PR TITLE
Allow Exit subtype to be a floating Effect

### DIFF
--- a/.changeset/metal-buses-rescue.md
+++ b/.changeset/metal-buses-rescue.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Allow Exit subtype to be a floating Effect

--- a/examples/diagnostics/floatingEffect.ts
+++ b/examples/diagnostics/floatingEffect.ts
@@ -18,5 +18,10 @@ Effect.runPromise(Effect.gen(function*(){
 
 export function constructorFunction(this: { boot: Effect.Effect<void>}){
     this.boot = Effect.void
+    // ^- This is fine, its another way to perform an assignment
 }
 
+const main = Effect.gen(function*(){
+    yield* Effect.exit(Effect.void)
+    // ^- This is fine, returns an exit
+})

--- a/src/utils/TypeParser.ts
+++ b/src/utils/TypeParser.ts
@@ -84,6 +84,21 @@ export function fiberType(ts: TypeScriptApi, typeChecker: ts.TypeChecker) {
     })
 }
 
+export function effectSubtype(ts: TypeScriptApi, typeChecker: ts.TypeChecker) {
+  return (type: ts.Type, atLocation: ts.Node) =>
+    Option.gen(function*(_) {
+      // there is no better way to check if a type is a subtype of effect
+      // so we just check for the existence of the property "_tag"
+      // which is common for Option, Either, and others
+      const tagSymbol = yield* Option.fromNullable(
+        typeChecker.getPropertyOfType(type, "_tag")
+      )
+      if (!tagSymbol) return yield* Option.none()
+      // and it is also an effect itself
+      return effectType(ts, typeChecker)(type, atLocation)
+    })
+}
+
 export function importedEffectModule(ts: TypeScriptApi, typeChecker: ts.TypeChecker) {
   return (node: ts.Node) =>
     Option.gen(function*() {


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`Exit<A, E>` is now an allowed type that can be floating.
It was reported as a floating effect due to subtyping of Effect.