### PR TITLE
Fix make schema opaque for non-object and non-union schemas

### DIFF
--- a/.changeset/bitter-lights-tie.md
+++ b/.changeset/bitter-lights-tie.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix make schema opaque for non-object and non-union schemas

--- a/docgen.json
+++ b/docgen.json
@@ -1,3 +1,0 @@
-{
-  "exclude": ["src/{refactors,utils}/**/*.ts"]
-}

--- a/examples/refactors/makeSchemaOpaque_brand.ts
+++ b/examples/refactors/makeSchemaOpaque_brand.ts
@@ -1,0 +1,4 @@
+// 4:17
+import * as Schema from "effect/Schema"
+
+export const ProductId = Schema.NonEmptyString.pipe(Schema.brand("ProductId"))

--- a/src/refactors/makeSchemaOpaque.ts
+++ b/src/refactors/makeSchemaOpaque.ts
@@ -76,7 +76,7 @@ export const _createOpaqueTypes = Nano.fn("_createOpaqueTypes")(function*(
       ts.factory.createIdentifier(inferFromName)
     )]
   )
-  const opaqueType = typeA.isUnion() ?
+  const opaqueType = !(typeA.flags & ts.TypeFlags.Object) ?
     ts.factory.createTypeAliasDeclaration(
       [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
       opaqueTypeName,
@@ -106,7 +106,7 @@ export const _createOpaqueTypes = Nano.fn("_createOpaqueTypes")(function*(
       ts.factory.createIdentifier(inferFromName)
     )]
   )
-  const encodedType = typeE.isUnion() ?
+  const encodedType = !(typeE.flags & ts.TypeFlags.Object) ?
     ts.factory.createTypeAliasDeclaration(
       [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
       opaqueEncodedName,

--- a/test/__snapshots__/refactors/makeSchemaOpaque_brand.ts.ln4col17.output
+++ b/test/__snapshots__/refactors/makeSchemaOpaque_brand.ts.ln4col17.output
@@ -1,0 +1,9 @@
+// Result of running refactor makeSchemaOpaque at position 4:17
+import * as Schema from "effect/Schema"
+
+export const ProductId_ = Schema.NonEmptyString.pipe(Schema.brand("ProductId"))
+
+export type ProductId = Schema.Schema.Type<typeof ProductId_>
+export type ProductIdEncoded = Schema.Schema.Encoded<typeof ProductId_>
+export type ProductIdContext = Schema.Schema.Context<typeof ProductId_>
+export const ProductId: Schema.Schema<ProductId, ProductIdEncoded, ProductIdContext> = ProductId_


### PR DESCRIPTION

## Type
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Properly detect when to use type aliases and when to use interface extends