### PR TITLE
Schema opaque refactor

### DIFF
--- a/.changeset/chubby-meals-drum.md
+++ b/.changeset/chubby-meals-drum.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add refator to make a schema opaque

--- a/examples/refactors/makeSchemaOpaque.ts
+++ b/examples/refactors/makeSchemaOpaque.ts
@@ -1,0 +1,7 @@
+// 4:17
+import * as Schema from "effect/Schema"
+
+export const MyStruct = Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+})

--- a/examples/refactors/makeSchemaOpaque_shortImport.ts
+++ b/examples/refactors/makeSchemaOpaque_shortImport.ts
@@ -1,0 +1,7 @@
+// 4:17
+import { Schema } from "effect"
+
+export const MyStruct = Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+})

--- a/examples/refactors/makeSchemaOpaque_shortImportAlias.ts
+++ b/examples/refactors/makeSchemaOpaque_shortImportAlias.ts
@@ -1,0 +1,7 @@
+// 4:17
+import { Schema as S } from "effect"
+
+export const MyStruct = S.Struct({
+    id: S.Number,
+    name: S.String
+})

--- a/examples/refactors/makeSchemaOpaque_union.ts
+++ b/examples/refactors/makeSchemaOpaque_union.ts
@@ -1,0 +1,7 @@
+// 4:17
+import * as Schema from "effect/Schema"
+
+export const MyUnion = Schema.Union(
+    Schema.Literal("A"),
+    Schema.Literal("B")
+)

--- a/src/refactors.ts
+++ b/src/refactors.ts
@@ -2,6 +2,7 @@ import { asyncAwaitToGen } from "./refactors/asyncAwaitToGen.js"
 import { asyncAwaitToGenTryPromise } from "./refactors/asyncAwaitToGenTryPromise.js"
 import { effectGenToFn } from "./refactors/effectGenToFn.js"
 import { functionToArrow } from "./refactors/functionToArrow.js"
+import { makeSchemaOpaque } from "./refactors/makeSchemaOpaque.js"
 import { pipeableToDatafirst } from "./refactors/pipeableToDatafirst.js"
 import { removeUnnecessaryEffectGen } from "./refactors/removeUnnecessaryEffectGen.js"
 import { toggleLazyConst } from "./refactors/toggleLazyConst.js"
@@ -14,6 +15,7 @@ export const refactors = [
   asyncAwaitToGen,
   asyncAwaitToGenTryPromise,
   functionToArrow,
+  makeSchemaOpaque,
   pipeableToDatafirst,
   removeUnnecessaryEffectGen,
   toggleLazyConst,

--- a/src/refactors/asyncAwaitToGenTryPromise.ts
+++ b/src/refactors/asyncAwaitToGenTryPromise.ts
@@ -11,113 +11,112 @@ import * as TypeParser from "../utils/TypeParser.js"
 export const asyncAwaitToGenTryPromise = LSP.createRefactor({
   name: "effect/asyncAwaitToGenTryPromise",
   description: "Convert to Effect.gen with failures",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
-      const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+  apply: Nano.fn("asyncAwaitToGenTryPromise.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
 
-      const maybeNode = pipe(
-        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
-        ReadonlyArray.filter(
-          (node) =>
-            ts.isFunctionDeclaration(node) || ts.isArrowFunction(node) ||
-            ts.isFunctionExpression(node)
-        ),
-        ReadonlyArray.filter((node) => !!node.body),
-        ReadonlyArray.filter((node) =>
-          !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Async)
-        ),
-        ReadonlyArray.head
-      )
+    const maybeNode = pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.filter(
+        (node) =>
+          ts.isFunctionDeclaration(node) || ts.isArrowFunction(node) ||
+          ts.isFunctionExpression(node)
+      ),
+      ReadonlyArray.filter((node) => !!node.body),
+      ReadonlyArray.filter((node) =>
+        !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Async)
+      ),
+      ReadonlyArray.head
+    )
 
-      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      const node = maybeNode.value
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    const node = maybeNode.value
 
-      return ({
-        kind: "refactor.rewrite.effect.asyncAwaitToGenTryPromise",
-        description: "Rewrite to Effect.gen with failures",
-        apply: pipe(
-          Nano.gen(function*() {
-            const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+    return ({
+      kind: "refactor.rewrite.effect.asyncAwaitToGenTryPromise",
+      description: "Rewrite to Effect.gen with failures",
+      apply: pipe(
+        Nano.gen(function*() {
+          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
 
-            const effectModuleIdentifierName = Option.match(
-              yield* Nano.option(
-                AST.findImportedModuleIdentifier(
-                  sourceFile,
-                  (node) =>
-                    pipe(
-                      TypeParser.importedEffectModule(node),
-                      Nano.option,
-                      Nano.map(Option.isSome)
-                    )
+          const effectModuleIdentifierName = Option.match(
+            yield* Nano.option(
+              AST.findImportedModuleIdentifier(
+                sourceFile,
+                (node) =>
+                  pipe(
+                    TypeParser.importedEffectModule(node),
+                    Nano.option,
+                    Nano.map(Option.isSome)
+                  )
+              )
+            ),
+            {
+              onNone: () => "Effect",
+              onSome: (node) => node.text
+            }
+          )
+
+          let errorCount = 0
+
+          function createErrorADT() {
+            errorCount++
+            return ts.factory.createObjectLiteralExpression([
+              ts.factory.createPropertyAssignment(
+                "_tag",
+                ts.factory.createAsExpression(
+                  ts.factory.createStringLiteral("Error" + errorCount),
+                  ts.factory.createTypeReferenceNode("const")
                 )
               ),
-              {
-                onNone: () => "Effect",
-                onSome: (node) => node.text
-              }
-            )
+              ts.factory.createShorthandPropertyAssignment("error")
+            ])
+          }
 
-            let errorCount = 0
-
-            function createErrorADT() {
-              errorCount++
-              return ts.factory.createObjectLiteralExpression([
-                ts.factory.createPropertyAssignment(
-                  "_tag",
-                  ts.factory.createAsExpression(
-                    ts.factory.createStringLiteral("Error" + errorCount),
-                    ts.factory.createTypeReferenceNode("const")
-                  )
+          const newDeclaration = yield* AST.transformAsyncAwaitToEffectGen(
+            node,
+            effectModuleIdentifierName,
+            (expression) =>
+              ts.factory.createCallExpression(
+                ts.factory.createPropertyAccessExpression(
+                  ts.factory.createIdentifier(effectModuleIdentifierName),
+                  "tryPromise"
                 ),
-                ts.factory.createShorthandPropertyAssignment("error")
-              ])
-            }
-
-            const newDeclaration = yield* AST.transformAsyncAwaitToEffectGen(
-              node,
-              effectModuleIdentifierName,
-              (expression) =>
-                ts.factory.createCallExpression(
-                  ts.factory.createPropertyAccessExpression(
-                    ts.factory.createIdentifier(effectModuleIdentifierName),
-                    "tryPromise"
-                  ),
-                  undefined,
-                  [
-                    ts.factory.createObjectLiteralExpression([
-                      ts.factory.createPropertyAssignment(
-                        ts.factory.createIdentifier("try"),
-                        ts.factory.createArrowFunction(
-                          undefined,
-                          undefined,
-                          [],
-                          undefined,
-                          undefined,
-                          expression
-                        )
-                      ),
-                      ts.factory.createPropertyAssignment(
-                        ts.factory.createIdentifier("catch"),
-                        ts.factory.createArrowFunction(
-                          undefined,
-                          undefined,
-                          [ts.factory.createParameterDeclaration(undefined, undefined, "error")],
-                          undefined,
-                          undefined,
-                          createErrorADT()
-                        )
+                undefined,
+                [
+                  ts.factory.createObjectLiteralExpression([
+                    ts.factory.createPropertyAssignment(
+                      ts.factory.createIdentifier("try"),
+                      ts.factory.createArrowFunction(
+                        undefined,
+                        undefined,
+                        [],
+                        undefined,
+                        undefined,
+                        expression
                       )
-                    ])
-                  ]
-                )
-            )
+                    ),
+                    ts.factory.createPropertyAssignment(
+                      ts.factory.createIdentifier("catch"),
+                      ts.factory.createArrowFunction(
+                        undefined,
+                        undefined,
+                        [ts.factory.createParameterDeclaration(undefined, undefined, "error")],
+                        undefined,
+                        undefined,
+                        createErrorADT()
+                      )
+                    )
+                  ])
+                ]
+              )
+          )
 
-            changeTracker.replaceNode(sourceFile, node, newDeclaration)
-          }),
-          Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
-          Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker)
-        )
-      })
+          changeTracker.replaceNode(sourceFile, node, newDeclaration)
+        }),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker)
+      )
     })
+  })
 })

--- a/src/refactors/effectGenToFn.ts
+++ b/src/refactors/effectGenToFn.ts
@@ -11,104 +11,101 @@ import * as TypeParser from "../utils/TypeParser.js"
 export const effectGenToFn = LSP.createRefactor({
   name: "effect/effectGenToFn",
   description: "Convert to Effect.fn",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+  apply: Nano.fn("effectGenToFn.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
 
-      function parseEffectGenNode(node: ts.Node) {
-        return Nano.gen(function*() {
-          // check if the node is a Effect.gen(...)
-          const effectGen = yield* TypeParser.effectGen(node)
-          // if parent is a Effect.gen(...).pipe(...) we then move the pipe tot the new Effect.fn
-          let pipeArgs = ts.factory.createNodeArray<ts.Expression>([])
-          let nodeToReplace = node.parent
-          if (
-            ts.isPropertyAccessExpression(node.parent) && node.parent.name.text === "pipe" &&
-            ts.isCallExpression(node.parent.parent)
-          ) {
-            pipeArgs = node.parent.parent.arguments
-            nodeToReplace = node.parent.parent.parent
-          }
-          // then we iterate upwards until we find the function declaration
-          while (nodeToReplace) {
-            // if arrow function, exit
-            if (
-              ts.isArrowFunction(nodeToReplace) || ts.isFunctionDeclaration(nodeToReplace) ||
-              ts.isMethodDeclaration(nodeToReplace)
-            ) {
-              return ({ ...effectGen, pipeArgs, nodeToReplace })
-            }
-            // concise body go up
-            if (ts.isConciseBody(nodeToReplace) || ts.isReturnStatement(nodeToReplace)) {
-              nodeToReplace = nodeToReplace.parent
-              continue
-            }
-            // function body with only one statement, go up
-            if (ts.isBlock(nodeToReplace) && nodeToReplace.statements.length === 1) {
-              nodeToReplace = nodeToReplace.parent
-              continue
-            }
-            // exit
-            break
-          }
-          return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-        })
+    const parseEffectGenNode = Nano.fn("asyncAwaitToGen.apply")(function*(node: ts.Node) {
+      // check if the node is a Effect.gen(...)
+      const effectGen = yield* TypeParser.effectGen(node)
+      // if parent is a Effect.gen(...).pipe(...) we then move the pipe tot the new Effect.fn
+      let pipeArgs = ts.factory.createNodeArray<ts.Expression>([])
+      let nodeToReplace = node.parent
+      if (
+        ts.isPropertyAccessExpression(node.parent) && node.parent.name.text === "pipe" &&
+        ts.isCallExpression(node.parent.parent)
+      ) {
+        pipeArgs = node.parent.parent.arguments
+        nodeToReplace = node.parent.parent.parent
       }
+      // then we iterate upwards until we find the function declaration
+      while (nodeToReplace) {
+        // if arrow function, exit
+        if (
+          ts.isArrowFunction(nodeToReplace) || ts.isFunctionDeclaration(nodeToReplace) ||
+          ts.isMethodDeclaration(nodeToReplace)
+        ) {
+          return ({ ...effectGen, pipeArgs, nodeToReplace })
+        }
+        // concise body go up
+        if (ts.isConciseBody(nodeToReplace) || ts.isReturnStatement(nodeToReplace)) {
+          nodeToReplace = nodeToReplace.parent
+          continue
+        }
+        // function body with only one statement, go up
+        if (ts.isBlock(nodeToReplace) && nodeToReplace.statements.length === 1) {
+          nodeToReplace = nodeToReplace.parent
+          continue
+        }
+        // exit
+        break
+      }
+      return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    })
 
-      const maybeNode = yield* pipe(
-        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
-        ReadonlyArray.map(parseEffectGenNode),
-        Nano.firstSuccessOf,
-        Nano.option
-      )
+    const maybeNode = yield* pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.map(parseEffectGenNode),
+      Nano.firstSuccessOf,
+      Nano.option
+    )
 
-      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      const { effectModule, generatorFunction, nodeToReplace, pipeArgs } = maybeNode.value
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    const { effectModule, generatorFunction, nodeToReplace, pipeArgs } = maybeNode.value
 
-      return ({
-        kind: "refactor.rewrite.effect.effectGenToFn",
-        description: "Convert to Effect.fn",
-        apply: pipe(
-          Nano.gen(function*() {
-            const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+    return ({
+      kind: "refactor.rewrite.effect.effectGenToFn",
+      description: "Convert to Effect.fn",
+      apply: pipe(
+        Nano.gen(function*() {
+          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
 
-            // if we have a name in the function declaration,
-            // we call Effect.fn with the name
-            const effectFn = nodeToReplace.name && ts.isIdentifier(nodeToReplace.name) ?
-              ts.factory.createCallExpression(
-                ts.factory.createPropertyAccessExpression(
-                  effectModule,
-                  "fn"
-                ),
-                undefined,
-                [ts.factory.createStringLiteral(nodeToReplace.name.text)]
-              ) :
+          // if we have a name in the function declaration,
+          // we call Effect.fn with the name
+          const effectFn = nodeToReplace.name && ts.isIdentifier(nodeToReplace.name) ?
+            ts.factory.createCallExpression(
               ts.factory.createPropertyAccessExpression(
                 effectModule,
                 "fn"
-              )
-            // append the generator and pipe arguments to the Effect.fn call
-            const effectFnCallWithGenerator = ts.factory.createCallExpression(
-              effectFn,
+              ),
               undefined,
-              [ts.factory.createFunctionExpression(
-                undefined,
-                ts.factory.createToken(ts.SyntaxKind.AsteriskToken),
-                undefined,
-                nodeToReplace.typeParameters,
-                nodeToReplace.parameters,
-                nodeToReplace.type,
-                generatorFunction.body
-              ) as ts.Expression].concat(pipeArgs)
+              [ts.factory.createStringLiteral(nodeToReplace.name.text)]
+            ) :
+            ts.factory.createPropertyAccessExpression(
+              effectModule,
+              "fn"
             )
-            changeTracker.replaceNode(
-              sourceFile,
-              nodeToReplace,
-              yield* AST.tryPreserveDeclarationSemantics(nodeToReplace, effectFnCallWithGenerator)
-            )
-          }),
-          Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
-        )
-      })
+          // append the generator and pipe arguments to the Effect.fn call
+          const effectFnCallWithGenerator = ts.factory.createCallExpression(
+            effectFn,
+            undefined,
+            [ts.factory.createFunctionExpression(
+              undefined,
+              ts.factory.createToken(ts.SyntaxKind.AsteriskToken),
+              undefined,
+              nodeToReplace.typeParameters,
+              nodeToReplace.parameters,
+              nodeToReplace.type,
+              generatorFunction.body
+            ) as ts.Expression].concat(pipeArgs)
+          )
+          changeTracker.replaceNode(
+            sourceFile,
+            nodeToReplace,
+            yield* AST.tryPreserveDeclarationSemantics(nodeToReplace, effectFnCallWithGenerator)
+          )
+        }),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
+      )
     })
+  })
 })

--- a/src/refactors/functionToArrow.ts
+++ b/src/refactors/functionToArrow.ts
@@ -10,62 +10,61 @@ import * as TypeScriptApi from "../core/TypeScriptApi.js"
 export const functionToArrow = LSP.createRefactor({
   name: "effect/functionToArrow",
   description: "Convert to arrow",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+  apply: Nano.fn("functionToArrow.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
 
-      const maybeNode = pipe(
-        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
-        ReadonlyArray.filter((_) => ts.isFunctionDeclaration(_) || ts.isMethodDeclaration(_)),
-        ReadonlyArray.filter((_) => !!_.body),
-        ReadonlyArray.filter((_) => !!_.name && AST.isNodeInRange(textRange)(_.name)),
-        ReadonlyArray.head
-      )
+    const maybeNode = pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.filter((_) => ts.isFunctionDeclaration(_) || ts.isMethodDeclaration(_)),
+      ReadonlyArray.filter((_) => !!_.body),
+      ReadonlyArray.filter((_) => !!_.name && AST.isNodeInRange(textRange)(_.name)),
+      ReadonlyArray.head
+    )
 
-      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      const node = maybeNode.value
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    const node = maybeNode.value
 
-      return ({
-        kind: "refactor.rewrite.effect.functionToArrow",
-        description: "Convert to arrow",
-        apply: pipe(
-          Nano.gen(function*() {
-            const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+    return ({
+      kind: "refactor.rewrite.effect.functionToArrow",
+      description: "Convert to arrow",
+      apply: pipe(
+        Nano.gen(function*() {
+          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
 
-            const body = node.body!
-            let newBody: ts.ConciseBody = ts.factory.createBlock(body.statements)
-            if (body.statements.length === 1) {
-              const statement = body.statements[0]
-              if (statement && ts.isReturnStatement(statement) && statement.expression) {
-                newBody = statement.expression!
-              }
+          const body = node.body!
+          let newBody: ts.ConciseBody = ts.factory.createBlock(body.statements)
+          if (body.statements.length === 1) {
+            const statement = body.statements[0]
+            if (statement && ts.isReturnStatement(statement) && statement.expression) {
+              newBody = statement.expression!
             }
+          }
 
-            let arrowFlags = ts.getCombinedModifierFlags(node)
-            arrowFlags &= ~ts.ModifierFlags.Export
-            arrowFlags &= ~ts.ModifierFlags.Default
-            const arrowModifiers = ts.factory.createModifiersFromModifierFlags(arrowFlags)
+          let arrowFlags = ts.getCombinedModifierFlags(node)
+          arrowFlags &= ~ts.ModifierFlags.Export
+          arrowFlags &= ~ts.ModifierFlags.Default
+          const arrowModifiers = ts.factory.createModifiersFromModifierFlags(arrowFlags)
 
-            const arrowFunction = ts.factory.createArrowFunction(
-              arrowModifiers,
-              node.typeParameters,
-              node.parameters,
-              undefined,
-              ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-              newBody
-            )
+          const arrowFunction = ts.factory.createArrowFunction(
+            arrowModifiers,
+            node.typeParameters,
+            node.parameters,
+            undefined,
+            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            newBody
+          )
 
-            const newDeclaration: ts.Node = yield* AST.tryPreserveDeclarationSemantics(
-              node,
-              arrowFunction
-            )
-            changeTracker.replaceNode(sourceFile, node, newDeclaration, {
-              leadingTriviaOption: ts.textChanges.LeadingTriviaOption.IncludeAll,
-              trailingTriviaOption: ts.textChanges.TrailingTriviaOption.Exclude
-            })
-          }),
-          Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
-        )
-      })
+          const newDeclaration: ts.Node = yield* AST.tryPreserveDeclarationSemantics(
+            node,
+            arrowFunction
+          )
+          changeTracker.replaceNode(sourceFile, node, newDeclaration, {
+            leadingTriviaOption: ts.textChanges.LeadingTriviaOption.IncludeAll,
+            trailingTriviaOption: ts.textChanges.TrailingTriviaOption.Exclude
+          })
+        }),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
+      )
     })
+  })
 })

--- a/src/refactors/makeSchemaOpaque.ts
+++ b/src/refactors/makeSchemaOpaque.ts
@@ -1,0 +1,86 @@
+import * as ReadonlyArray from "effect/Array"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import type ts from "typescript"
+import * as AST from "../core/AST.js"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+import * as TypeParser from "../utils/TypeParser.js"
+
+export const makeSchemaOpaque = LSP.createRefactor({
+  name: "effect/makeSchemaOpaque",
+  description: "Make Schema opaque",
+  apply: Nano.fn("makeSchemaOpaque.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+
+    const findSchema = Nano.fn("makeSchemaOpaque.apply.findSchema")(
+      function*(node: ts.Node) {
+        if (!ts.isVariableDeclaration(node)) {
+          return yield* Nano.fail("parent should be variable declaration")
+        }
+        const identifier = node.name
+        if (!ts.isIdentifier(identifier)) return yield* Nano.fail("name should be an identifier")
+        const initializer = node.initializer
+        if (!initializer) return yield* Nano.fail("should have an initializer")
+
+        const variableDeclarationList = node.parent
+        if (!variableDeclarationList || !ts.isVariableDeclarationList(variableDeclarationList)) {
+          return yield* Nano.fail("parent is not a variable declaration list")
+        }
+
+        const variableStatement = variableDeclarationList.parent
+        if (!variableStatement || !ts.isVariableStatement(variableStatement)) {
+          return yield* Nano.fail("parent not variable declaration statement")
+        }
+
+        const type = typeChecker.getTypeAtLocation(initializer)
+        yield* TypeParser.effectSchemaType(type, initializer)
+
+        return { identifier, variableStatement, variableDeclarationList }
+      }
+    )
+
+    const maybeNode = yield* pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.map(findSchema),
+      Nano.firstSuccessOf,
+      Nano.option
+    )
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+
+    const { identifier, variableDeclarationList, variableStatement } = maybeNode.value
+
+    return {
+      kind: "refactor.rewrite.effect.makeSchemaOpaque",
+      description: `Make Schema opaque`,
+      apply: Nano.gen(function*() {
+        const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+
+        const newIdentifier = ts.factory.createIdentifier(identifier.text + "_")
+        // change current name
+        changeTracker.replaceNode(
+          sourceFile,
+          identifier,
+          newIdentifier
+        )
+        // insert new declaration
+        const newDeclaration = ts.factory.createVariableStatement(
+          variableStatement.modifiers,
+          ts.factory.createVariableDeclarationList(
+            [ts.factory.createVariableDeclaration(
+              identifier.text,
+              undefined,
+              undefined,
+              identifier
+            )],
+            variableDeclarationList.flags
+          )
+        )
+        changeTracker.insertNodeAfter(sourceFile, variableStatement, newDeclaration)
+      })
+    }
+  })
+})

--- a/src/refactors/pipeableToDatafirst.ts
+++ b/src/refactors/pipeableToDatafirst.ts
@@ -11,93 +11,92 @@ import * as TypeScriptApi from "../core/TypeScriptApi.js"
 export const pipeableToDatafirst = LSP.createRefactor({
   name: "effect/pipeableToDatafirst",
   description: "Rewrite to datafirst",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
-      const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+  apply: Nano.fn("pipeableToDatafirst.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
 
-      function isPipeCall(node: ts.Node): node is ts.CallExpression {
-        if (!ts.isCallExpression(node)) return false
-        const expression = node.expression
-        if (!ts.isIdentifier(expression)) return false
-        if (expression.text !== "pipe") return false
-        return true
-      }
+    function isPipeCall(node: ts.Node): node is ts.CallExpression {
+      if (!ts.isCallExpression(node)) return false
+      const expression = node.expression
+      if (!ts.isIdentifier(expression)) return false
+      if (expression.text !== "pipe") return false
+      return true
+    }
 
-      function asDataFirstExpression(
-        node: ts.Node,
-        self: ts.Expression
-      ): Option.Option<ts.CallExpression> {
-        if (!ts.isCallExpression(node)) return Option.none()
-        const signature = typeChecker.getResolvedSignature(node)
-        if (!signature) return Option.none()
-        const callSignatures = typeChecker.getTypeAtLocation(node.expression).getCallSignatures()
-        for (let i = 0; i < callSignatures.length; i++) {
-          const callSignature = callSignatures[i]
-          if (callSignature.parameters.length === node.arguments.length + 1) {
-            return Option.some(
-              ts.factory.createCallExpression(
-                node.expression,
-                [],
-                [self].concat(node.arguments)
-              )
+    function asDataFirstExpression(
+      node: ts.Node,
+      self: ts.Expression
+    ): Option.Option<ts.CallExpression> {
+      if (!ts.isCallExpression(node)) return Option.none()
+      const signature = typeChecker.getResolvedSignature(node)
+      if (!signature) return Option.none()
+      const callSignatures = typeChecker.getTypeAtLocation(node.expression).getCallSignatures()
+      for (let i = 0; i < callSignatures.length; i++) {
+        const callSignature = callSignatures[i]
+        if (callSignature.parameters.length === node.arguments.length + 1) {
+          return Option.some(
+            ts.factory.createCallExpression(
+              node.expression,
+              [],
+              [self].concat(node.arguments)
             )
-          }
+          )
         }
-        return Option.none()
       }
+      return Option.none()
+    }
 
-      const maybeNode = pipe(
-        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
-        ReadonlyArray.filter(isPipeCall),
-        ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.expression)),
-        ReadonlyArray.filter(
-          (node) => node.arguments.length > 0
-        ),
-        ReadonlyArray.map((node) => {
-          let newNode = node.arguments[0]
-          let didSomething = false
-          for (let i = 1; i < node.arguments.length; i++) {
-            const arg = node.arguments[i]
-            const a = asDataFirstExpression(arg, newNode)
-            if (Option.isSome(a)) {
-              // use found datafirst
-              newNode = a.value
-              didSomething = true
+    const maybeNode = pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.filter(isPipeCall),
+      ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.expression)),
+      ReadonlyArray.filter(
+        (node) => node.arguments.length > 0
+      ),
+      ReadonlyArray.map((node) => {
+        let newNode = node.arguments[0]
+        let didSomething = false
+        for (let i = 1; i < node.arguments.length; i++) {
+          const arg = node.arguments[i]
+          const a = asDataFirstExpression(arg, newNode)
+          if (Option.isSome(a)) {
+            // use found datafirst
+            newNode = a.value
+            didSomething = true
+          } else {
+            if (isPipeCall(newNode)) {
+              // avoid nested pipe(a, pipe(b, c))
+              newNode = ts.factory.createCallExpression(
+                ts.factory.createIdentifier("pipe"),
+                [],
+                newNode.arguments.concat([arg])
+              )
             } else {
-              if (isPipeCall(newNode)) {
-                // avoid nested pipe(a, pipe(b, c))
-                newNode = ts.factory.createCallExpression(
-                  ts.factory.createIdentifier("pipe"),
-                  [],
-                  newNode.arguments.concat([arg])
-                )
-              } else {
-                // no datafirst, keep pipeable
-                newNode = ts.factory.createCallExpression(ts.factory.createIdentifier("pipe"), [], [
-                  newNode,
-                  arg
-                ])
-              }
+              // no datafirst, keep pipeable
+              newNode = ts.factory.createCallExpression(ts.factory.createIdentifier("pipe"), [], [
+                newNode,
+                arg
+              ])
             }
           }
-          return didSomething ? Option.some([node, newNode] as const) : Option.none()
-        }),
-        ReadonlyArray.filter(Option.isSome),
-        ReadonlyArray.map((_) => _.value),
-        ReadonlyArray.head
-      )
+        }
+        return didSomething ? Option.some([node, newNode] as const) : Option.none()
+      }),
+      ReadonlyArray.filter(Option.isSome),
+      ReadonlyArray.map((_) => _.value),
+      ReadonlyArray.head
+    )
 
-      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      const [node, newNode] = maybeNode.value
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    const [node, newNode] = maybeNode.value
 
-      return ({
-        kind: "refactor.rewrite.effect.pipeableToDatafirst",
-        description: "Rewrite to datafirst",
-        apply: Nano.gen(function*() {
-          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
-          changeTracker.replaceNode(sourceFile, node, newNode)
-        })
+    return ({
+      kind: "refactor.rewrite.effect.pipeableToDatafirst",
+      description: "Rewrite to datafirst",
+      apply: Nano.gen(function*() {
+        const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+        changeTracker.replaceNode(sourceFile, node, newNode)
       })
     })
+  })
 })

--- a/src/refactors/toggleLazyConst.ts
+++ b/src/refactors/toggleLazyConst.ts
@@ -9,48 +9,47 @@ import * as TypeScriptApi from "../core/TypeScriptApi.js"
 export const toggleLazyConst = LSP.createRefactor({
   name: "effect/toggleLazyConst",
   description: "Toggle lazy const",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+  apply: Nano.fn("toggleLazyConst.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
 
-      const maybeNode = pipe(
-        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
-        ReadonlyArray.filter(ts.isVariableDeclaration),
-        ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.name)),
-        ReadonlyArray.filter((node) =>
-          !!node.initializer &&
-          !(ts.isArrowFunction(node.initializer) && ts.isBlock(node.initializer.body))
-        ),
-        ReadonlyArray.head
-      )
+    const maybeNode = pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.filter(ts.isVariableDeclaration),
+      ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.name)),
+      ReadonlyArray.filter((node) =>
+        !!node.initializer &&
+        !(ts.isArrowFunction(node.initializer) && ts.isBlock(node.initializer.body))
+      ),
+      ReadonlyArray.head
+    )
 
-      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      const node = maybeNode.value
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    const node = maybeNode.value
 
-      return ({
-        kind: "refactor.rewrite.effect.toggleLazyConst",
-        description: "Toggle lazy const",
-        apply: Nano.gen(function*() {
-          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
-          const initializer = node.initializer!
+    return ({
+      kind: "refactor.rewrite.effect.toggleLazyConst",
+      description: "Toggle lazy const",
+      apply: Nano.gen(function*() {
+        const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+        const initializer = node.initializer!
 
-          if (ts.isArrowFunction(initializer) && initializer.parameters.length === 0) {
-            // delete eventual closing bracked
-            changeTracker.deleteRange(sourceFile, {
-              pos: initializer.body.end,
-              end: initializer.end
-            })
-            // remove () => {
-            changeTracker.deleteRange(sourceFile, {
-              pos: initializer.pos,
-              end: initializer.body.pos
-            })
-            return
-          }
+        if (ts.isArrowFunction(initializer) && initializer.parameters.length === 0) {
+          // delete eventual closing bracked
+          changeTracker.deleteRange(sourceFile, {
+            pos: initializer.body.end,
+            end: initializer.end
+          })
+          // remove () => {
+          changeTracker.deleteRange(sourceFile, {
+            pos: initializer.pos,
+            end: initializer.body.pos
+          })
+          return
+        }
 
-          // adds () => before
-          changeTracker.insertText(sourceFile, initializer.pos, " () =>")
-        })
+        // adds () => before
+        changeTracker.insertText(sourceFile, initializer.pos, " () =>")
       })
     })
+  })
 })

--- a/src/refactors/toggleReturnTypeAnnotation.ts
+++ b/src/refactors/toggleReturnTypeAnnotation.ts
@@ -10,57 +10,56 @@ import * as TypeScriptApi from "../core/TypeScriptApi.js"
 export const toggleReturnTypeAnnotation = LSP.createRefactor({
   name: "effect/toggleReturnTypeAnnotation",
   description: "Toggle return type annotation",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
-      const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+  apply: Nano.fn("toggleReturnTypeAnnotation.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
 
-      const maybeNode = pipe(
-        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
-        ReadonlyArray.filter((node) =>
-          ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) ||
-          ts.isArrowFunction(node) || ts.isMethodDeclaration(node)
-        ),
-        ReadonlyArray.head
-      )
+    const maybeNode = pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.filter((node) =>
+        ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) || ts.isMethodDeclaration(node)
+      ),
+      ReadonlyArray.head
+    )
 
-      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      const node = maybeNode.value
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    const node = maybeNode.value
 
-      if (node.type) {
-        return ({
-          kind: "refactor.rewrite.effect.toggleReturnTypeAnnotation",
-          description: "Toggle return type annotation",
-          apply: pipe(
-            AST.removeReturnTypeAnnotation(sourceFile, node),
-            Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
-          )
-        })
-      }
-
-      const returnType = yield* Nano.option(TypeCheckerApi.getInferredReturnType(node))
-      if (Option.isNone(returnType)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-
-      const returnTypeNode = typeChecker.typeToTypeNode(
-        returnType.value,
-        node,
-        ts.NodeBuilderFlags.NoTruncation
-      )
-
-      if (!returnTypeNode) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-
+    if (node.type) {
       return ({
         kind: "refactor.rewrite.effect.toggleReturnTypeAnnotation",
         description: "Toggle return type annotation",
         apply: pipe(
-          AST.addReturnTypeAnnotation(
-            sourceFile,
-            node,
-            yield* AST.simplifyTypeNode(returnTypeNode)
-          ),
-          Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
+          AST.removeReturnTypeAnnotation(sourceFile, node),
           Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
         )
       })
+    }
+
+    const returnType = yield* Nano.option(TypeCheckerApi.getInferredReturnType(node))
+    if (Option.isNone(returnType)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+
+    const returnTypeNode = typeChecker.typeToTypeNode(
+      returnType.value,
+      node,
+      ts.NodeBuilderFlags.NoTruncation
+    )
+
+    if (!returnTypeNode) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+
+    return ({
+      kind: "refactor.rewrite.effect.toggleReturnTypeAnnotation",
+      description: "Toggle return type annotation",
+      apply: pipe(
+        AST.addReturnTypeAnnotation(
+          sourceFile,
+          node,
+          yield* AST.simplifyTypeNode(returnTypeNode)
+        ),
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
+      )
     })
+  })
 })

--- a/src/refactors/toggleTypeAnnotation.ts
+++ b/src/refactors/toggleTypeAnnotation.ts
@@ -10,65 +10,64 @@ import * as TypeScriptApi from "../core/TypeScriptApi.js"
 export const toggleTypeAnnotation = LSP.createRefactor({
   name: "effect/toggleTypeAnnotation",
   description: "Toggle type annotation",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
-      const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+  apply: Nano.fn("toggleTypeAnnotation.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
 
-      const maybeNode = pipe(
-        yield* AST.getAncestorNodesInRange(sourceFile, textRange),
-        ReadonlyArray.filter((node) =>
-          ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)
-        ),
-        ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.name)),
-        ReadonlyArray.filter((node) => !!node.initializer),
-        ReadonlyArray.head
-      )
+    const maybeNode = pipe(
+      yield* AST.getAncestorNodesInRange(sourceFile, textRange),
+      ReadonlyArray.filter((node) =>
+        ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node)
+      ),
+      ReadonlyArray.filter((node) => AST.isNodeInRange(textRange)(node.name)),
+      ReadonlyArray.filter((node) => !!node.initializer),
+      ReadonlyArray.head
+    )
 
-      if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      const node = maybeNode.value
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    const node = maybeNode.value
 
-      return ({
-        kind: "refactor.rewrite.effect.toggleTypeAnnotation",
-        description: "Toggle type annotation",
-        apply: pipe(
-          Nano.gen(function*() {
-            const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+    return ({
+      kind: "refactor.rewrite.effect.toggleTypeAnnotation",
+      description: "Toggle type annotation",
+      apply: pipe(
+        Nano.gen(function*() {
+          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
 
-            if (node.type) {
-              changeTracker.deleteRange(sourceFile, { pos: node.name.end, end: node.type.end })
-              return
-            }
+          if (node.type) {
+            changeTracker.deleteRange(sourceFile, { pos: node.name.end, end: node.type.end })
+            return
+          }
 
-            const initializer = node.initializer!
-            const initializerType = typeChecker.getTypeAtLocation(initializer)
-            const initializerTypeNode = Option.fromNullable(typeChecker.typeToTypeNode(
-              initializerType,
-              node,
-              ts.NodeBuilderFlags.NoTruncation
-            )).pipe(
-              Option.orElse(() =>
-                Option.fromNullable(typeChecker.typeToTypeNode(
-                  initializerType,
-                  undefined,
-                  ts.NodeBuilderFlags.NoTruncation
-                ))
-              ),
-              Option.getOrUndefined
+          const initializer = node.initializer!
+          const initializerType = typeChecker.getTypeAtLocation(initializer)
+          const initializerTypeNode = Option.fromNullable(typeChecker.typeToTypeNode(
+            initializerType,
+            node,
+            ts.NodeBuilderFlags.NoTruncation
+          )).pipe(
+            Option.orElse(() =>
+              Option.fromNullable(typeChecker.typeToTypeNode(
+                initializerType,
+                undefined,
+                ts.NodeBuilderFlags.NoTruncation
+              ))
+            ),
+            Option.getOrUndefined
+          )
+          if (initializerTypeNode) {
+            changeTracker.insertNodeAt(
+              sourceFile,
+              node.name.end,
+              yield* AST.simplifyTypeNode(initializerTypeNode),
+              {
+                prefix: ": "
+              }
             )
-            if (initializerTypeNode) {
-              changeTracker.insertNodeAt(
-                sourceFile,
-                node.name.end,
-                yield* AST.simplifyTypeNode(initializerTypeNode),
-                {
-                  prefix: ": "
-                }
-              )
-            }
-          }),
-          Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
-        )
-      })
+          }
+        }),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
+      )
     })
+  })
 })

--- a/src/refactors/wrapWithPipe.ts
+++ b/src/refactors/wrapWithPipe.ts
@@ -5,21 +5,20 @@ import * as TypeScriptApi from "../core/TypeScriptApi.js"
 export const wrapWithPipe = LSP.createRefactor({
   name: "effect/wrapWithPipe",
   description: "Wrap with pipe",
-  apply: (sourceFile, textRange) =>
-    Nano.gen(function*() {
-      if (textRange.end - textRange.pos === 0) {
-        return yield* Nano.fail(new LSP.RefactorNotApplicableError())
-      }
+  apply: Nano.fn("wrapWithPipe.apply")(function*(sourceFile, textRange) {
+    if (textRange.end - textRange.pos === 0) {
+      return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    }
 
-      return ({
-        kind: "refactor.rewrite.effect.wrapWithPipe",
-        description: `Wrap with pipe(...)`,
-        apply: Nano.gen(function*() {
-          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+    return ({
+      kind: "refactor.rewrite.effect.wrapWithPipe",
+      description: `Wrap with pipe(...)`,
+      apply: Nano.gen(function*() {
+        const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
 
-          changeTracker.insertText(sourceFile, textRange.pos, "pipe(")
-          changeTracker.insertText(sourceFile, textRange.end, ")")
-        })
+        changeTracker.insertText(sourceFile, textRange.pos, "pipe(")
+        changeTracker.insertText(sourceFile, textRange.end, ")")
       })
     })
+  })
 })

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -509,6 +509,17 @@ class Sample {
 "
 `;
 
+exports[`Refactor makeSchemaOpaque > makeSchemaOpaque.ts at 4:17 1`] = `
+"// Result of running refactor effect/makeSchemaOpaque at position 4:17
+import * as Schema from "effect/Schema"
+
+export const MyStruct = Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+})
+"
+`;
+
 exports[`Refactor pipeableToDatafirst > pipeableToDatafirst.ts at 5:16 1`] = `
 "// Result of running refactor effect/pipeableToDatafirst at position 5:16
 import * as T from "effect/Effect"

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -513,10 +513,63 @@ exports[`Refactor makeSchemaOpaque > makeSchemaOpaque.ts at 4:17 1`] = `
 "// Result of running refactor effect/makeSchemaOpaque at position 4:17
 import * as Schema from "effect/Schema"
 
-export const MyStruct = Schema.Struct({
+export const MyStruct_ = Schema.Struct({
     id: Schema.Number,
     name: Schema.String
 })
+
+export interface MyStruct extends Schema.Schema.Type<typeof MyStruct_> { }
+export interface MyStructEncoded extends Schema.Schema.Encoded<typeof MyStruct_> { }
+export type MyStructContext = Schema.Schema.Context<typeof MyStruct_>
+export const MyStruct: Schema.Schema<MyStruct, MyStructEncoded, MyStructContext> = MyStruct_
+"
+`;
+
+exports[`Refactor makeSchemaOpaque > makeSchemaOpaque_shortImport.ts at 4:17 1`] = `
+"// Result of running refactor effect/makeSchemaOpaque at position 4:17
+import { Schema } from "effect"
+
+export const MyStruct_ = Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+})
+
+export interface MyStruct extends Schema.Schema.Type<typeof MyStruct_> { }
+export interface MyStructEncoded extends Schema.Schema.Encoded<typeof MyStruct_> { }
+export type MyStructContext = Schema.Schema.Context<typeof MyStruct_>
+export const MyStruct: Schema.Schema<MyStruct, MyStructEncoded, MyStructContext> = MyStruct_
+"
+`;
+
+exports[`Refactor makeSchemaOpaque > makeSchemaOpaque_shortImportAlias.ts at 4:17 1`] = `
+"// Result of running refactor effect/makeSchemaOpaque at position 4:17
+import { Schema as S } from "effect"
+
+export const MyStruct_ = S.Struct({
+    id: S.Number,
+    name: S.String
+})
+
+export interface MyStruct extends S.Schema.Type<typeof MyStruct_> { }
+export interface MyStructEncoded extends S.Schema.Encoded<typeof MyStruct_> { }
+export type MyStructContext = S.Schema.Context<typeof MyStruct_>
+export const MyStruct: S.Schema<MyStruct, MyStructEncoded, MyStructContext> = MyStruct_
+"
+`;
+
+exports[`Refactor makeSchemaOpaque > makeSchemaOpaque_union.ts at 4:17 1`] = `
+"// Result of running refactor effect/makeSchemaOpaque at position 4:17
+import * as Schema from "effect/Schema"
+
+export const MyUnion_ = Schema.Union(
+    Schema.Literal("A"),
+    Schema.Literal("B")
+)
+
+export type MyUnion = Schema.Schema.Type<typeof MyUnion_>
+export type MyUnionEncoded = Schema.Schema.Encoded<typeof MyUnion_>
+export type MyUnionContext = Schema.Schema.Context<typeof MyUnion_>
+export const MyUnion: Schema.Schema<MyUnion, MyUnionEncoded, MyUnionContext> = MyUnion_
 "
 `;
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a refactor that given a variable that declares a schema, it will automatically generate opaque types for the schema type, encoded and context, and re-export the schema with the new opaque types.

Given:
```ts
import { Schema } from "effect"

export const MyStruct = Schema.Struct({
    id: Schema.Number,
    name: Schema.String
})
```
will output
```ts
import { Schema } from "effect"

export const MyStruct_ = Schema.Struct({
    id: Schema.Number,
    name: Schema.String
})
export interface MyStruct extends Schema.Schema.Type<typeof MyStruct_> { }
export interface MyStructEncoded extends Schema.Schema.Encoded<typeof MyStruct_> { }
export type MyStructContext = Schema.Schema.Context<typeof MyStruct_>
export const MyStruct: Schema.Schema<MyStruct, MyStructEncoded, MyStructContext> = MyStruct_
```