### PR TITLE
Handle unnecessary Effect.gen even when yielded expression is not ret…

### DIFF
--- a/.changeset/crazy-humans-camp.md
+++ b/.changeset/crazy-humans-camp.md
@@ -1,0 +1,17 @@
+---
+"@effect/language-service": patch
+---
+
+Handle unnecessary Effect.gen even when yielded expression is not returned
+
+```ts
+export const shouldRaiseForSingle = Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+// ^- this will become Effect.asVoid(Effect.succeed(42))
+
+export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
+  yield* Effect.void
+})
+// ^- this will become Effect.void
+```

--- a/examples/diagnostics/unnecessaryEffectGen_ifBlock.ts
+++ b/examples/diagnostics/unnecessaryEffectGen_ifBlock.ts
@@ -1,6 +1,6 @@
 import * as Effect from "effect/Effect"
 
-const a = Effect.gen(function*() {
+export const shouldNotTrigger = Effect.gen(function*() {
   const query = yield* Effect.succeed("")
   yield* Effect.annotateCurrentSpan("query", query)
   if (query.length < 3) {

--- a/examples/diagnostics/unnecessaryEffectGen_noReturn.ts
+++ b/examples/diagnostics/unnecessaryEffectGen_noReturn.ts
@@ -1,0 +1,18 @@
+import * as Effect from "effect/Effect"
+
+export const shouldNotRant = Effect.gen(function*() {
+  yield* Effect.succeed(true)
+  yield* Effect.succeed(42)
+})
+
+export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
+  return 42
+})
+
+export const shouldRaiseForSingle = Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+
+export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
+  yield* Effect.void
+})

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.codefixes
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.codefixes
@@ -1,0 +1,6 @@
+unnecessaryEffectGen_fix from 276 to 331
+unnecessaryEffectGen_skipNextLine from 276 to 331
+unnecessaryEffectGen_skipFile from 276 to 331
+unnecessaryEffectGen_fix from 379 to 427
+unnecessaryEffectGen_skipNextLine from 379 to 427
+unnecessaryEffectGen_skipFile from 379 to 427

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.output
@@ -1,0 +1,9 @@
+Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+12:36 - 14:2 | 2 | This Effect.gen contains a single return statement.
+
+Effect.gen(function*() {
+  yield* Effect.void
+})
+16:46 - 18:2 | 2 | This Effect.gen contains a single return statement.

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_fix.from276to331.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_fix.from276to331.output
@@ -1,0 +1,17 @@
+// code fix unnecessaryEffectGen_fix  output for range 276 - 331
+import * as Effect from "effect/Effect"
+
+export const shouldNotRant = Effect.gen(function*() {
+  yield* Effect.succeed(true)
+  yield* Effect.succeed(42)
+})
+
+export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
+  return 42
+})
+
+export const shouldRaiseForSingle = Effect.asVoid(Effect.succeed(42))
+
+export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
+  yield* Effect.void
+})

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_fix.from379to427.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_fix.from379to427.output
@@ -1,0 +1,17 @@
+// code fix unnecessaryEffectGen_fix  output for range 379 - 427
+import * as Effect from "effect/Effect"
+
+export const shouldNotRant = Effect.gen(function*() {
+  yield* Effect.succeed(true)
+  yield* Effect.succeed(42)
+})
+
+export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
+  return 42
+})
+
+export const shouldRaiseForSingle = Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+
+export const shouldRaiseForSingleReturnVoid = Effect.void

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipFile.from276to331.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipFile.from276to331.output
@@ -1,0 +1,20 @@
+// code fix unnecessaryEffectGen_skipFile  output for range 276 - 331
+/** @effect-diagnostics unnecessaryEffectGen:skip-file */
+import * as Effect from "effect/Effect"
+
+export const shouldNotRant = Effect.gen(function*() {
+  yield* Effect.succeed(true)
+  yield* Effect.succeed(42)
+})
+
+export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
+  return 42
+})
+
+export const shouldRaiseForSingle = Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+
+export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
+  yield* Effect.void
+})

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipFile.from379to427.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipFile.from379to427.output
@@ -1,0 +1,20 @@
+// code fix unnecessaryEffectGen_skipFile  output for range 379 - 427
+/** @effect-diagnostics unnecessaryEffectGen:skip-file */
+import * as Effect from "effect/Effect"
+
+export const shouldNotRant = Effect.gen(function*() {
+  yield* Effect.succeed(true)
+  yield* Effect.succeed(42)
+})
+
+export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
+  return 42
+})
+
+export const shouldRaiseForSingle = Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+
+export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
+  yield* Effect.void
+})

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipNextLine.from276to331.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipNextLine.from276to331.output
@@ -1,0 +1,20 @@
+// code fix unnecessaryEffectGen_skipNextLine  output for range 276 - 331
+import * as Effect from "effect/Effect"
+
+export const shouldNotRant = Effect.gen(function*() {
+  yield* Effect.succeed(true)
+  yield* Effect.succeed(42)
+})
+
+export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
+  return 42
+})
+
+// @effect-diagnostics-next-line unnecessaryEffectGen:off
+export const shouldRaiseForSingle = Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+
+export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
+  yield* Effect.void
+})

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipNextLine.from379to427.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.unnecessaryEffectGen_skipNextLine.from379to427.output
@@ -1,0 +1,20 @@
+// code fix unnecessaryEffectGen_skipNextLine  output for range 379 - 427
+import * as Effect from "effect/Effect"
+
+export const shouldNotRant = Effect.gen(function*() {
+  yield* Effect.succeed(true)
+  yield* Effect.succeed(42)
+})
+
+export const shouldNotRaiseForNonEffect = Effect.gen(function*() {
+  return 42
+})
+
+export const shouldRaiseForSingle = Effect.gen(function*() {
+  yield* Effect.succeed(42)
+})
+
+// @effect-diagnostics-next-line unnecessaryEffectGen:off
+export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
+  yield* Effect.void
+})


### PR DESCRIPTION
…urned


## Type

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Handle unnecessary Effect.gen even when yielded expression is not returned

```ts
export const shouldRaiseForSingle = Effect.gen(function*() {
  yield* Effect.succeed(42)
})
// ^- this will become Effect.asVoid(Effect.succeed(42))

export const shouldRaiseForSingleReturnVoid = Effect.gen(function*() {
  yield* Effect.void
})
// ^- this will become Effect.void
```

