### PR TITLE
In type to effect schema, follow top level typeof nodes

### DIFF
--- a/.changeset/great-hotels-sell.md
+++ b/.changeset/great-hotels-sell.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+In type to effect schema, follow top level typeof nodes

--- a/examples/refactors/typeToEffectSchema_typeOf.ts
+++ b/examples/refactors/typeToEffectSchema_typeOf.ts
@@ -1,0 +1,8 @@
+// 6:21
+import * as Schema from "effect/Schema"
+
+const myVar = 'A' as const
+
+export interface MyStruct {
+    prop: typeof myVar
+}

--- a/src/refactors/typeToEffectSchema.ts
+++ b/src/refactors/typeToEffectSchema.ts
@@ -2,6 +2,7 @@ import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as LSP from "../core/LSP.js"
 import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
 import * as TypeScriptApi from "../core/TypeScriptApi.js"
 import * as SchemaGen from "../utils/SchemaGen.js"
 
@@ -10,6 +11,7 @@ export const typeToEffectSchema = LSP.createRefactor({
   description: "Refactor to Schema",
   apply: Nano.fn("typeToEffectSchema.apply")(function*(sourceFile, textRange) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
 
     const maybeNode = yield* SchemaGen.findNodeToProcess(sourceFile, textRange)
 
@@ -21,6 +23,7 @@ export const typeToEffectSchema = LSP.createRefactor({
       description: "Refactor to Schema",
       apply: pipe(
         SchemaGen.applyAtNode(sourceFile, node, false),
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
         Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
       )
     })

--- a/src/refactors/typeToEffectSchemaClass.ts
+++ b/src/refactors/typeToEffectSchemaClass.ts
@@ -2,6 +2,7 @@ import { pipe } from "effect/Function"
 import * as Option from "effect/Option"
 import * as LSP from "../core/LSP.js"
 import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
 import * as TypeScriptApi from "../core/TypeScriptApi.js"
 import * as SchemaGen from "../utils/SchemaGen.js"
 
@@ -10,6 +11,7 @@ export const typeToEffectSchemaClass = LSP.createRefactor({
   description: "Refactor to Schema.Class",
   apply: Nano.fn("typeToEffectSchemaClass.apply")(function*(sourceFile, textRange) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
 
     const maybeNode = yield* SchemaGen.findNodeToProcess(sourceFile, textRange)
 
@@ -21,6 +23,7 @@ export const typeToEffectSchemaClass = LSP.createRefactor({
       description: "Refactor to Schema.Class",
       apply: pipe(
         SchemaGen.applyAtNode(sourceFile, node, true),
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
         Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
       )
     })

--- a/test/__snapshots__/refactors.test.ts.snap
+++ b/test/__snapshots__/refactors.test.ts.snap
@@ -2541,6 +2541,22 @@ export type Test = { a: string, b: boolean}
 "
 `;
 
+exports[`Refactor typeToEffectSchema > typeToEffectSchema_typeOf.ts at 6:21 1`] = `
+"// Result of running refactor effect/typeToEffectSchema at position 6:21
+import * as Schema from "effect/Schema"
+
+const myVar = 'A' as const
+
+export const MyStruct = Schema.Struct({
+    prop: Schema.Literal("A")
+})
+
+export interface MyStruct {
+    prop: typeof myVar
+}
+"
+`;
+
 exports[`Refactor typeToEffectSchemaClass > typeToEffectSchemaClass.ts at 4:21 1`] = `
 "// Result of running refactor effect/typeToEffectSchemaClass at position 4:21
 import * as Schema from "effect/Schema"


### PR DESCRIPTION
## Type

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a top level typeof node is encuntered, it's type will be resolved and treated. Nested typeof node won't be considered to avoid circular references.

## Related

- Related Issue #157 
- Closes #157 
