### PR TITLE
Add refactor: remove unnecessary Effect.gen

### DIFF
--- a/.changeset/new-lamps-hope.md
+++ b/.changeset/new-lamps-hope.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add refactor remove-unnecessary-effect-gen. This removes unnecessary `Effect.gen` calls by simplifying generator functions that only wrap a single `yield*` statement returning an `Effect`. This refactor replaces the `Effect.gen` wrapper with the inner `Effect` directly, making the code more concise and readable.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This package implements a TypeScript language service plugin that allows additio
 
 ## Installation
 
-1) `npm install @effect/language-service` in your project
-2) inside your tsconfig.json, you should add the plugin configuration as follows:
+1. `npm install @effect/language-service` in your project
+2. inside your tsconfig.json, you should add the plugin configuration as follows:
 
 ```json
 {
@@ -18,10 +18,11 @@ This package implements a TypeScript language service plugin that allows additio
   }
 }
 ```
-3) Ensure that you set your editor to use your workspace TypeScript version. 
-  
-    - In VSCode you can do this by pressing "F1" and typing "TypeScript: Select TypeScript version". Then select "Use workspace version".
-    - In JetBrains you may have to disable the Vue language service, and chose the workspace version of TypeScript in the settings from the dropdown.
+
+3. Ensure that you set your editor to use your workspace TypeScript version.
+
+   - In VSCode you can do this by pressing "F1" and typing "TypeScript: Select TypeScript version". Then select "Use workspace version".
+   - In JetBrains you may have to disable the Vue language service, and chose the workspace version of TypeScript in the settings from the dropdown.
 
 And you're done! You'll now be able to use a set of refactor and diagnostics that targets Effect!
 
@@ -46,6 +47,7 @@ Few options can be provided alongside the initialization of the Language Service
 ## Provided functionalities
 
 ### Quickinfo
+
 - Show the extended type of the current Effect
 
 ### Diagnostics
@@ -63,3 +65,4 @@ Few options can be provided alongside the initialization of the Language Service
 - Function calls to pipe: Transform a set of function calls to a pipe() call.
 - Pipe to datafirst: Transform a pipe() call into a series of datafirst function calls (where available).
 - Toggle return type signature: With a single refactor, adds or removes type annotations from the definition.
+- Remove unnecessary `Effect.gen` calls by simplifying generator functions that only wrap a single `yield*` statement returning an `Effect`. This refactor replaces the `Effect.gen` wrapper with the inner `Effect` directly, making the code more concise and readable.

--- a/examples/refactors/removeUnnecessaryEffectGen.ts
+++ b/examples/refactors/removeUnnecessaryEffectGen.ts
@@ -1,0 +1,22 @@
+// 4:22,8:1,12:22,13:19,19:27
+import * as Effect from "effect/Effect"
+
+export const test1 = Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+export const test2 = Effect.gen(function* () {
+    return yield* Effect.gen(function* () {
+        return yield* Effect.succeed(42)
+    })
+})
+
+export const test3 = Effect.succeed(42).pipe(
+    Effect.andThen((a) => Effect.gen(function* () {
+        return yield* Effect.succeed(a)
+    })),
+)

--- a/src/diagnostics/unnecessaryEffectGen.ts
+++ b/src/diagnostics/unnecessaryEffectGen.ts
@@ -2,7 +2,7 @@ import * as Option from "effect/Option"
 import type ts from "typescript"
 import type { ApplicableDiagnosticDefinition } from "../definition.js"
 import { createDiagnostic } from "../definition.js"
-import * as TypeParser from "../utils/TypeParser.js"
+import * as AST from "../utils/AST.js"
 
 export const unnecessaryEffectGen = createDiagnostic({
   code: 5,
@@ -12,27 +12,8 @@ export const unnecessaryEffectGen = createDiagnostic({
     const brokenGenerators = new Set<ts.Node>()
 
     const visit = (node: ts.Node) => {
-      // did we hit an effect gen-like?
-      const effectGenLike = TypeParser.effectGen(ts, typeChecker)(node)
-
-      if (Option.isSome(effectGenLike)) {
-        // if we hit an effect gen-like, we need to check if its body is just a single return statement
-        const body = effectGenLike.value.body
-        if (
-          body.statements.length === 1 &&
-          ts.isReturnStatement(body.statements[0]) &&
-          body.statements[0].expression &&
-          ts.isYieldExpression(body.statements[0].expression) &&
-          body.statements[0].expression.expression
-        ) {
-          // get the type of the node
-          const nodeToCheck = body.statements[0].expression.expression
-          const type = typeChecker.getTypeAtLocation(nodeToCheck)
-          const maybeEffect = TypeParser.effectType(ts, typeChecker)(type, nodeToCheck)
-          if (Option.isSome(maybeEffect)) {
-            brokenGenerators.add(node)
-          }
-        }
+      if (Option.isSome(AST.getSingleReturnEffectFromEffectGen(typeChecker, node))) {
+        brokenGenerators.add(node)
       }
       ts.forEachChild(node, visit)
     }

--- a/src/quickinfo.ts
+++ b/src/quickinfo.ts
@@ -58,7 +58,7 @@ export function prependEffectTypeArguments(ts: TypeScriptApi, program: ts.Progra
     const typeChecker = program.getTypeChecker()
 
     const effectTypeArgsDocumentation = pipe(
-      AST.getNodesContainingRange(ts)(sourceFile, AST.toTextRange(position)),
+      AST.getAncestorNodesInRange(ts)(sourceFile, AST.toTextRange(position)),
       ReadonlyArray.head,
       Option.flatMap((_) =>
         TypeParser.effectType(ts, typeChecker)(typeChecker.getTypeAtLocation(_), _)

--- a/src/refactors.ts
+++ b/src/refactors.ts
@@ -6,6 +6,7 @@ import { asyncAwaitToGenTryPromise } from "./refactors/asyncAwaitToGenTryPromise
 import { effectGenToFn } from "./refactors/effectGenToFn.js"
 import { functionToArrow } from "./refactors/functionToArrow.js"
 import { pipeableToDatafirst } from "./refactors/pipeableToDatafirst.js"
+import { removeUnnecessaryEffectGen } from "./refactors/removeUnnecessaryEffectGen.js"
 import { toggleLazyConst } from "./refactors/toggleLazyConst.js"
 import { toggleReturnTypeAnnotation } from "./refactors/toggleReturnTypeAnnotation.js"
 import { toggleTypeAnnotation } from "./refactors/toggleTypeAnnotation.js"
@@ -19,6 +20,7 @@ export const refactors = {
   asyncAwaitToGenTryPromise,
   functionToArrow,
   pipeableToDatafirst,
+  removeUnnecessaryEffectGen,
   toggleLazyConst,
   toggleReturnTypeAnnotation,
   toggleTypeAnnotation,

--- a/src/refactors/asyncAwaitToGen.ts
+++ b/src/refactors/asyncAwaitToGen.ts
@@ -10,7 +10,7 @@ export const asyncAwaitToGen = createRefactor({
   description: "Convert to Effect.gen",
   apply: (ts, program) => (sourceFile, textRange) =>
     pipe(
-      AST.getNodesContainingRange(ts)(sourceFile, textRange),
+      AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
       ReadonlyArray.filter((node) =>
         ts.isFunctionDeclaration(node) || ts.isArrowFunction(node) || ts.isFunctionExpression(node)
       ),

--- a/src/refactors/asyncAwaitToGenTryPromise.ts
+++ b/src/refactors/asyncAwaitToGenTryPromise.ts
@@ -10,7 +10,7 @@ export const asyncAwaitToGenTryPromise = createRefactor({
   description: "Convert to Effect.gen with failures",
   apply: (ts, program) => (sourceFile, textRange) =>
     pipe(
-      AST.getNodesContainingRange(ts)(sourceFile, textRange),
+      AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
       ReadonlyArray.filter(
         (node) =>
           ts.isFunctionDeclaration(node) || ts.isArrowFunction(node) ||

--- a/src/refactors/effectGenToFn.ts
+++ b/src/refactors/effectGenToFn.ts
@@ -11,7 +11,7 @@ export const effectGenToFn = createRefactor({
   description: "Convert to Effect.fn",
   apply: (ts, program) => (sourceFile, textRange) =>
     pipe(
-      AST.getNodesContainingRange(ts)(sourceFile, textRange),
+      AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
       ReadonlyArray.findFirst((node) =>
         Option.gen(function*() {
           // check if the node is a Effect.gen(...)

--- a/src/refactors/functionToArrow.ts
+++ b/src/refactors/functionToArrow.ts
@@ -11,12 +11,12 @@ export const functionToArrow = createRefactor({
   apply: (ts) => (sourceFile, textRange) =>
     pipe(
       pipe(
-        AST.getNodesContainingRange(ts)(sourceFile, textRange),
+        AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
         ReadonlyArray.filter(ts.isFunctionDeclaration)
       ),
       ReadonlyArray.appendAll(
         pipe(
-          AST.getNodesContainingRange(ts)(sourceFile, textRange),
+          AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
           ReadonlyArray.filter(ts.isMethodDeclaration)
         )
       ),

--- a/src/refactors/pipeableToDatafirst.ts
+++ b/src/refactors/pipeableToDatafirst.ts
@@ -9,7 +9,7 @@ export const pipeableToDatafirst = createRefactor({
   description: "Rewrite to datafirst",
   apply: (ts, program) => (sourceFile, textRange) =>
     pipe(
-      AST.getNodesContainingRange(ts)(sourceFile, textRange),
+      AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
       ReadonlyArray.filter(AST.isPipeCall(ts)),
       ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.expression)),
       ReadonlyArray.filter(

--- a/src/refactors/removeUnnecessaryEffectGen.ts
+++ b/src/refactors/removeUnnecessaryEffectGen.ts
@@ -1,0 +1,78 @@
+import * as ReadonlyArray from "effect/Array"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import { createRefactor } from "../definition.js"
+import * as AST from "../utils/AST.js"
+import * as TypeParser from "../utils/TypeParser.js"
+
+/**
+ * Refactor to remove unnecessary `Effect.gen` calls.
+ *
+ * This refactor identifies `Effect.gen` calls that are redundant because they only wrap
+ * a single `yield*` statement returning an `Effect`. In such cases, the `Effect.gen` wrapper
+ * can be removed, and the inner `Effect` can be returned directly.
+ *
+ * The function works by analyzing the AST within the specified `textRange` to locate
+ * `Effect.gen` calls. It checks if the body of the generator function contains only a single
+ * `yield*` statement that directly returns an `Effect`. If such a pattern is found, the
+ * `Effect.gen` wrapper is replaced with the inner `Effect`.
+ *
+ * @example
+ * Input:
+ * ```ts
+ * const result = Effect.gen(function* () {
+ *   return yield* Effect.succeed(42)
+ * })
+ * ```
+ * Output:
+ * ```ts
+ * const result = Effect.succeed(42)
+ * ```
+ *
+ * @param ts - The TypeScript API.
+ * @param program - The TypeScript program instance, used for type checking.
+ * @returns A refactor function that takes a `SourceFile` and a `TextRange`, analyzes the AST,
+ *          and applies the refactor if applicable.
+ */
+export const removeUnnecessaryEffectGen = createRefactor({
+  name: "effect/removeUnnecessaryEffectGen",
+  description: "Remove unnecessary Effect.gen",
+  apply: (ts, program) => (sourceFile, textRange) =>
+    pipe(
+      AST.collectDescendantsAndAncestorsInRange(sourceFile, textRange),
+      ReadonlyArray.findFirst((node) =>
+        Option.gen(function*() {
+          const typeChecker = program.getTypeChecker()
+          const effectGen = yield* TypeParser.effectGen(ts, typeChecker)(node)
+
+          const body = effectGen.body
+          if (
+            body.statements.length === 1 &&
+            ts.isReturnStatement(body.statements[0]) &&
+            body.statements[0].expression &&
+            ts.isYieldExpression(body.statements[0].expression) &&
+            body.statements[0].expression.expression
+          ) {
+            // get the type of the node
+            const nodeToCheck = body.statements[0].expression.expression
+            const type = typeChecker.getTypeAtLocation(nodeToCheck)
+            const maybeEffect = TypeParser.effectType(ts, typeChecker)(type, nodeToCheck)
+            if (Option.isSome(maybeEffect)) {
+              return yield* Option.some({
+                nodeToReplace: effectGen.node,
+                returnedYieldedEffect: nodeToCheck
+              })
+            }
+          }
+          return yield* Option.none()
+        })
+      ),
+      Option.map((a) => ({
+        kind: "refactor.rewrite.effect.removeUnnecessaryEffectGen",
+        description: "Remove unnecessary Effect.gen",
+        apply: (changeTracker) => {
+          changeTracker.replaceNode(sourceFile, a.nodeToReplace, a.returnedYieldedEffect)
+        }
+      }))
+    )
+})

--- a/src/refactors/toggleLazyConst.ts
+++ b/src/refactors/toggleLazyConst.ts
@@ -9,7 +9,7 @@ export const toggleLazyConst = createRefactor({
   description: "Toggle type annotation",
   apply: (ts) => (sourceFile, textRange) =>
     pipe(
-      AST.getNodesContainingRange(ts)(sourceFile, textRange),
+      AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
       ReadonlyArray.filter(ts.isVariableDeclaration),
       ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.name)),
       ReadonlyArray.filter((node) =>

--- a/src/refactors/toggleReturnTypeAnnotation.ts
+++ b/src/refactors/toggleReturnTypeAnnotation.ts
@@ -12,7 +12,7 @@ export const toggleReturnTypeAnnotation = createRefactor({
     return Option.gen(function*() {
       const typeChecker = program.getTypeChecker()
       const node = yield* pipe(
-        AST.getNodesContainingRange(ts)(sourceFile, textRange),
+        AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
         ReadonlyArray.filter((node) =>
           ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) ||
           ts.isArrowFunction(node) || ts.isMethodDeclaration(node)

--- a/src/refactors/toggleTypeAnnotation.ts
+++ b/src/refactors/toggleTypeAnnotation.ts
@@ -9,7 +9,7 @@ export const toggleTypeAnnotation = createRefactor({
   description: "Toggle type annotation",
   apply: (ts, program) => (sourceFile, textRange) =>
     pipe(
-      AST.getNodesContainingRange(ts)(sourceFile, textRange),
+      AST.getAncestorNodesInRange(ts)(sourceFile, textRange),
       ReadonlyArray.filter((node) =>
         ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)
       ),

--- a/src/utils/AST.ts
+++ b/src/utils/AST.ts
@@ -59,9 +59,11 @@ export function getAncestorNodesInRange(
  *
  * @param sourceFile - The TypeScript SourceFile to search within.
  * @param position - The position in the file to locate the node for.
- * @returns The deepest AST node at the specified position, or undefined if no node is found.
+ * @returns An `Option`:
+ *          - `Option.some<ts.Node>` if a node is found at the specified position.
+ *          - `Option.none` if no node is found at the specified position.
  */
-function findNodeAtPosition(sourceFile: ts.SourceFile, position: number): ts.Node | undefined {
+function findNodeAtPosition(sourceFile: ts.SourceFile, position: number): Option.Option<ts.Node> {
   function find(node: ts.Node): ts.Node | undefined {
     if (position >= node.getStart() && position < node.getEnd()) {
       // If the position is within this node, keep traversing its children
@@ -69,7 +71,7 @@ function findNodeAtPosition(sourceFile: ts.SourceFile, position: number): ts.Nod
     }
     return undefined
   }
-  return find(sourceFile)
+  return Option.fromNullable(find(sourceFile))
 }
 
 /**
@@ -90,8 +92,8 @@ export function collectDescendantsAndAncestorsInRange(
   textRange: ts.TextRange
 ) {
   const nodeAtPosition = findNodeAtPosition(sourceFile, textRange.pos)
-  if (!nodeAtPosition) return ReadonlyArray.empty<ts.Node>()
-  return collectSelfAndAncestorNodesInRange(nodeAtPosition, textRange)
+  if (Option.isNone(nodeAtPosition)) return ReadonlyArray.empty<ts.Node>()
+  return collectSelfAndAncestorNodesInRange(nodeAtPosition.value, textRange)
 }
 
 /**

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -457,6 +457,126 @@ const test3 = pipe(T.flatMap(T.succeed("Hello"), (_) => T.log(_)), noDataFirst("
 "
 `;
 
+exports[`removeUnnecessaryEffectGen.ts > removeUnnecessaryEffectGen.ts at 4:22 1`] = `
+"// Result of running refactor effect/removeUnnecessaryEffectGen at position 4:22
+import * as Effect from "effect/Effect"
+
+export const test1 = Effect.succeed(42)
+
+Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+export const test2 = Effect.gen(function* () {
+    return yield* Effect.gen(function* () {
+        return yield* Effect.succeed(42)
+    })
+})
+
+export const test3 = Effect.succeed(42).pipe(
+    Effect.andThen((a) => Effect.gen(function* () {
+        return yield* Effect.succeed(a)
+    })),
+)
+"
+`;
+
+exports[`removeUnnecessaryEffectGen.ts > removeUnnecessaryEffectGen.ts at 8:1 1`] = `
+"// Result of running refactor effect/removeUnnecessaryEffectGen at position 8:1
+import * as Effect from "effect/Effect"
+
+export const test1 = Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+Effect.succeed(42)
+
+export const test2 = Effect.gen(function* () {
+    return yield* Effect.gen(function* () {
+        return yield* Effect.succeed(42)
+    })
+})
+
+export const test3 = Effect.succeed(42).pipe(
+    Effect.andThen((a) => Effect.gen(function* () {
+        return yield* Effect.succeed(a)
+    })),
+)
+"
+`;
+
+exports[`removeUnnecessaryEffectGen.ts > removeUnnecessaryEffectGen.ts at 12:22 1`] = `
+"// Result of running refactor effect/removeUnnecessaryEffectGen at position 12:22
+import * as Effect from "effect/Effect"
+
+export const test1 = Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+export const test2 = Effect.gen(function*() {
+    return yield* Effect.succeed(42)
+})
+
+export const test3 = Effect.succeed(42).pipe(
+    Effect.andThen((a) => Effect.gen(function* () {
+        return yield* Effect.succeed(a)
+    })),
+)
+"
+`;
+
+exports[`removeUnnecessaryEffectGen.ts > removeUnnecessaryEffectGen.ts at 13:19 1`] = `
+"// Result of running refactor effect/removeUnnecessaryEffectGen at position 13:19
+import * as Effect from "effect/Effect"
+
+export const test1 = Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+export const test2 = Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+export const test3 = Effect.succeed(42).pipe(
+    Effect.andThen((a) => Effect.gen(function* () {
+        return yield* Effect.succeed(a)
+    })),
+)
+"
+`;
+
+exports[`removeUnnecessaryEffectGen.ts > removeUnnecessaryEffectGen.ts at 19:27 1`] = `
+"// Result of running refactor effect/removeUnnecessaryEffectGen at position 19:27
+import * as Effect from "effect/Effect"
+
+export const test1 = Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+Effect.gen(function* () {
+    return yield* Effect.succeed(42)
+})
+
+export const test2 = Effect.gen(function* () {
+    return yield* Effect.gen(function* () {
+        return yield* Effect.succeed(42)
+    })
+})
+
+export const test3 = Effect.succeed(42).pipe(
+    Effect.andThen((a) => Effect.succeed(a)),
+)
+"
+`;
+
 exports[`toggleLazyConst.ts > toggleLazyConst.ts at 3:10 1`] = `
 "// Result of running refactor effect/toggleLazyConst at position 3:10
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
This PR adds a new refactor which removes unnecessary `Effect.gen` calls by simplifying generator functions that only wrap a single `yield*` statement returning an `Effect`. This refactor replaces the `Effect.gen` wrapper with the inner `Effect` directly, making the code more concise and readable.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

n/a