### PR TITLE
Avoid to bail-out type generation when imports are missing, show inst…

### DIFF
--- a/.changeset/common-memes-agree.md
+++ b/.changeset/common-memes-agree.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Avoid to bail-out type generation when imports are missing, show instead partial signature

--- a/examples/refactors/toggleTypeAnnotation_schema.ts
+++ b/examples/refactors/toggleTypeAnnotation_schema.ts
@@ -1,0 +1,12 @@
+// 11:15
+import * as Schema from "effect/Schema"
+import * as ParseResult from "effect/ParseResult"
+import * as ParseOption from "effect/SchemaAST"
+import * as Effect from "effect/Effect"
+
+class Person extends Schema.TaggedClass<Person>("Person")("Person", {
+    name: Schema.NonEmptyString,
+    age: Schema.Int
+}){
+    static decode = Schema.decode(Person)
+}

--- a/src/refactors/toggleTypeAnnotation.ts
+++ b/src/refactors/toggleTypeAnnotation.ts
@@ -30,10 +30,19 @@ export const toggleTypeAnnotation = createRefactor({
 
             const initializer = node.initializer!
             const initializerType = typeChecker.getTypeAtLocation(initializer)
-            const initializerTypeNode = typeChecker.typeToTypeNode(
+            const initializerTypeNode = Option.fromNullable(typeChecker.typeToTypeNode(
               initializerType,
               node,
               ts.NodeBuilderFlags.NoTruncation
+            )).pipe(
+              Option.orElse(() =>
+                Option.fromNullable(typeChecker.typeToTypeNode(
+                  initializerType,
+                  undefined,
+                  ts.NodeBuilderFlags.NoTruncation
+                ))
+              ),
+              Option.getOrUndefined
             )
             if (initializerTypeNode) {
               changeTracker.insertNodeAt(

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -1057,6 +1057,22 @@ class Test {
 "
 `;
 
+exports[`toggleTypeAnnotation_schema.ts > toggleTypeAnnotation_schema.ts at 11:15 1`] = `
+"// Result of running refactor effect/toggleTypeAnnotation at position 11:15
+import * as Schema from "effect/Schema"
+import * as ParseResult from "effect/ParseResult"
+import * as ParseOption from "effect/SchemaAST"
+import * as Effect from "effect/Effect"
+
+class Person extends Schema.TaggedClass<Person>("Person")("Person", {
+    name: Schema.NonEmptyString,
+    age: Schema.Int
+}){
+    static decode: (i: { readonly name: string; readonly age: number; readonly _tag: "Person" }, overrideOptions?: ParseOption.ParseOptions) => Effect.Effect<Person, ParseResult.ParseError, never> = Schema.decode(Person)
+}
+"
+`;
+
 exports[`wrapWithPipe.ts > wrapWithPipe.ts at 2:13-2:26 1`] = `
 "// Result of running refactor effect/wrapWithPipe at position 2:13-2:26
 const txt = pipe("Hello World")


### PR DESCRIPTION
…ead partial signature


## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The following would have failed before due to missing Effect/ParseResult import
```ts
import * as Schema from "effect/Schema"

class Person extends Schema.TaggedClass<Person>("Person")("Person", {
    name: Schema.NonEmptyString
}){
    static decode = Schema.decode(Person)
}
```

now it will instead produce an output anyway, with non-qualified types:

```ts
import * as Schema from "effect/Schema"

class Person extends Schema.TaggedClass<Person>("Person")("Person", {
    name: Schema.NonEmptyString
}){
    static decode: (i: { readonly name: string; readonly _tag: "Person" }, overrideOptions?: ParseOptions | undefined) => Effect<Person, ParseError, never> = Schema.decode(Person)
}

```