### PR TITLE
Add support for toggle type annotation in class property members

### DIFF
--- a/.changeset/lemon-bears-teach.md
+++ b/.changeset/lemon-bears-teach.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add support for toggle type annotation in class property members

--- a/examples/refactors/toggleTypeAnnotation.ts
+++ b/examples/refactors/toggleTypeAnnotation.ts
@@ -1,4 +1,4 @@
-// 4:16,5:16,8:16,11:16,12:16,14:16,15:16,20:16,24:16,38:16
+// 4:16,5:16,8:16,11:16,12:16,14:16,15:16,20:16,24:16,38:16,41:15,42:15,43:9,44:9
 import * as T from "effect/Effect"
 
 export const test1 = T.succeed
@@ -36,3 +36,10 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}

--- a/src/refactors/toggleTypeAnnotation.ts
+++ b/src/refactors/toggleTypeAnnotation.ts
@@ -10,7 +10,7 @@ export const toggleTypeAnnotation = createRefactor({
   apply: (ts, program) => (sourceFile, textRange) =>
     pipe(
       AST.getNodesContainingRange(ts)(sourceFile, textRange),
-      ReadonlyArray.filter(ts.isVariableDeclaration),
+      ReadonlyArray.filter(node => ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)),
       ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.name)),
       ReadonlyArray.filter((node) => !!node.initializer),
       ReadonlyArray.head,

--- a/src/refactors/toggleTypeAnnotation.ts
+++ b/src/refactors/toggleTypeAnnotation.ts
@@ -10,7 +10,9 @@ export const toggleTypeAnnotation = createRefactor({
   apply: (ts, program) => (sourceFile, textRange) =>
     pipe(
       AST.getNodesContainingRange(ts)(sourceFile, textRange),
-      ReadonlyArray.filter(node => ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)),
+      ReadonlyArray.filter((node) =>
+        ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)
+      ),
       ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.name)),
       ReadonlyArray.filter((node) => !!node.initializer),
       ReadonlyArray.head,

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -399,6 +399,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -441,6 +448,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -483,6 +497,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -525,6 +546,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -567,6 +595,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -609,6 +644,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -651,6 +693,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -696,6 +745,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -741,6 +797,13 @@ declare const intersection2: {
 declare function intersect<A, B>(a: A, b: B): A & B
 
 export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
 "
 `;
 
@@ -788,6 +851,209 @@ export const test8: {
     (a: 3): number;
     (b: 4): bigint
 } = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
+"
+`;
+
+exports[`toggleTypeAnnotation.ts > toggleTypeAnnotation.ts at 41:15 1`] = `
+"// Result of running refactor effect/toggleTypeAnnotation at position 41:15
+import * as T from "effect/Effect"
+
+export const test1 = T.succeed
+export const test2 = T.fail("LOL")
+
+const predefined = 42
+export const test3 = predefined
+
+const callable = () => 42
+export const test4 = callable
+export const test5 = T.die
+
+const removeAnnotation:number=42
+const removeAnnotationWithSpace: number = 42
+
+declare function withOverloads(a: 1): boolean
+declare function withOverloads(a: 2): string
+
+export const test6 = withOverloads
+
+declare const functIntersection: ((a: 1) => boolean) & ((a: 2) => string)
+
+export const test7 = functIntersection
+
+declare const intersection1: {
+    (a: 1): boolean
+    (b: 2): string
+}
+
+declare const intersection2: {
+    (a: 3): number
+    (b: 4): bigint
+}
+
+declare function intersect<A, B>(a: A, b: B): A & B
+
+export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd: "hello" = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
+"
+`;
+
+exports[`toggleTypeAnnotation.ts > toggleTypeAnnotation.ts at 42:15 1`] = `
+"// Result of running refactor effect/toggleTypeAnnotation at position 42:15
+import * as T from "effect/Effect"
+
+export const test1 = T.succeed
+export const test2 = T.fail("LOL")
+
+const predefined = 42
+export const test3 = predefined
+
+const callable = () => 42
+export const test4 = callable
+export const test5 = T.die
+
+const removeAnnotation:number=42
+const removeAnnotationWithSpace: number = 42
+
+declare function withOverloads(a: 1): boolean
+declare function withOverloads(a: 2): string
+
+export const test6 = withOverloads
+
+declare const functIntersection: ((a: 1) => boolean) & ((a: 2) => string)
+
+export const test7 = functIntersection
+
+declare const intersection1: {
+    (a: 1): boolean
+    (b: 2): string
+}
+
+declare const intersection2: {
+    (a: 3): number
+    (b: 4): bigint
+}
+
+declare function intersect<A, B>(a: A, b: B): A & B
+
+export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove = "hello"
+    propAdd = "hello"
+    propRemove: string = "hello"    
+}
+"
+`;
+
+exports[`toggleTypeAnnotation.ts > toggleTypeAnnotation.ts at 43:9 1`] = `
+"// Result of running refactor effect/toggleTypeAnnotation at position 43:9
+import * as T from "effect/Effect"
+
+export const test1 = T.succeed
+export const test2 = T.fail("LOL")
+
+const predefined = 42
+export const test3 = predefined
+
+const callable = () => 42
+export const test4 = callable
+export const test5 = T.die
+
+const removeAnnotation:number=42
+const removeAnnotationWithSpace: number = 42
+
+declare function withOverloads(a: 1): boolean
+declare function withOverloads(a: 2): string
+
+export const test6 = withOverloads
+
+declare const functIntersection: ((a: 1) => boolean) & ((a: 2) => string)
+
+export const test7 = functIntersection
+
+declare const intersection1: {
+    (a: 1): boolean
+    (b: 2): string
+}
+
+declare const intersection2: {
+    (a: 3): number
+    (b: 4): bigint
+}
+
+declare function intersect<A, B>(a: A, b: B): A & B
+
+export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd: "hello" = "hello"
+    propRemove: string = "hello"    
+}
+"
+`;
+
+exports[`toggleTypeAnnotation.ts > toggleTypeAnnotation.ts at 44:9 1`] = `
+"// Result of running refactor effect/toggleTypeAnnotation at position 44:9
+import * as T from "effect/Effect"
+
+export const test1 = T.succeed
+export const test2 = T.fail("LOL")
+
+const predefined = 42
+export const test3 = predefined
+
+const callable = () => 42
+export const test4 = callable
+export const test5 = T.die
+
+const removeAnnotation:number=42
+const removeAnnotationWithSpace: number = 42
+
+declare function withOverloads(a: 1): boolean
+declare function withOverloads(a: 2): string
+
+export const test6 = withOverloads
+
+declare const functIntersection: ((a: 1) => boolean) & ((a: 2) => string)
+
+export const test7 = functIntersection
+
+declare const intersection1: {
+    (a: 1): boolean
+    (b: 2): string
+}
+
+declare const intersection2: {
+    (a: 3): number
+    (b: 4): bigint
+}
+
+declare function intersect<A, B>(a: A, b: B): A & B
+
+export const test8 = intersect(intersection1, intersection2)
+
+class Test {
+    static liveAdd = "hello"
+    static liveRemove: string = "hello"
+    propAdd = "hello"
+    propRemove = "hello"    
+}
 "
 `;
 


### PR DESCRIPTION

## Type


- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Now refactor toggle return type is available inside property declarations of classes, such as

```ts
class Test {
   static live /*<- here */ = "value to infer type from"
}
```

