### PR TITLE
Add refactor to make schema opaque with namespaces

### DIFF
--- a/.changeset/olive-pans-taste.md
+++ b/.changeset/olive-pans-taste.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add refactor to make schema opaque using namespaces

--- a/examples/refactors/makeSchemaOpaqueWithNs_shortImport.ts
+++ b/examples/refactors/makeSchemaOpaqueWithNs_shortImport.ts
@@ -1,0 +1,7 @@
+// 4:17
+import { Schema } from "effect"
+
+export const MyStruct = Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+})

--- a/src/refactors.ts
+++ b/src/refactors.ts
@@ -3,6 +3,7 @@ import { asyncAwaitToGenTryPromise } from "./refactors/asyncAwaitToGenTryPromise
 import { effectGenToFn } from "./refactors/effectGenToFn.js"
 import { functionToArrow } from "./refactors/functionToArrow.js"
 import { makeSchemaOpaque } from "./refactors/makeSchemaOpaque.js"
+import { makeSchemaOpaqueWithNs } from "./refactors/makeSchemaOpaqueWithNs.js"
 import { pipeableToDatafirst } from "./refactors/pipeableToDatafirst.js"
 import { removeUnnecessaryEffectGen } from "./refactors/removeUnnecessaryEffectGen.js"
 import { toggleLazyConst } from "./refactors/toggleLazyConst.js"
@@ -16,6 +17,7 @@ export const refactors = [
   asyncAwaitToGenTryPromise,
   functionToArrow,
   makeSchemaOpaque,
+  makeSchemaOpaqueWithNs,
   pipeableToDatafirst,
   removeUnnecessaryEffectGen,
   toggleLazyConst,

--- a/src/refactors/makeSchemaOpaqueWithNs.ts
+++ b/src/refactors/makeSchemaOpaqueWithNs.ts
@@ -1,0 +1,108 @@
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import * as AST from "../core/AST.js"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+import { _createOpaqueTypes, _findSchemaVariableDeclaration } from "./makeSchemaOpaque.js"
+
+export const makeSchemaOpaqueWithNs = LSP.createRefactor({
+  name: "effect/makeSchemaOpaqueWithNs",
+  description: "Make Schema opaque with namespace",
+  apply: Nano.fn("makeSchemaOpaqueWithNs.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+
+    const maybeNode = yield* _findSchemaVariableDeclaration(sourceFile, textRange)
+    if (Option.isNone(maybeNode)) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+
+    const { identifier, types, variableDeclarationList, variableStatement } = maybeNode.value
+
+    return {
+      kind: "refactor.rewrite.effect.makeSchemaOpaqueWithNs",
+      description: `Make Schema opaque with namespace`,
+      apply: pipe(
+        Nano.gen(function*() {
+          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+          const effectSchemaName = Option.match(
+            yield* Nano.option(
+              AST.findImportedModuleIdentifierByPackageAndNameOrBarrel(
+                sourceFile,
+                "effect",
+                "Schema"
+              )
+            ),
+            {
+              onNone: () => "Schema",
+              onSome: (_) => _.text
+            }
+          )
+          const newIdentifier = ts.factory.createIdentifier(identifier.text + "_")
+          const { contextType, encodedType, opaqueType } = _createOpaqueTypes(
+            effectSchemaName,
+            newIdentifier.text,
+            types.A,
+            identifier.text,
+            types.I,
+            "Encoded",
+            "Context"
+          )
+
+          const namespace = ts.factory.createModuleDeclaration(
+            [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+            ts.factory.createIdentifier(identifier.text),
+            ts.factory.createModuleBlock([
+              encodedType,
+              contextType
+            ]),
+            ts.NodeFlags.Namespace
+          )
+
+          changeTracker.replaceNode(
+            sourceFile,
+            identifier,
+            newIdentifier
+          )
+          changeTracker.insertNodeAfter(sourceFile, variableStatement, opaqueType)
+          changeTracker.insertNodeAfter(sourceFile, variableStatement, namespace)
+
+          // insert new declaration
+          const newSchemaType = ts.factory.createTypeReferenceNode(
+            ts.factory.createQualifiedName(
+              ts.factory.createIdentifier(effectSchemaName),
+              ts.factory.createIdentifier("Schema")
+            ),
+            [
+              ts.factory.createTypeReferenceNode(opaqueType.name),
+              ts.factory.createTypeReferenceNode(
+                ts.factory.createQualifiedName(
+                  ts.factory.createIdentifier(namespace.name.text),
+                  encodedType.name
+                )
+              ),
+              ts.factory.createTypeReferenceNode(ts.factory.createQualifiedName(
+                ts.factory.createIdentifier(namespace.name.text),
+                contextType.name
+              ))
+            ]
+          )
+          const newConstDeclaration = ts.factory.createVariableStatement(
+            variableStatement.modifiers,
+            ts.factory.createVariableDeclarationList(
+              [ts.factory.createVariableDeclaration(
+                identifier.text,
+                undefined,
+                newSchemaType,
+                ts.factory.createIdentifier(newIdentifier.text)
+              )],
+              variableDeclarationList.flags
+            )
+          )
+
+          changeTracker.insertNodeAfter(sourceFile, variableStatement, newConstDeclaration)
+          changeTracker.insertText(sourceFile, variableStatement.end, "\n")
+        }),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
+      )
+    }
+  })
+})

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -573,6 +573,24 @@ export const MyUnion: Schema.Schema<MyUnion, MyUnionEncoded, MyUnionContext> = M
 "
 `;
 
+exports[`Refactor makeSchemaOpaqueWithNs > makeSchemaOpaqueWithNs_shortImport.ts at 4:17 1`] = `
+"// Result of running refactor effect/makeSchemaOpaqueWithNs at position 4:17
+import { Schema } from "effect"
+
+export const MyStruct_ = Schema.Struct({
+    id: Schema.Number,
+    name: Schema.String
+})
+
+export interface MyStruct extends Schema.Schema.Type<typeof MyStruct_> { }
+export namespace MyStruct {
+    export interface Encoded extends Schema.Schema.Encoded<typeof MyStruct_> { }
+    export type Context = Schema.Schema.Context<typeof MyStruct_>
+}
+export const MyStruct: Schema.Schema<MyStruct, MyStruct.Encoded, MyStruct.Context> = MyStruct_
+"
+`;
+
 exports[`Refactor pipeableToDatafirst > pipeableToDatafirst.ts at 5:16 1`] = `
 "// Result of running refactor effect/pipeableToDatafirst at position 5:16
 import * as T from "effect/Effect"


### PR DESCRIPTION


## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

```ts
export const MyStruct_ = Schema.Struct({
    id: Schema.Number,
    name: Schema.String
})
export interface MyStruct extends Schema.Schema.Type<typeof MyStruct_> { }
export namespace MyStruct {
    export interface Encoded extends Schema.Schema.Encoded<typeof MyStruct_> { }
    export type Context = Schema.Schema.Context<typeof MyStruct_>
}
export const MyStruct: Schema.Schema<MyStruct, MyStruct.Encoded, MyStruct.Context> = MyStruct_

```

