### PR TITLE
Add quickinfo hover for yield* statements

### DIFF
--- a/.changeset/tall-jokes-roll.md
+++ b/.changeset/tall-jokes-roll.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add quickinfo hover for yield\* statements

--- a/examples/quickinfo/effectGen.ts
+++ b/examples/quickinfo/effectGen.ts
@@ -1,0 +1,13 @@
+import * as Effect from "effect/Effect"
+import * as Data from "effect/Data"
+
+class DivisionByZeroError extends Data.TaggedError("DivisionByZeroError")<{}>{}
+
+const divide = Effect.fn(function*(fa: number, divideBy: number){
+    if(divideBy === 0) return yield* new DivisionByZeroError()
+    return fa / divideBy
+})
+
+const program = Effect.gen(function*(){
+    const result = yield* divide(42, 2)
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ const init = (
     proxy.getQuickInfoAtPosition = (fileName, position, ...args) => {
       const quickInfo = languageService.getQuickInfoAtPosition(fileName, position, ...args)
 
-      if (pluginOptions.quickinfo && quickInfo) {
+      if (pluginOptions.quickinfo) {
         const dedupedTagsQuickInfo = dedupeJsDocTags(quickInfo)
 
         const program = languageService.getProgram()

--- a/src/quickinfo.ts
+++ b/src/quickinfo.ts
@@ -18,7 +18,8 @@ const JSDocTagInfoEq = Eq.make<ts.JSDocTagInfo>((fa, fb) =>
   (typeof fa.text !== "undefined" ? Eq.array(SymbolDisplayPartEq)(fa.text!, fb.text!) : true)
 )
 
-export function dedupeJsDocTags(quickInfo: ts.QuickInfo): ts.QuickInfo {
+export function dedupeJsDocTags(quickInfo: ts.QuickInfo | undefined): ts.QuickInfo | undefined {
+  if (!quickInfo) return quickInfo
   if (quickInfo.tags) {
     return {
       ...quickInfo,
@@ -45,25 +46,38 @@ function formatTypeForQuickInfo(channelType: ts.Type, channelName: string) {
 export function prependEffectTypeArguments(
   sourceFile: ts.SourceFile,
   position: number,
-  quickInfo: ts.QuickInfo
+  quickInfo: ts.QuickInfo | undefined
 ) {
   return pipe(
     Nano.gen(function*() {
       const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
       const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
 
-      const hasTruncationHappened =
-        ts.displayPartsToString(quickInfo.displayParts).indexOf("...") > -1
-      if (!hasTruncationHappened) return quickInfo
-
+      // find the node we are hovering
       const maybeNode = pipe(
         yield* AST.getAncestorNodesInRange(sourceFile, AST.toTextRange(position)),
         ReadonlyArray.head
       )
       if (Option.isNone(maybeNode)) return quickInfo
+      const node = maybeNode.value
+
+      const hasTruncationHappened = quickInfo &&
+        ts.displayPartsToString(quickInfo.displayParts).indexOf("...") > -1
+
+      // if we are hovering a "yield*" and there are no quickinfo,
+      // we try to parse the effect type
+      // otherwise if no truncation has happened, do nothing
+      const nodeForType =
+        (!quickInfo && ts.isYieldExpression(node) && node.asteriskToken && node.expression)
+          ? node.expression
+          : (hasTruncationHappened ? node : undefined)
+
+      // we have no node to get type from
+      if (!nodeForType) return quickInfo
+
       const effectType = yield* TypeParser.effectType(
-        typeChecker.getTypeAtLocation(maybeNode.value),
-        maybeNode.value
+        typeChecker.getTypeAtLocation(nodeForType),
+        nodeForType
       )
 
       const effectTypeArgsDocumentation: Array<ts.SymbolDisplayPart> = [{
@@ -79,6 +93,18 @@ export function prependEffectTypeArguments(
           "\n```\n"
         )
       }]
+
+      // there are cases where we create it from scratch
+      if (!quickInfo) {
+        const start = node.getStart()
+        const end = node.getEnd()
+        return {
+          kind: ts.ScriptElementKind.callSignatureElement,
+          kindModifiers: "",
+          textSpan: { start, length: end - start },
+          documentation: effectTypeArgsDocumentation
+        } satisfies ts.QuickInfo
+      }
 
       if (quickInfo.documentation) {
         return {


### PR DESCRIPTION
## Type


- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When hovering a yield* that emits an effect, type parameters will be shown.

![CleanShot 2025-05-15 at 09 53 35](https://github.com/user-attachments/assets/653f7ab7-52b6-433c-b3db-765baf3fd823)


