### PR TITLE
Refactor AutoImport provider and add sortText support

### DIFF
--- a/.changeset/fifty-sloths-double.md
+++ b/.changeset/fifty-sloths-double.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Refactor AutoImport provider and add sortText support

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,5 +9,7 @@
 - The remote origin/main branch is not writeable, so anytime you are asked to push commits, ensure you are in a non-origin/main branch.
 - Provide a description of what changed
 - If the change involve refactors or diagnostic, provide an example of the feature added/changed
-- Run "pnpm test" before pushing
+- Before pushing ensure:
+  - Run "pnpm test" to ensure that all test passes
+  - Ensure a changeset exists, if new features are added bump by a minor, otherwise patch; do not bump major
 - If all checks pass, create a github PR

--- a/src/completions/middlewareAutoImports.ts
+++ b/src/completions/middlewareAutoImports.ts
@@ -5,8 +5,6 @@ import * as LanguageServicePluginOptions from "../core/LanguageServicePluginOpti
 import * as Nano from "../core/Nano"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 
-const importProvidersCache = new Map<string, AutoImport.AutoImportProvider>()
-
 export const appendEffectCompletionEntryData = Nano.fn("appendEffectCompletionEntryData")(
   function*(_sourceFile: ts.SourceFile, applicableCompletions: ts.WithMetadata<ts.CompletionInfo> | undefined) {
     // exit if not enabled
@@ -252,12 +250,10 @@ export const postprocessCompletionEntryDetails = Nano.fn("postprocessCompletionE
     if (!result) return applicableCompletionEntryDetails
 
     // get or create the namespace cache info
-    const packagesMetadata = importProvidersCache.get(sourceFile.fileName) ||
-      (yield* AutoImport.makeAutoImportProvider(sourceFile))
-    importProvidersCache.set(sourceFile.fileName, packagesMetadata)
+    const autoImportProvider = yield* AutoImport.getOrMakeAutoImportProvider(sourceFile)
 
     // get the expected auto-import
-    const effectAutoImport = packagesMetadata(fileName, exportName)
+    const effectAutoImport = autoImportProvider.resolve(fileName, exportName)
     if (!effectAutoImport) return applicableCompletionEntryDetails
 
     // create the code action

--- a/test/autoimport.test.ts
+++ b/test/autoimport.test.ts
@@ -28,7 +28,7 @@ function testAutoImport(
 
   const test = pipe(
     AutoImport.makeAutoImportProvider(sourceFile),
-    Nano.map((_) => _(exportFileName, exportName)),
+    Nano.map((_) => _.resolve(exportFileName, exportName)),
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
     Nano.provideService(


### PR DESCRIPTION
## Summary
- Refactored AutoImportProvider from a function to an object with `resolve` and `sortText` methods
- Added `getOrMakeAutoImportProvider` function with caching functionality
- Moved import provider cache from `middlewareAutoImports` module to `AutoImport` module for better organization

## Changes
This refactor improves the auto-import functionality by:
1. Adding support for sortText to properly order completion suggestions
2. Namespace imports like `{ Effect } from "effect"` will now appear at the bottom of suggestions (sortText="99")
3. Centralizing the caching logic in the AutoImport module

## Test plan
[x] All existing tests pass
[x] Changeset included for patch version bump

🤖 Generated with [Claude Code](https://claude.ai/code)