### PR TITLE
Add refactor to toggle pipe style

### DIFF
--- a/.changeset/fine-houses-throw.md
+++ b/.changeset/fine-houses-throw.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add refactor to toggle pipe style

--- a/examples/refactors/togglePipeStyle.ts
+++ b/examples/refactors/togglePipeStyle.ts
@@ -1,0 +1,7 @@
+// 5:54,7:32
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+export const toRegularPipe = Effect.succeed(42).pipe(Effect.map((x) => x * 2))
+
+export const toPipeable = pipe(Effect.succeed(42), Effect.map((x) => x * 2))

--- a/src/refactors.ts
+++ b/src/refactors.ts
@@ -7,6 +7,7 @@ import { makeSchemaOpaqueWithNs } from "./refactors/makeSchemaOpaqueWithNs.js"
 import { pipeableToDatafirst } from "./refactors/pipeableToDatafirst.js"
 import { removeUnnecessaryEffectGen } from "./refactors/removeUnnecessaryEffectGen.js"
 import { toggleLazyConst } from "./refactors/toggleLazyConst.js"
+import { togglePipeStyle } from "./refactors/togglePipeStyle.js"
 import { toggleReturnTypeAnnotation } from "./refactors/toggleReturnTypeAnnotation.js"
 import { toggleTypeAnnotation } from "./refactors/toggleTypeAnnotation.js"
 import { typeToEffectSchema } from "./refactors/typeToEffectSchema.js"
@@ -29,5 +30,6 @@ export const refactors = [
   toggleTypeAnnotation,
   wrapWithEffectGen,
   wrapWithPipe,
-  effectGenToFn
+  effectGenToFn,
+  togglePipeStyle
 ]

--- a/src/refactors/togglePipeStyle.ts
+++ b/src/refactors/togglePipeStyle.ts
@@ -1,0 +1,71 @@
+import { pipe } from "effect/Function"
+import type ts from "typescript"
+import * as AST from "../core/AST.js"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const togglePipeStyle = LSP.createRefactor({
+  name: "togglePipeStyle",
+  description: "Toggle pipe style",
+  apply: Nano.fn("togglePipeStyle.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const togglePipeStyle = (node: ts.Node) =>
+      Nano.gen(function*() {
+        const pipeCall = yield* typeParser.pipeCall(node)
+        switch (pipeCall.kind) {
+          case "pipe": {
+            yield* typeParser.pipeableType(typeChecker.getTypeAtLocation(pipeCall.subject), pipeCall.subject)
+            return ({
+              kind: "refactor.rewrite.effect.togglePipeStyle",
+              description: "Rewrite as X.pipe(Y, Z, ...)",
+              apply: Nano.gen(function*() {
+                const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+                changeTracker.replaceNode(
+                  sourceFile,
+                  node,
+                  ts.factory.createCallExpression(
+                    ts.factory.createPropertyAccessExpression(
+                      pipeCall.subject,
+                      "pipe"
+                    ),
+                    undefined,
+                    pipeCall.args
+                  )
+                )
+              })
+            })
+          }
+          case "pipeable":
+            return ({
+              kind: "refactor.rewrite.effect.togglePipeStyle",
+              description: "Rewrite as pipe(X, Y, Z, ...)",
+              apply: Nano.gen(function*() {
+                const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+                changeTracker.replaceNode(
+                  sourceFile,
+                  node,
+                  ts.factory.createCallExpression(
+                    ts.factory.createIdentifier("pipe"),
+                    undefined,
+                    [pipeCall.subject].concat(pipeCall.args)
+                  )
+                )
+              })
+            })
+        }
+      })
+
+    const ancestorNodes = yield* AST.getAncestorNodesInRange(sourceFile, textRange)
+
+    return yield* pipe(
+      Nano.firstSuccessOf(ancestorNodes.map(togglePipeStyle)),
+      Nano.orElse(() => Nano.fail(new LSP.RefactorNotApplicableError()))
+    )
+  })
+})

--- a/test/__snapshots__/refactors/togglePipeStyle.ts.ln5col54.output
+++ b/test/__snapshots__/refactors/togglePipeStyle.ts.ln5col54.output
@@ -1,0 +1,7 @@
+// Result of running refactor togglePipeStyle at position 5:54
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+export const toRegularPipe = pipe(Effect.succeed(42), Effect.map((x) => x * 2))
+
+export const toPipeable = pipe(Effect.succeed(42), Effect.map((x) => x * 2))

--- a/test/__snapshots__/refactors/togglePipeStyle.ts.ln7col32.output
+++ b/test/__snapshots__/refactors/togglePipeStyle.ts.ln7col32.output
@@ -1,0 +1,7 @@
+// Result of running refactor togglePipeStyle at position 7:32
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+
+export const toRegularPipe = Effect.succeed(42).pipe(Effect.map((x) => x * 2))
+
+export const toPipeable = Effect.succeed(42).pipe(Effect.map((x) => x * 2))


### PR DESCRIPTION
## Type

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Provides a refactor that changes style of pipe from/to X.pipe(Y) and pipe(X, Y)

## Related

- Closes #204 
