### PR TITLE
Allow throw as way to break gen control flow - closes #244

### DIFF
--- a/.changeset/long-loops-repair.md
+++ b/.changeset/long-loops-repair.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Allow throw as way to break gen control flow

--- a/examples/diagnostics/missingReturnYieldStar.ts
+++ b/examples/diagnostics/missingReturnYieldStar.ts
@@ -19,3 +19,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/src/diagnostics/missingReturnYieldStar.ts
+++ b/src/diagnostics/missingReturnYieldStar.ts
@@ -43,11 +43,14 @@ export const missingReturnYieldStar = LSP.createDiagnostic({
             (
               _
             ) => (ts.isFunctionExpression(_) || ts.isFunctionDeclaration(_) || ts.isMethodDeclaration(_) ||
-              ts.isReturnStatement(_))
+              ts.isReturnStatement(_) || ts.isThrowStatement(_))
           )
 
           // we already have a return statement
-          if (generatorFunctionOrReturnStatement && !ts.isReturnStatement(generatorFunctionOrReturnStatement)) {
+          if (
+            generatorFunctionOrReturnStatement && !ts.isReturnStatement(generatorFunctionOrReturnStatement) &&
+            !ts.isThrowStatement(generatorFunctionOrReturnStatement)
+          ) {
             // .gen should always be the parent ideally
             if (generatorFunctionOrReturnStatement && generatorFunctionOrReturnStatement.parent) {
               const effectGenNode = generatorFunctionOrReturnStatement.parent

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_fix.from288to318.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_fix.from288to318.output
@@ -20,3 +20,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_fix.from429to452.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_fix.from429to452.output
@@ -20,3 +20,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_fix.from457to481.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_fix.from457to481.output
@@ -20,3 +20,8 @@ export const shouldComplainOther = (n: number) =>
     return yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipFile.from288to318.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipFile.from288to318.output
@@ -21,3 +21,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipFile.from429to452.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipFile.from429to452.output
@@ -21,3 +21,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipFile.from457to481.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipFile.from457to481.output
@@ -21,3 +21,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipNextLine.from288to318.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipNextLine.from288to318.output
@@ -21,3 +21,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipNextLine.from429to452.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipNextLine.from429to452.output
@@ -21,3 +21,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipNextLine.from457to481.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.missingReturnYieldStar_skipNextLine.from457to481.output
@@ -21,3 +21,8 @@ export const shouldComplainOther = (n: number) =>
     yield* Effect.die("lol")
     return n / 1
   })
+
+export const shouldNotComplainThrows = Effect.gen(function*() {
+  throw yield* Effect.fail(42)
+  return 42
+})


### PR DESCRIPTION

## Type

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow throw as way to break gen control flow

## Related

- Closes #244
