### PR TITLE
Fix handling of nested pipes in effectGenToFn refactor

### DIFF
--- a/.changeset/cute-suns-own.md
+++ b/.changeset/cute-suns-own.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix handling of nested pipes in effectGenToFn refactor

--- a/examples/refactors/effectGenToFn_mixedPipes.ts
+++ b/examples/refactors/effectGenToFn_mixedPipes.ts
@@ -1,0 +1,11 @@
+// 6:13
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+const test = () => pipe(
+    Effect.gen(function* () {
+        const test = "test"
+        return yield* Effect.succeed(test);
+    }).pipe(Effect.asVoid),
+    Effect.tapError(Effect.logError)
+)

--- a/examples/refactors/effectGenToFn_withPipes.ts
+++ b/examples/refactors/effectGenToFn_withPipes.ts
@@ -1,0 +1,11 @@
+// 6:13
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+const test = () => pipe(
+    Effect.gen(function* () {
+        const test = "test"
+        return yield* Effect.succeed(test);
+    }),
+    Effect.tapError(Effect.logError)
+)

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -429,6 +429,30 @@ class Test {
 "
 `;
 
+exports[`Refactor effectGenToFn > effectGenToFn_mixedPipes.ts at 6:13 1`] = `
+"// Result of running refactor effect/effectGenToFn at position 6:13
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+const test = Effect.fn(function*() {
+    const test = "test";
+    return yield* Effect.succeed(test);
+}, Effect.asVoid, Effect.tapError(Effect.logError))
+"
+`;
+
+exports[`Refactor effectGenToFn > effectGenToFn_withPipes.ts at 6:13 1`] = `
+"// Result of running refactor effect/effectGenToFn at position 6:13
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+const test = Effect.fn(function*() {
+    const test = "test";
+    return yield* Effect.succeed(test);
+}, Effect.tapError(Effect.logError))
+"
+`;
+
 exports[`Refactor functionToArrow > functionToArrow.ts at 5:20 1`] = `
 "// Result of running refactor effect/functionToArrow at position 5:20
 /**


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix issue with refactor removing pipe arguments in some edge cases
