### PR TITLE
Warn on usage of try/catch inside Effect.gen

### DIFF
--- a/.changeset/good-forks-hide.md
+++ b/.changeset/good-forks-hide.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Warn on usage of try/catch inside `Effect.gen`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+## MANDATORY STEPS
+- After any write to a TypeScript .ts file, run "pnpm lint-fix"
+
+## Repo structure
+- Tests for diagnostics are placed inside the examples/diagnostic folder, and the name should start with the rule name
+  e.g. for rule "floatingEffect" the file name of the test should be either "floatingEffect.ts" or "floatingEffect_xxxx.ts" where xxxx is anything.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Warn on Scope as requirement of a Layer
 - Unnecessary usages of `Effect.gen` or `pipe()`
 - Warn when importing from a barrel file instead of from the module directly
+- Warn on usage of try/catch inside `Effect.gen` and family
 
 ### Completions
 

--- a/examples/diagnostics/tryCatchInEffectGen.ts
+++ b/examples/diagnostics/tryCatchInEffectGen.ts
@@ -1,0 +1,46 @@
+import * as Effect from "effect/Effect"
+
+export const shouldTrigger = Effect.gen(function*() {
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+// This should also trigger with Effect.fn
+export const exampleWithEffectFn = Effect.fn("example")(function*() {
+  try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+// This should NOT trigger (no try/catch)
+export const shouldNotTrigger = Effect.gen(function*() {
+  const result = yield* Effect.succeed(42)
+  return result
+})
+
+// This should NOT trigger (try/catch outside Effect.gen)
+export function regularFunction() {
+  try {
+    console.log("regular try/catch")
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Nested case should trigger
+export const nestedExample = Effect.gen(function*() {
+  const inner = yield* Effect.gen(function*() {
+    try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+  })
+  return inner
+})

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -10,6 +10,7 @@ import { missingReturnYieldStar } from "./diagnostics/missingReturnYieldStar.js"
 import { missingStarInYieldEffectGen } from "./diagnostics/missingStarInYieldEffectGen.js"
 import { returnEffectInGen } from "./diagnostics/returnEffectInGen.js"
 import { scopeInLayerEffect } from "./diagnostics/scopeInLayerEffect.js"
+import { tryCatchInEffectGen } from "./diagnostics/tryCatchInEffectGen.js"
 import { unnecessaryEffectGen } from "./diagnostics/unnecessaryEffectGen.js"
 import { unnecessaryPipe } from "./diagnostics/unnecessaryPipe.js"
 
@@ -25,6 +26,7 @@ export const diagnostics = [
   unnecessaryPipe,
   genericEffectServices,
   returnEffectInGen,
+  tryCatchInEffectGen,
   importFromBarrel,
   scopeInLayerEffect,
   effectInVoidSuccess

--- a/src/diagnostics/tryCatchInEffectGen.ts
+++ b/src/diagnostics/tryCatchInEffectGen.ts
@@ -1,0 +1,69 @@
+import { pipe } from "effect/Function"
+import type ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const tryCatchInEffectGen = LSP.createDiagnostic({
+  name: "tryCatchInEffectGen",
+  code: 12,
+  severity: "warning",
+  apply: Nano.fn("tryCatchInEffectGen.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+      ts.forEachChild(node, appendNodeToVisit)
+
+      // Check if this is a try statement
+      if (ts.isTryStatement(node)) {
+        // Find the containing generator function
+        // go up until we meet the causing generator/function
+        const generatorOrRegularFunction = ts.findAncestor(
+          node,
+          (
+            _
+          ) => (ts.isFunctionExpression(_) || ts.isFunctionDeclaration(_) || ts.isMethodDeclaration(_) ||
+            ts.isArrowFunction(_) || ts.isGetAccessor(_) || ts.isFunctionLike(_))
+        )
+
+        if (
+          !(generatorOrRegularFunction && "asteriskToken" in generatorOrRegularFunction &&
+            generatorOrRegularFunction.asteriskToken)
+        ) continue // fast exit
+
+        if (!generatorOrRegularFunction) continue
+
+        // Check if we're inside Effect.gen or Effect.fn
+        if (generatorOrRegularFunction && generatorOrRegularFunction.parent) {
+          const effectGenNode = generatorOrRegularFunction.parent
+
+          // Check if this generator is inside Effect.gen/Effect.fn
+          yield* pipe(
+            typeParser.effectGen(effectGenNode),
+            Nano.orElse(() => typeParser.effectFnUntracedGen(effectGenNode)),
+            Nano.orElse(() => typeParser.effectFnGen(effectGenNode)),
+            Nano.map(() => {
+              report({
+                node,
+                messageText:
+                  "Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).",
+                fixes: []
+              })
+            }),
+            Nano.ignore
+          )
+        }
+      }
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -168,7 +168,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,returnEffectInGen,scopeInLayerEffect,unnecessaryEffectGen,unnecessaryPipe|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,returnEffectInGen,scopeInLayerEffect,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -179,7 +179,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,returnEffectInGen,scopeInLayerEffect,unnecessaryEffectGen,unnecessaryPipe|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,returnEffectInGen,scopeInLayerEffect,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.codefixes
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.codefixes
@@ -1,0 +1,6 @@
+tryCatchInEffectGen_skipNextLine from 97 to 214
+tryCatchInEffectGen_skipFile from 97 to 214
+tryCatchInEffectGen_skipNextLine from 334 to 415
+tryCatchInEffectGen_skipFile from 334 to 415
+tryCatchInEffectGen_skipNextLine from 901 to 991
+tryCatchInEffectGen_skipFile from 901 to 991

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.output
@@ -1,0 +1,21 @@
+try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+4:2 - 9:3 | 0 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).
+
+try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+14:2 - 18:3 | 0 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).
+
+try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+39:4 - 43:5 | 0 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipFile.from334to415.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipFile.from334to415.output
@@ -1,0 +1,48 @@
+// code fix tryCatchInEffectGen_skipFile  output for range 334 - 415
+/** @effect-diagnostics tryCatchInEffectGen:skip-file */
+import * as Effect from "effect/Effect"
+
+export const shouldTrigger = Effect.gen(function*() {
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+// This should also trigger with Effect.fn
+export const exampleWithEffectFn = Effect.fn("example")(function*() {
+  try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+// This should NOT trigger (no try/catch)
+export const shouldNotTrigger = Effect.gen(function*() {
+  const result = yield* Effect.succeed(42)
+  return result
+})
+
+// This should NOT trigger (try/catch outside Effect.gen)
+export function regularFunction() {
+  try {
+    console.log("regular try/catch")
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Nested case should trigger
+export const nestedExample = Effect.gen(function*() {
+  const inner = yield* Effect.gen(function*() {
+    try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+  })
+  return inner
+})

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipFile.from901to991.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipFile.from901to991.output
@@ -1,0 +1,48 @@
+// code fix tryCatchInEffectGen_skipFile  output for range 901 - 991
+/** @effect-diagnostics tryCatchInEffectGen:skip-file */
+import * as Effect from "effect/Effect"
+
+export const shouldTrigger = Effect.gen(function*() {
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+// This should also trigger with Effect.fn
+export const exampleWithEffectFn = Effect.fn("example")(function*() {
+  try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+// This should NOT trigger (no try/catch)
+export const shouldNotTrigger = Effect.gen(function*() {
+  const result = yield* Effect.succeed(42)
+  return result
+})
+
+// This should NOT trigger (try/catch outside Effect.gen)
+export function regularFunction() {
+  try {
+    console.log("regular try/catch")
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Nested case should trigger
+export const nestedExample = Effect.gen(function*() {
+  const inner = yield* Effect.gen(function*() {
+    try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+  })
+  return inner
+})

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipFile.from97to214.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipFile.from97to214.output
@@ -1,0 +1,48 @@
+// code fix tryCatchInEffectGen_skipFile  output for range 97 - 214
+/** @effect-diagnostics tryCatchInEffectGen:skip-file */
+import * as Effect from "effect/Effect"
+
+export const shouldTrigger = Effect.gen(function*() {
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+// This should also trigger with Effect.fn
+export const exampleWithEffectFn = Effect.fn("example")(function*() {
+  try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+// This should NOT trigger (no try/catch)
+export const shouldNotTrigger = Effect.gen(function*() {
+  const result = yield* Effect.succeed(42)
+  return result
+})
+
+// This should NOT trigger (try/catch outside Effect.gen)
+export function regularFunction() {
+  try {
+    console.log("regular try/catch")
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Nested case should trigger
+export const nestedExample = Effect.gen(function*() {
+  const inner = yield* Effect.gen(function*() {
+    try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+  })
+  return inner
+})

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipNextLine.from334to415.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipNextLine.from334to415.output
@@ -1,0 +1,48 @@
+// code fix tryCatchInEffectGen_skipNextLine  output for range 334 - 415
+import * as Effect from "effect/Effect"
+
+export const shouldTrigger = Effect.gen(function*() {
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+// This should also trigger with Effect.fn
+export const exampleWithEffectFn = Effect.fn("example")(function*() {
+  // @effect-diagnostics-next-line tryCatchInEffectGen:off
+  try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+// This should NOT trigger (no try/catch)
+export const shouldNotTrigger = Effect.gen(function*() {
+  const result = yield* Effect.succeed(42)
+  return result
+})
+
+// This should NOT trigger (try/catch outside Effect.gen)
+export function regularFunction() {
+  try {
+    console.log("regular try/catch")
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Nested case should trigger
+export const nestedExample = Effect.gen(function*() {
+  const inner = yield* Effect.gen(function*() {
+    try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+  })
+  return inner
+})

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipNextLine.from901to991.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipNextLine.from901to991.output
@@ -1,0 +1,48 @@
+// code fix tryCatchInEffectGen_skipNextLine  output for range 901 - 991
+import * as Effect from "effect/Effect"
+
+export const shouldTrigger = Effect.gen(function*() {
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+// This should also trigger with Effect.fn
+export const exampleWithEffectFn = Effect.fn("example")(function*() {
+  try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+// This should NOT trigger (no try/catch)
+export const shouldNotTrigger = Effect.gen(function*() {
+  const result = yield* Effect.succeed(42)
+  return result
+})
+
+// This should NOT trigger (try/catch outside Effect.gen)
+export function regularFunction() {
+  try {
+    console.log("regular try/catch")
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Nested case should trigger
+export const nestedExample = Effect.gen(function*() {
+  const inner = yield* Effect.gen(function*() {
+    // @effect-diagnostics-next-line tryCatchInEffectGen:off
+    try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+  })
+  return inner
+})

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipNextLine.from97to214.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.tryCatchInEffectGen_skipNextLine.from97to214.output
@@ -1,0 +1,48 @@
+// code fix tryCatchInEffectGen_skipNextLine  output for range 97 - 214
+import * as Effect from "effect/Effect"
+
+export const shouldTrigger = Effect.gen(function*() {
+  // @effect-diagnostics-next-line tryCatchInEffectGen:off
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+// This should also trigger with Effect.fn
+export const exampleWithEffectFn = Effect.fn("example")(function*() {
+  try {
+    yield* Effect.succeed("hello")
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+// This should NOT trigger (no try/catch)
+export const shouldNotTrigger = Effect.gen(function*() {
+  const result = yield* Effect.succeed(42)
+  return result
+})
+
+// This should NOT trigger (try/catch outside Effect.gen)
+export function regularFunction() {
+  try {
+    console.log("regular try/catch")
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+// Nested case should trigger
+export const nestedExample = Effect.gen(function*() {
+  const inner = yield* Effect.gen(function*() {
+    try {
+      return yield* Effect.succeed(1)
+    } catch (e) {
+      console.error(e)
+    }
+  })
+  return inner
+})


### PR DESCRIPTION
## Summary
This PR adds a diagnostic warning when try/catch blocks are used inside `Effect.gen` functions.

## Test plan
- Added diagnostic tests in examples/diagnostic folder

🤖 Generated with [Claude Code](https://claude.ai/code)