### PR TITLE
Add refactor wrapWithEffectGen

### DIFF
--- a/.changeset/evil-seas-pay.md
+++ b/.changeset/evil-seas-pay.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add refactor to wrap an `Effect` expression with `Effect.gen`. 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Few options can be provided alongside the initialization of the Language Service
 - Pipe to datafirst: Transform a pipe() call into a series of datafirst function calls (where available).
 - Toggle return type signature: With a single refactor, adds or removes type annotations from the definition.
 - Remove unnecessary `Effect.gen` definitions that contains a single `yield` statement.
+- Wrap an `Effect` expression with `Effect.gen`
 
 ## Configuring diagnostics
 

--- a/examples/refactors/wrapWithEffectGen.ts
+++ b/examples/refactors/wrapWithEffectGen.ts
@@ -1,0 +1,18 @@
+// 5:22;7:22;9:22;9:22-12:1;14:22;15:5
+import * as Effect from "effect/Effect"
+import { pipe } from "effect"
+
+export const test1 = Effect.succeed(42)
+
+export const test3 = test1
+
+export const test2 = Effect.succeed(42).pipe(
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+
+export const test4 = pipe(
+    Effect.succeed(42),
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)

--- a/src/refactors.ts
+++ b/src/refactors.ts
@@ -7,6 +7,7 @@ import { removeUnnecessaryEffectGen } from "./refactors/removeUnnecessaryEffectG
 import { toggleLazyConst } from "./refactors/toggleLazyConst.js"
 import { toggleReturnTypeAnnotation } from "./refactors/toggleReturnTypeAnnotation.js"
 import { toggleTypeAnnotation } from "./refactors/toggleTypeAnnotation.js"
+import { wrapWithEffectGen } from "./refactors/wrapWithEffectGen.js"
 import { wrapWithPipe } from "./refactors/wrapWithPipe.js"
 
 export const refactors = [
@@ -18,6 +19,7 @@ export const refactors = [
   toggleLazyConst,
   toggleReturnTypeAnnotation,
   toggleTypeAnnotation,
+  wrapWithEffectGen,
   wrapWithPipe,
   effectGenToFn
 ]

--- a/src/refactors/wrapWithEffectGen.ts
+++ b/src/refactors/wrapWithEffectGen.ts
@@ -1,0 +1,81 @@
+import * as ReadonlyArray from "effect/Array"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import type ts from "typescript"
+import * as AST from "../core/AST.js"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+import * as TypeParser from "../utils/TypeParser.js"
+
+export const wrapWithEffectGen = LSP.createRefactor({
+  name: "effect/wrapWithEffectGen",
+  description: "Wrap with Effect.gen",
+  apply: (sourceFile, textRange) =>
+    Nano.gen(function*() {
+      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+      const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+
+      const findEffectToWrap = Nano.fn("findEffectToWrap")(function*(node: ts.Node) {
+        if (!ts.isExpression(node)) return yield* Nano.fail("is not an expression")
+
+        const parent = node.parent
+        if (
+          parent != null && ts.isVariableDeclaration(parent) && parent.initializer !== node
+        ) return yield* Nano.fail("is LHS of variable declaration")
+
+        const type = typeChecker.getTypeAtLocation(node)
+        yield* TypeParser.effectType(type, node)
+
+        return node
+      })
+
+      const maybeNode = yield* pipe(
+        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+        ReadonlyArray.map(findEffectToWrap),
+        Nano.firstSuccessOf,
+        Nano.option
+      )
+      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+
+      const node = maybeNode.value
+      if (!ts.isExpression(node)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+
+      const effectGen = yield* AST.createEffectGenCallExpressionWithBlock(
+        yield* getEffectModuleIdentifierName(sourceFile),
+        yield* AST.createReturnYieldStarStatement(node)
+      )
+
+      return {
+        kind: "refactor.rewrite.effect.wrapWithEffectGen",
+        description: `Wrap with Effect.gen`,
+        apply: Nano.gen(function*() {
+          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+          changeTracker.replaceNode(sourceFile, node, effectGen)
+        })
+      }
+    })
+})
+
+export const getEffectModuleIdentifierName = Nano.fn("getEffectModuleIdentifierName")(
+  function*(sourceFile: ts.SourceFile) {
+    return Option.match(
+      yield* Nano.option(
+        AST.findImportedModuleIdentifier(
+          sourceFile,
+          (node) =>
+            pipe(
+              TypeParser.importedEffectModule(node),
+              Nano.option,
+              Nano.map(Option.isSome)
+            )
+        )
+      ),
+      {
+        onNone: () => "Effect",
+        onSome: (node) => node.text
+      }
+    )
+  }
+)

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -2242,6 +2242,142 @@ class Person extends Schema.TaggedClass<Person>("Person")("Person", {
 "
 `;
 
+exports[`Refactor wrapWithEffectGen > wrapWithEffectGen.ts at 5:22 1`] = `
+"// Result of running refactor effect/wrapWithEffectGen at position 5:22
+import * as Effect from "effect/Effect"
+import { pipe } from "effect"
+
+export const test1 = Effect.gen(function*() { return yield* Effect.succeed(42) })
+
+export const test3 = test1
+
+export const test2 = Effect.succeed(42).pipe(
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+
+export const test4 = pipe(
+    Effect.succeed(42),
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+"
+`;
+
+exports[`Refactor wrapWithEffectGen > wrapWithEffectGen.ts at 7:22 1`] = `
+"// Result of running refactor effect/wrapWithEffectGen at position 7:22
+import * as Effect from "effect/Effect"
+import { pipe } from "effect"
+
+export const test1 = Effect.succeed(42)
+
+export const test3 = Effect.gen(function*() { return yield* test1 })
+
+export const test2 = Effect.succeed(42).pipe(
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+
+export const test4 = pipe(
+    Effect.succeed(42),
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+"
+`;
+
+exports[`Refactor wrapWithEffectGen > wrapWithEffectGen.ts at 9:22 1`] = `
+"// Result of running refactor effect/wrapWithEffectGen at position 9:22
+import * as Effect from "effect/Effect"
+import { pipe } from "effect"
+
+export const test1 = Effect.succeed(42)
+
+export const test3 = test1
+
+export const test2 = Effect.gen(function*() { return yield* Effect.succeed(42) }).pipe(
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+
+export const test4 = pipe(
+    Effect.succeed(42),
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+"
+`;
+
+exports[`Refactor wrapWithEffectGen > wrapWithEffectGen.ts at 9:22-12:1 1`] = `
+"// Result of running refactor effect/wrapWithEffectGen at position 9:22-12:1
+import * as Effect from "effect/Effect"
+import { pipe } from "effect"
+
+export const test1 = Effect.succeed(42)
+
+export const test3 = test1
+
+export const test2 = Effect.gen(function*() {
+    return yield* Effect.succeed(42).pipe(
+        Effect.map((n) => n + 1),
+        Effect.map((n) => n - 1)
+    )
+})
+
+export const test4 = pipe(
+    Effect.succeed(42),
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+"
+`;
+
+exports[`Refactor wrapWithEffectGen > wrapWithEffectGen.ts at 14:22 1`] = `
+"// Result of running refactor effect/wrapWithEffectGen at position 14:22
+import * as Effect from "effect/Effect"
+import { pipe } from "effect"
+
+export const test1 = Effect.succeed(42)
+
+export const test3 = test1
+
+export const test2 = Effect.succeed(42).pipe(
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+
+export const test4 = Effect.gen(function*() {
+    return yield* pipe(
+        Effect.succeed(42),
+        Effect.map((n) => n + 1),
+        Effect.map((n) => n - 1)
+    )
+})
+"
+`;
+
+exports[`Refactor wrapWithEffectGen > wrapWithEffectGen.ts at 15:5 1`] = `
+"// Result of running refactor effect/wrapWithEffectGen at position 15:5
+import * as Effect from "effect/Effect"
+import { pipe } from "effect"
+
+export const test1 = Effect.succeed(42)
+
+export const test3 = test1
+
+export const test2 = Effect.succeed(42).pipe(
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+
+export const test4 = pipe(
+    Effect.gen(function*() { return yield* Effect.succeed(42) }),
+    Effect.map((n) => n + 1),
+    Effect.map((n) => n - 1),
+)
+"
+`;
+
 exports[`Refactor wrapWithPipe > wrapWithPipe.ts at 2:13-2:26 1`] = `
 "// Result of running refactor effect/wrapWithPipe at position 2:13-2:26
 const txt = pipe("Hello World")


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

Adds refactor which wraps an `Effect` expression with `Effect.gen`

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #92 and #96
After the Nano refactor, my PR #92 never got merged, and the related PR #96 didn't include the commits from #92.
(See comment https://github.com/Effect-TS/language-service/pull/92#issuecomment-2823849226)
I'm open to all feedback and hope we can work together to get it through, as my team have said this refactor would be useful.
