### PR TITLE
Add middleware for auto-import quickfixes

### DIFF
--- a/.changeset/import-quickfix-middleware.md
+++ b/.changeset/import-quickfix-middleware.md
@@ -1,0 +1,9 @@
+---
+"@effect/language-service": patch
+---
+
+Add middleware for auto-import quickfixes
+
+- Extracted auto-import logic into a reusable `AutoImport` core module
+- Refactored existing middleware auto-import completion to use the new shared `AutoImport` provider
+- This enables consistent auto-import behavior across both completions and quickfixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,5 +11,14 @@
 - If the change involve refactors or diagnostic, provide an example of the feature added/changed
 - Before pushing ensure:
   - Run "pnpm test" to ensure that all test passes
-  - Ensure a changeset exists, if new features are added bump by a minor, otherwise patch; do not bump major
+  - If in the git changes does not exists a new changeset file to be added, create a new one in the .changeset folder, the pattern is something like this:
+  ```
+---
+"@effect/language-service": ${patchType}
+---
+
+Description of the change with examples
+```
+"${patchType}" should be replaced by "patch" if the PR contains only bugfixes or small changes; or "minor" if new diagnostics, refactors or features are added.
+
 - If all checks pass, create a github PR

--- a/src/diagnostics/middlewareAutoImportQuickfixes.ts
+++ b/src/diagnostics/middlewareAutoImportQuickfixes.ts
@@ -1,0 +1,94 @@
+import { pipe } from "effect/Function"
+import type * as ts from "typescript"
+import * as AutoImport from "../core/AutoImport"
+import * as Nano from "../core/Nano"
+import * as TypeScriptApi from "../core/TypeScriptApi"
+
+export const middlewareAutoImportQuickfixes = Nano.fn("middlewareAutoImportQuickfixes")(function*(
+  sourceFile: ts.SourceFile,
+  languageServiceHost: ts.LanguageServiceHost,
+  formatOptions: ts.FormatCodeSettings,
+  preferences: ts.UserPreferences | undefined,
+  codeFixes: ReadonlyArray<ts.CodeFixAction>
+) {
+  const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+  const program = yield* Nano.service(TypeScriptApi.TypeScriptProgram)
+  const autoImportProvider = yield* AutoImport.getOrMakeAutoImportProvider(sourceFile)
+  const changedCodeFixes: Array<ts.CodeFixAction> = []
+
+  const createImportAllChanges = (imports: Array<AutoImport.ParsedImportFromTextChange>) =>
+    Nano.gen(function*() {
+      const newImports: Array<AutoImport.ImportKind> = []
+      for (const importToAdd of imports) {
+        // we should have what to import
+        if (!importToAdd.exportName) return
+        // from the module name, get the file name
+        const fileName = ts.resolveModuleName(
+          importToAdd.moduleName,
+          sourceFile.fileName,
+          program.getCompilerOptions(),
+          program as any
+        )
+        if (!fileName.resolvedModule) return
+        // resolve the import kind
+        const importKind = autoImportProvider.resolve(fileName.resolvedModule.resolvedFileName, importToAdd.exportName)
+        if (!importKind) return
+        // we cannot retroactively change the whole source code
+        if (importKind.introducedPrefix) return
+        newImports.push(importKind)
+      }
+      // then we need to produce the actual changes
+      const formatContext = ts.formatting.getFormatContext(
+        formatOptions,
+        languageServiceHost
+      )
+
+      const edits = ts.textChanges.ChangeTracker.with(
+        {
+          formatContext,
+          host: languageServiceHost,
+          preferences: preferences || {}
+        },
+        (changeTracker) =>
+          newImports.forEach((_) => AutoImport.addImport(ts, sourceFile, changeTracker, preferences, _))
+      )
+      return edits
+    })
+
+  for (const codeFix of codeFixes) {
+    const textFileChanges = codeFix.changes
+    // only one change
+    if (textFileChanges.length !== 1) {
+      changedCodeFixes.push(codeFix)
+      continue
+    }
+    // on the current file
+    if (textFileChanges[0].fileName !== sourceFile.fileName) {
+      changedCodeFixes.push(codeFix)
+      continue
+    }
+    // should be import only changes
+    const parsedChanges = yield* AutoImport.parseImportOnlyChanges(sourceFile, textFileChanges[0].textChanges)
+    if (!parsedChanges) {
+      changedCodeFixes.push(codeFix)
+      continue
+    }
+    // no deletions!
+    if (parsedChanges.deletions.length !== 0) {
+      changedCodeFixes.push(codeFix)
+      continue
+    }
+    // ok process them
+    const changes = yield* pipe(
+      createImportAllChanges(parsedChanges.imports),
+      Nano.orElse(() => Nano.succeed(codeFix.changes))
+    )
+    if (changes) {
+      changedCodeFixes.push({ ...codeFix, changes })
+    } else {
+      changedCodeFixes.push(codeFix)
+    }
+  }
+
+  return changedCodeFixes
+})


### PR DESCRIPTION
## Summary
- Extracted auto-import logic into a reusable `AutoImport` core module for better code organization
- Added new `middlewareAutoImportQuickfixes` diagnostic middleware that processes code fixes to add auto-import functionality
- Refactored existing middleware auto-import completion to use the new shared `AutoImport` provider

## Example
The new middleware enables auto-import functionality in quickfixes. When TypeScript suggests a quickfix that involves importing a module, this middleware will:
1. Parse the import information from the quickfix text changes
2. Resolve the correct import path and style based on the project's configuration
3. Apply the import automatically with the quickfix

This provides a consistent auto-import experience across both code completions and quickfixes.

## Test plan
- [x] All existing tests pass
- [x] Auto-import completions continue to work as before (refactored to use shared provider)
- [x] New middleware is integrated into the diagnostic pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)