### PR TITLE
Add exclusion rules for barrel style

### DIFF
--- a/.changeset/proud-kiwis-fail.md
+++ b/.changeset/proud-kiwis-fail.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add exclusion rules for barrel style so pipe will be imported from "effect" instead of "effect/Function"


### PR DESCRIPTION

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When barrelImportPackages is enabled, top-level function re-exports like "pipe" are now redirected to top barrel instead of prefixed