### PR TITLE
Add diagnostic for multiple subsequent Effect.provide calls

### DIFF
--- a/.changeset/bright-sloths-fetch.md
+++ b/.changeset/bright-sloths-fetch.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Warn about subsequent Effect.provide

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Multiple versions of Effect in your project
 - Warn on leaking requirements in Effect services
 - Warn on Scope as requirement of a Layer
+- Warn on subsequent `Effect.provide` anti-pattern
 - Unnecessary usages of `Effect.gen` or `pipe()`
 - Warn when importing from a barrel file instead of from the module directly
 - Warn on usage of try/catch inside `Effect.gen` and family

--- a/examples/diagnostics/multipleEffectProvide.ts
+++ b/examples/diagnostics/multipleEffectProvide.ts
@@ -1,0 +1,33 @@
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -8,6 +8,7 @@ import { missingEffectContext } from "./diagnostics/missingEffectContext.js"
 import { missingEffectError } from "./diagnostics/missingEffectError.js"
 import { missingReturnYieldStar } from "./diagnostics/missingReturnYieldStar.js"
 import { missingStarInYieldEffectGen } from "./diagnostics/missingStarInYieldEffectGen.js"
+import { multipleEffectProvide } from "./diagnostics/multipleEffectProvide.js"
 import { returnEffectInGen } from "./diagnostics/returnEffectInGen.js"
 import { scopeInLayerEffect } from "./diagnostics/scopeInLayerEffect.js"
 import { strictBooleanExpressions } from "./diagnostics/strictBooleanExpressions.js"
@@ -33,5 +34,6 @@ export const diagnostics = [
   scopeInLayerEffect,
   effectInVoidSuccess,
   unnecessaryPipeChain,
-  strictBooleanExpressions
+  strictBooleanExpressions,
+  multipleEffectProvide
 ]

--- a/src/diagnostics/multipleEffectProvide.ts
+++ b/src/diagnostics/multipleEffectProvide.ts
@@ -1,0 +1,127 @@
+import { pipe } from "effect/Function"
+import type ts from "typescript"
+import * as AST from "../core/AST.js"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const multipleEffectProvide = LSP.createDiagnostic({
+  name: "multipleEffectProvide",
+  code: 18,
+  severity: "warning",
+  apply: Nano.fn("multipleEffectProvide.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const effectModuleIdentifier = yield* pipe(
+      AST.findImportedModuleIdentifierByPackageAndNameOrBarrel(
+        sourceFile,
+        "effect",
+        "Effect"
+      ),
+      Nano.map((_) => _.text),
+      Nano.orElse(() => Nano.succeed("Effect"))
+    )
+
+    const layerModuleIdentifier = yield* pipe(
+      AST.findImportedModuleIdentifierByPackageAndNameOrBarrel(
+        sourceFile,
+        "effect",
+        "Layer"
+      ),
+      Nano.map((_) => _.text),
+      Nano.orElse(() => Nano.succeed("Layer"))
+    )
+
+    const parseEffectProvideLayer = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.name) &&
+        node.expression.name.text === "provide" &&
+        node.arguments.length > 0
+      ) {
+        const layer = node.arguments[0]
+        const type = typeChecker.getTypeAtLocation(layer)
+        return pipe(
+          typeParser.importedEffectModule(node.expression.expression),
+          Nano.flatMap(() => typeParser.layerType(type, layer)),
+          Nano.map(() => ({ layer, node })),
+          Nano.orElse(() => Nano.void_)
+        )
+      }
+      return Nano.void_
+    }
+
+    const parsePipeCall = (node: ts.Node) =>
+      Nano.gen(function*() {
+        const { args } = yield* typeParser.pipeCall(node)
+        let currentChunk = 0
+        const previousLayers: Array<Array<{ layer: ts.Expression; node: ts.CallExpression }>> = [[]]
+        for (const pipeArg of args) {
+          const parsedProvide = yield* (parseEffectProvideLayer(pipeArg))
+          if (parsedProvide) {
+            previousLayers[currentChunk].push(parsedProvide)
+          } else {
+            currentChunk++
+            previousLayers.push([])
+          }
+        }
+        // report for each chunk
+        for (const chunk of previousLayers) {
+          if (chunk.length < 2) continue
+          report({
+            node: chunk[0].node,
+            messageText:
+              "Calling multiple subsequent times Effect.provide is an anti-pattern and can lead to service lifecycle issues. You should combine the layers and provide them once instead.",
+            fixes: [{
+              fixName: "multipleEffectProvide_fix",
+              description: "Combine into a single provide",
+              apply: Nano.gen(function*() {
+                const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+                changeTracker.deleteRange(sourceFile, {
+                  pos: chunk[0].node.getStart(sourceFile),
+                  end: chunk[chunk.length - 1].node.getEnd()
+                })
+                const newNode = ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    ts.factory.createIdentifier(effectModuleIdentifier),
+                    ts.factory.createIdentifier("provide")
+                  ),
+                  undefined,
+                  [ts.factory.createCallExpression(
+                    ts.factory.createPropertyAccessExpression(
+                      ts.factory.createIdentifier(layerModuleIdentifier),
+                      ts.factory.createIdentifier("mergeAll")
+                    ),
+                    undefined,
+                    chunk.map((c) => c.layer)
+                  )]
+                )
+                changeTracker.insertNodeAt(sourceFile, chunk[0].node.getStart(sourceFile), newNode)
+              })
+            }]
+          })
+        }
+      })
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+      ts.forEachChild(node, appendNodeToVisit)
+
+      if (ts.isCallExpression(node)) {
+        yield* pipe(parsePipeCall(node), Nano.ignore)
+      }
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -168,7 +168,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -179,7 +179,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.codefixes
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.codefixes
@@ -1,0 +1,12 @@
+multipleEffectProvide_fix from 430 to 464
+multipleEffectProvide_skipNextLine from 430 to 464
+multipleEffectProvide_skipFile from 430 to 464
+multipleEffectProvide_fix from 564 to 598
+multipleEffectProvide_skipNextLine from 564 to 598
+multipleEffectProvide_skipFile from 564 to 598
+multipleEffectProvide_fix from 663 to 697
+multipleEffectProvide_skipNextLine from 663 to 697
+multipleEffectProvide_skipFile from 663 to 697
+multipleEffectProvide_fix from 793 to 827
+multipleEffectProvide_skipNextLine from 793 to 827
+multipleEffectProvide_skipFile from 793 to 827

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from430to464.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from430to464.output
@@ -1,0 +1,33 @@
+// code fix multipleEffectProvide_fix  output for range 430 - 464
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from564to598.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from564to598.output
@@ -1,0 +1,33 @@
+// code fix multipleEffectProvide_fix  output for range 564 - 598
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default)),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from663to697.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from663to697.output
@@ -1,0 +1,33 @@
+// code fix multipleEffectProvide_fix  output for range 663 - 697
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from793to827.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from793to827.output
@@ -1,0 +1,32 @@
+// code fix multipleEffectProvide_fix  output for range 793 - 827
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default, MyService3.Default))
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from430to464.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from430to464.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipFile  output for range 430 - 464
+/** @effect-diagnostics multipleEffectProvide:skip-file */
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from564to598.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from564to598.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipFile  output for range 564 - 598
+/** @effect-diagnostics multipleEffectProvide:skip-file */
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from663to697.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from663to697.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipFile  output for range 663 - 697
+/** @effect-diagnostics multipleEffectProvide:skip-file */
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from793to827.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipFile.from793to827.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipFile  output for range 793 - 827
+/** @effect-diagnostics multipleEffectProvide:skip-file */
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from430to464.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from430to464.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipNextLine  output for range 430 - 464
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// @effect-diagnostics-next-line multipleEffectProvide:off
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from564to598.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from564to598.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipNextLine  output for range 564 - 598
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+// @effect-diagnostics-next-line multipleEffectProvide:off
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from663to697.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from663to697.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipNextLine  output for range 663 - 697
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+// @effect-diagnostics-next-line multipleEffectProvide:off
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from793to827.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_skipNextLine.from793to827.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipNextLine  output for range 793 - 827
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+export const shouldReport = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportSeparately = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.ignoreLogged,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+// @effect-diagnostics-next-line multipleEffectProvide:off
+export const shouldReportSingle = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.output
@@ -1,0 +1,11 @@
+Effect.provide(MyService1.Default)
+17:2 - 17:36 | 0 | Calling multiple subsequent times Effect.provide is an anti-pattern and can lead to service lifecycle issues. You should combine the layers and provide them once instead.
+
+Effect.provide(MyService1.Default)
+22:2 - 22:36 | 0 | Calling multiple subsequent times Effect.provide is an anti-pattern and can lead to service lifecycle issues. You should combine the layers and provide them once instead.
+
+Effect.provide(MyService1.Default)
+25:2 - 25:36 | 0 | Calling multiple subsequent times Effect.provide is an anti-pattern and can lead to service lifecycle issues. You should combine the layers and provide them once instead.
+
+Effect.provide(MyService1.Default)
+30:2 - 30:36 | 0 | Calling multiple subsequent times Effect.provide is an anti-pattern and can lead to service lifecycle issues. You should combine the layers and provide them once instead.


### PR DESCRIPTION
## Summary
- Adds a new diagnostic rule `multipleEffectProvide` that detects and warns about anti-patterns when calling `Effect.provide` multiple times in succession
- Provides automatic code fixes to combine multiple `provide` calls into a single one using `Layer.mergeAll`
- Improves developer experience by encouraging better service lifecycle management

## What Changed
- Added new diagnostic rule in `src/diagnostics/multipleEffectProvide.ts`
- Registered the diagnostic in `src/diagnostics.ts`
- Added test cases in `examples/diagnostics/multipleEffectProvide.ts`
- Added changeset for patch release

## Why This Change
Multiple subsequent calls to `Effect.provide` can lead to service lifecycle issues. This diagnostic helps developers identify this anti-pattern and provides an automatic fix to combine layers properly.

## Example
Before:
```typescript
Effect.void.pipe(
  Effect.provide(MyService1.Default),
  Effect.provide(MyService2.Default)
)
```

After applying the fix:
```typescript
Effect.void.pipe(
  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
)
```

Closes #293

🤖 Generated with [Claude Code](https://claude.ai/code)