### PR TITLE
Support ts-patch transformer to emit diagnostics at compile time

### DIFF
--- a/.changeset/wise-queens-search.md
+++ b/.changeset/wise-queens-search.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Support ts-patch transformer to emit diagnostics at compile time

--- a/README.md
+++ b/README.md
@@ -26,6 +26,38 @@ This package implements a TypeScript language service plugin that allows additio
 
 And you're done! You'll now be able to use a set of refactor and diagnostics that targets Effect!
 
+## Enable diagnostics at compile time
+
+TypeScript LSP are loaded only while editing your files. That means that if you run `tsc` in your project, the plugin won't be loaded and you'll miss out on the Effect diagnostics.
+
+HOWEVER, if you use `ts-patch` you can enable the transform as well to get the diagnostics also at compile time.
+Your `tsconfig.json` should look like this:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "transform": "@effect/language-service/transform" // enables diagnostics at compile time when using ts-patch
+      }
+    ]
+  }
+}
+```
+
+Running `tspc` in your project will now also run the plugin and give you the diagnostics at compile time.
+
+```ts
+$ npm tspc
+index.ts:3:1 - error TS3: Effect must be yielded or assigned to a variable.
+
+3 Effect.succeed(1)
+  ~~~~~~~~~~~~~~~~~
+
+Found 1 error in index.ts:3 
+```
+
 ## Options
 
 Few options can be provided alongside the initialization of the Language Service Plugin.

--- a/package.json
+++ b/package.json
@@ -65,10 +65,11 @@
     "eslint-plugin-sort-destructure-keys": "^1.6.0",
     "madge": "^6.1.0",
     "rimraf": "^5.0.10",
+    "ts-patch": "^3.3.0",
     "tsup": "^8.4.0",
+    "tsx": "^4.19.4",
     "typescript": "^5.8.2",
     "vite": "^5.4.14",
-    "vitest": "^1.6.1",
-    "tsx": "^4.19.4"
+    "vitest": "^1.6.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ devDependencies:
   rimraf:
     specifier: ^5.0.10
     version: 5.0.10
+  ts-patch:
+    specifier: ^3.3.0
+    version: 3.3.0
   tsup:
     specifier: ^8.4.0
     version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.2)
@@ -3536,6 +3539,15 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
+  /global-prefix@4.0.0:
+    resolution: {integrity: sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==}
+    engines: {node: '>=16'}
+    dependencies:
+      ini: 4.1.3
+      kind-of: 6.0.3
+      which: 4.0.0
+    dev: true
+
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -3696,6 +3708,11 @@ packages:
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: true
+
+  /ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
 
   /internal-slot@1.1.0:
@@ -3997,6 +4014,11 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
+  /isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
+    dev: true
+
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -4169,6 +4191,11 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
+    dev: true
+
+  /kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /levn@0.4.1:
@@ -5689,6 +5716,18 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
+  /ts-patch@3.3.0:
+    resolution: {integrity: sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      global-prefix: 4.0.0
+      minimist: 1.2.8
+      resolve: 1.22.10
+      semver: 7.7.1
+      strip-ansi: 6.0.1
+    dev: true
+
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -6157,6 +6196,14 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      isexe: 3.1.1
     dev: true
 
   /why-is-node-running@2.3.0:

--- a/src/core/LSP.ts
+++ b/src/core/LSP.ts
@@ -84,6 +84,24 @@ export interface PluginOptions {
   multipleEffectCheck: boolean
 }
 
+export function parsePluginOptions(config: any) {
+  return {
+    diagnostics: config && "diagnostics" in config && typeof config.diagnostics === "boolean"
+      ? config.diagnostics
+      : true,
+    quickinfo: config && "quickinfo" in config && typeof config.quickinfo === "boolean"
+      ? config.quickinfo
+      : true,
+    completions: config && "completions" in config && typeof config.completions === "boolean"
+      ? config.completions
+      : true,
+    multipleEffectCheck: config && "multipleEffectCheck" in config &&
+        typeof config.multipleEffectCheck === "boolean"
+      ? config.multipleEffectCheck
+      : true
+  }
+}
+
 export interface CompletionDefinition {
   name: string
   apply: (

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,24 +17,7 @@ const init = (
 ) => {
   function create(info: ts.server.PluginCreateInfo) {
     const languageService = info.languageService
-    const pluginOptions: LSP.PluginOptions = {
-      diagnostics:
-        info.config && "diagnostics" in info.config && typeof info.config.diagnostics === "boolean"
-          ? info.config.diagnostics
-          : true,
-      quickinfo:
-        info.config && "quickinfo" in info.config && typeof info.config.quickinfo === "boolean"
-          ? info.config.quickinfo
-          : true,
-      completions:
-        info.config && "completions" in info.config && typeof info.config.completions === "boolean"
-          ? info.config.completions
-          : true,
-      multipleEffectCheck: info.config && "multipleEffectCheck" in info.config &&
-          typeof info.config.multipleEffectCheck === "boolean"
-        ? info.config.multipleEffectCheck
-        : true
-    }
+    const pluginOptions: LSP.PluginOptions = LSP.parsePluginOptions(info.config)
 
     // this is nothing more than an hack. Seems like vscode and other editors do not
     // support new error codes in diagnostics. Because they somehow rely on looking into

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,0 +1,38 @@
+import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
+import type { PluginConfig, TransformerExtras } from "ts-patch"
+import type * as ts from "typescript"
+import * as LSP from "../src/core/LSP"
+import * as Nano from "../src/core/Nano"
+import * as TypeCheckerApi from "../src/core/TypeCheckerApi"
+import * as TypeScriptApi from "../src/core/TypeScriptApi"
+import { diagnostics } from "../src/diagnostics"
+
+export default function(
+  program: ts.Program,
+  pluginConfig: PluginConfig,
+  { addDiagnostic, ts: tsInstance }: TransformerExtras
+) {
+  return (_: ts.TransformationContext) => {
+    return (sourceFile: ts.SourceFile) => {
+      // run the diagnostics and pipe them into addDiagnostic
+      pipe(
+        LSP.getSemanticDiagnosticsWithCodeFixes(diagnostics, sourceFile),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
+        Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
+        Nano.provideService(
+          TypeCheckerApi.TypeCheckerApiCache,
+          TypeCheckerApi.makeTypeCheckerApiCache()
+        ),
+        Nano.provideService(LSP.PluginOptions, LSP.parsePluginOptions(pluginConfig)),
+        Nano.run,
+        Either.map((_) => _.diagnostics),
+        Either.getOrElse(() => [])
+      ).map(addDiagnostic)
+
+      // do not transform source ccde
+      return sourceFile
+    }
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ import { Effect, Layer } from "effect"
 import { defineConfig } from "tsup"
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/transform.ts"],
   clean: true,
   sourcemap: true,
   noExternal: ["effect"],


### PR DESCRIPTION
## Type


- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
With this PR we add a SourceTransformer compatible with ts-patch that allows emitting diagnostics at compile time.
tspc should be used instead of tsc, and transform should be configured as well inside tsconfig.json

