### PR TITLE
Handle Effect.fn and Effect.fnUntraced in missing yield star diagnostic

### DIFF
--- a/.changeset/icy-ghosts-jog.md
+++ b/.changeset/icy-ghosts-jog.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Handle Effect.fn and Effect.fnUntraced in missing yield star diagnostic

--- a/examples/diagnostics/missingStarInYieldEffectGen.ts
+++ b/examples/diagnostics/missingStarInYieldEffectGen.ts
@@ -27,14 +27,17 @@ export function* effectInsideStandardGenerator(){
     // ^- this is fine, not inside an effect gen
 }
 
+// @ts-expect-error
 const effectFnUsage = Effect.fn(function*(){
     yield Effect.never
 })
 
+// @ts-expect-error
 const tracedEffectFnUsage = Effect.fn("tracedEffectFnUsage")(function*(){
     yield Effect.never
 })
 
+// @ts-expect-error
 const untracedEffectFnUsage = Effect.fnUntraced(function*(){
     yield Effect.never
 })

--- a/examples/diagnostics/missingStarInYieldEffectGen.ts
+++ b/examples/diagnostics/missingStarInYieldEffectGen.ts
@@ -21,3 +21,20 @@ const missingStarInInnerYield = Effect.gen(function*(){
         yield Effect.succeed(1)
     })
 })
+
+export function* effectInsideStandardGenerator(){
+    yield Effect.never
+    // ^- this is fine, not inside an effect gen
+}
+
+const effectFnUsage = Effect.fn(function*(){
+    yield Effect.never
+})
+
+const tracedEffectFnUsage = Effect.fn("tracedEffectFnUsage")(function*(){
+    yield Effect.never
+})
+
+const untracedEffectFnUsage = Effect.fnUntraced(function*(){
+    yield Effect.never
+})

--- a/test/__snapshots__/diagnostics.test.ts.snap
+++ b/test/__snapshots__/diagnostics.test.ts.snap
@@ -103,5 +103,23 @@ function
 20:22 - 20:30 | Seems like you used yield instead of yield* inside this Effect.gen.
 
 yield Effect.succeed(1)
-21:8 - 21:31 | When yielding Effects inside Effect.gen, you should use yield* instead of yield."
+21:8 - 21:31 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+
+function
+30:32 - 30:40 | Seems like you used yield instead of yield* inside this Effect.gen.
+
+yield Effect.never
+31:4 - 31:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+
+function
+34:61 - 34:69 | Seems like you used yield instead of yield* inside this Effect.gen.
+
+yield Effect.never
+35:4 - 35:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+
+function
+38:48 - 38:56 | Seems like you used yield instead of yield* inside this Effect.gen.
+
+yield Effect.never
+39:4 - 39:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield."
 `;

--- a/test/__snapshots__/diagnostics.test.ts.snap
+++ b/test/__snapshots__/diagnostics.test.ts.snap
@@ -106,20 +106,20 @@ yield Effect.succeed(1)
 21:8 - 21:31 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
 
 function
-30:32 - 30:40 | Seems like you used yield instead of yield* inside this Effect.gen.
+31:32 - 31:40 | Seems like you used yield instead of yield* inside this Effect.gen.
 
 yield Effect.never
-31:4 - 31:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+32:4 - 32:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
 
 function
-34:61 - 34:69 | Seems like you used yield instead of yield* inside this Effect.gen.
+36:61 - 36:69 | Seems like you used yield instead of yield* inside this Effect.gen.
 
 yield Effect.never
-35:4 - 35:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+37:4 - 37:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
 
 function
-38:48 - 38:56 | Seems like you used yield instead of yield* inside this Effect.gen.
+41:48 - 41:56 | Seems like you used yield instead of yield* inside this Effect.gen.
 
 yield Effect.never
-39:4 - 39:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield."
+42:4 - 42:22 | When yielding Effects inside Effect.gen, you should use yield* instead of yield."
 `;


### PR DESCRIPTION
## Type


- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Handle Effect.fn and Effect.fnUntraced in missing yield star diagnostic. The generator will be checked in the same way we check Effect.gen
