### PR TITLE
Use a single Schema.Literal call in unions of literals

### DIFF
--- a/.changeset/warm-sloths-tie.md
+++ b/.changeset/warm-sloths-tie.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Use a single Schema.Literal call in unions of literals

--- a/examples/refactors/typeToEffectSchema_literal.ts
+++ b/examples/refactors/typeToEffectSchema_literal.ts
@@ -1,0 +1,6 @@
+// 4:15,6:15
+import * as Schema from "effect/Schema"
+
+export type Test = "a" | "b" | "c" | true | 42
+
+export type NoLiteralOptimization = {a: boolean} | "a"

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -2465,6 +2465,32 @@ export interface MyStruct {
 "
 `;
 
+exports[`Refactor typeToEffectSchema > typeToEffectSchema_literal.ts at 4:15 1`] = `
+"// Result of running refactor effect/typeToEffectSchema at position 4:15
+import * as Schema from "effect/Schema"
+
+export const Test = Schema.Literal("a", "b", "c", true, 42)
+
+export type Test = "a" | "b" | "c" | true | 42
+
+export type NoLiteralOptimization = {a: boolean} | "a"
+"
+`;
+
+exports[`Refactor typeToEffectSchema > typeToEffectSchema_literal.ts at 6:15 1`] = `
+"// Result of running refactor effect/typeToEffectSchema at position 6:15
+import * as Schema from "effect/Schema"
+
+export type Test = "a" | "b" | "c" | true | 42
+
+export const NoLiteralOptimization = Schema.Union(Schema.Struct({
+    a: Schema.Boolean
+}), Schema.Literal("a"))
+
+export type NoLiteralOptimization = {a: boolean} | "a"
+"
+`;
+
 exports[`Refactor typeToEffectSchema > typeToEffectSchema_noGenerics.ts at 3:22 1`] = `
 "// Result of running refactor effect/typeToEffectSchema at position 3:22
 


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

`type MyType = "a" | "b"`
was producing
`export const MyType = Schema.Union(Schema.Literal("a"), Schema.Literal("b"))`
now outputs
`export const MyType = Schema.Literal("a", "b")`

