### PR TITLE
Avoid multiple LSP patching

### DIFF
--- a/.changeset/blue-windows-divide.md
+++ b/.changeset/blue-windows-divide.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Avoid multiple LSP patching


### PR DESCRIPTION

## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In some configurations, LSP may be applied multiple times to the same env. Use a flag to detect and avoid multiple applications on the same instance proxy.