### PR TITLE
Improve message for return yield* diagnostic

### DIFF
--- a/.changeset/blue-times-speak.md
+++ b/.changeset/blue-times-speak.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Improve message for return yield\* diagnostic

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,10 +5,10 @@
   "editor.formatOnSave": true,
   "eslint.format.enable": true,
   "[json]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[markdown]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[javascript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
@@ -22,7 +22,11 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
-  "eslint.validate": ["markdown", "javascript", "typescript"],
+  "eslint.validate": [
+    "markdown",
+    "javascript",
+    "typescript"
+  ],
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },

--- a/src/diagnostics/missingReturnYieldStar.ts
+++ b/src/diagnostics/missingReturnYieldStar.ts
@@ -92,7 +92,7 @@ export const missingReturnYieldStar = LSP.createDiagnostic({
       effectDiagnostics.push({
         node,
         category: ts.DiagnosticCategory.Error,
-        messageText: `Yielded Effect never completes, so it is best to use a 'return yield*' instead.`,
+        messageText: `Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.`,
         fixes: fix
       })
     })

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.output
@@ -1,8 +1,8 @@
 yield* Effect.fail("no zero!")
-11:6 - 11:36 | 1 | Yielded Effect never completes, so it is best to use a 'return yield*' instead.
+11:6 - 11:36 | 1 | Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.
 
 yield* Effect.interrupt
-18:4 - 18:27 | 1 | Yielded Effect never completes, so it is best to use a 'return yield*' instead.
+18:4 - 18:27 | 1 | Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.
 
 yield* Effect.die("lol")
-19:4 - 19:28 | 1 | Yielded Effect never completes, so it is best to use a 'return yield*' instead.
+19:4 - 19:28 | 1 | Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.


### PR DESCRIPTION
## Description

use "succeeds" instead of "completes"

