### PR TITLE
Allow to change diagnostic severity inside the LSP options

### DIFF
--- a/.changeset/cold-towns-cut.md
+++ b/.changeset/cold-towns-cut.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Allow to change diagnostic severity inside the LSP options

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Few options can be provided alongside the initialization of the Language Service
       {
         "name": "@effect/language-service",
         "diagnostics": true, // controls Effect diagnostics (default: true)
+        "diagnosticSeverity": { // allows to change per-rule default severity of the diagnostic in the whole project
+          "floatingEffect": "warning" // example for a rule, allowed values are off,error,warning,message,suggestion
+        },
         "quickinfo": true, // controls quickinfo over Effect (default: true)
         "completions": true, // controls Effect completions (default: true)
         "allowedDuplicatedPackages": [] // list of package names that has effect in peer dependencies and are allowed to be duplicated (default: [])

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -1,9 +1,14 @@
 import { isArray } from "effect/Array"
-import { hasProperty, isBoolean, isObject, isString } from "effect/Predicate"
+import * as Array from "effect/Array"
+import { pipe } from "effect/Function"
+import { hasProperty, isBoolean, isObject, isRecord, isString } from "effect/Predicate"
 import * as Nano from "./Nano"
+
+export type DiagnosticSeverity = "error" | "warning" | "message" | "suggestion"
 
 export interface LanguageServicePluginOptions {
   diagnostics: boolean
+  diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
   quickinfo: boolean
   completions: boolean
   goto: boolean
@@ -12,11 +17,29 @@ export interface LanguageServicePluginOptions {
 
 export const LanguageServicePluginOptions = Nano.Tag<LanguageServicePluginOptions>("PluginOptions")
 
+function parseDiagnosticSeverity(config: Record<PropertyKey, unknown>): Record<string, DiagnosticSeverity | "off"> {
+  if (!isRecord(config)) return {}
+  return Object.fromEntries(
+    pipe(
+      Object.entries(config),
+      Array.filter(([key, value]) => isString(key) && isString(value)),
+      Array.map(([key, value]) => [String(key).toLowerCase(), String(value).toLowerCase()]),
+      Array.filter(([_, value]) =>
+        value === "off" || value === "error" || value === "warning" || value === "message" || value === "suggestion"
+      )
+    )
+  )
+}
+
 export function parse(config: any): LanguageServicePluginOptions {
   return {
     diagnostics: isObject(config) && hasProperty(config, "diagnostics") && isBoolean(config.diagnostics)
       ? config.diagnostics
       : true,
+    diagnosticSeverity:
+      isObject(config) && hasProperty(config, "diagnosticSeverity") && isRecord(config.diagnosticSeverity)
+        ? parseDiagnosticSeverity(config.diagnosticSeverity)
+        : {},
     quickinfo: isObject(config) && hasProperty(config, "quickinfo") && isBoolean(config.quickinfo)
       ? config.quickinfo
       : true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,14 +20,19 @@ const init = (
     typescript: typeof ts
   }
 ) => {
+  let languageServicePluginOptions: LanguageServicePluginOptions.LanguageServicePluginOptions =
+    LanguageServicePluginOptions.parse({})
+
+  function onConfigurationChanged(config: any) {
+    languageServicePluginOptions = LanguageServicePluginOptions.parse(config)
+  }
+
   function create(info: ts.server.PluginCreateInfo) {
     const languageService = info.languageService
+    languageServicePluginOptions = LanguageServicePluginOptions.parse(info.config)
 
     // prevent double-injection of the effect language service
     if ((languageService as any)[LSP_INJECTED_URI]) return languageService
-
-    const languageServicePluginOptions: LanguageServicePluginOptions.LanguageServicePluginOptions =
-      LanguageServicePluginOptions.parse(info.config)
 
     // this is nothing more than an hack. Seems like vscode and other editors do not
     // support new error codes in diagnostics. Because they somehow rely on looking into
@@ -350,7 +355,7 @@ const init = (
     return proxy
   }
 
-  return { create }
+  return { create, onConfigurationChanged }
 }
 
 module.exports = init

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -52,6 +52,7 @@ function testCompletionOnExample(
     Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, program.getTypeChecker())),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
       diagnostics: false,
+      diagnosticSeverity: {},
       quickinfo: false,
       completions: false,
       goto: false,

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -65,6 +65,7 @@ function testDiagnosticOnExample(
     Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, program.getTypeChecker())),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
       diagnostics: true,
+      diagnosticSeverity: {},
       quickinfo: false,
       completions: false,
       goto: false,
@@ -171,6 +172,7 @@ function testDiagnosticQuickfixesOnExample(
     Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, program.getTypeChecker())),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
       diagnostics: true,
+      diagnosticSeverity: {},
       quickinfo: false,
       completions: false,
       goto: false,

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -43,6 +43,7 @@ function testAllDagnostics() {
         Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, example.program.getTypeChecker())),
         Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
           diagnostics: true,
+          diagnosticSeverity: {},
           quickinfo: false,
           completions: false,
           goto: false,

--- a/test/refactors.test.ts
+++ b/test/refactors.test.ts
@@ -80,6 +80,7 @@ function testRefactorOnExample(
     Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, program.getTypeChecker())),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
       diagnostics: false,
+      diagnosticSeverity: {},
       quickinfo: false,
       completions: false,
       goto: false,
@@ -105,6 +106,7 @@ function testRefactorOnExample(
     Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, program.getTypeChecker())),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
       diagnostics: false,
+      diagnosticSeverity: {},
       quickinfo: false,
       completions: false,
       goto: false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "include": [],
   "compilerOptions": {
     "strict": true,
-    "allowSyntheticDefaultImports":true,
+    "allowSyntheticDefaultImports": true,
     "exactOptionalPropertyTypes": true,
     "moduleDetection": "force",
     "composite": true,
@@ -14,7 +14,10 @@
     "emitDecoratorMetadata": false,
     "experimentalDecorators": true,
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022", "DOM"],
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
     "isolatedModules": true,
     "sourceMap": true,
     "declarationMap": true,
@@ -35,7 +38,9 @@
     "module": "NodeNext",
     "incremental": true,
     "removeComments": false,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "plugins": [
       {
         "name": "@effect/language-service"


### PR DESCRIPTION

## Type

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow to change diagnostics severity at project-level and per-rule based on tsconfig settings.