### PR TITLE
Add missingEffectServiceDependency diagnostic

### DIFF
--- a/.changeset/missing-effect-service-dependency.md
+++ b/.changeset/missing-effect-service-dependency.md
@@ -1,0 +1,21 @@
+---
+"@effect/language-service": minor
+---
+
+Add missingEffectServiceDependency diagnostic
+
+This diagnostic warns when an `Effect.Service` declaration has missing service dependencies. It checks if all services used within the service's effect are properly declared in the dependencies array.
+
+Example:
+```ts
+// This will show a warning because SampleService1 is used but not declared in dependencies
+export class InvalidService extends Effect.Service<InvalidService>()("InvalidService", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  })
+  // Missing: dependencies: [SampleService1.Default]
+}) {}
+```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Warn on usage of try/catch inside `Effect.gen` and family
 - Detect unnecessary pipe chains like `X.pipe(Y).pipe(Z)`
 - Warn when using `Effect.Service` with `accessors: true` but methods have generics or multiple signatures
+- Warn on missing service dependencies in `Effect.Service` declarations
 
 ### Completions
 

--- a/examples/diagnostics/missingEffectServiceDependency.ts
+++ b/examples/diagnostics/missingEffectServiceDependency.ts
@@ -1,0 +1,54 @@
+// @effect-diagnostics missingEffectServiceDependency:error
+import * as Effect from "effect/Effect"
+
+export class SampleService1 extends Effect.Service<SampleService1>()("SampleService1", {
+  succeed: { value: 1 }
+}) {
+}
+
+export class SampleService2 extends Effect.Service<SampleService2>()("SampleService2", {
+  succeed: { value: 2 }
+}) {
+}
+
+// this is valid because depends on SampleService1 and is defined in the dependencies array
+export class ValidService extends Effect.Service<ValidService>()("ValidService", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}
+
+// this is valid because it has no dependencies
+export class ValidService2 extends Effect.Service<ValidService2>()("ValidService2", {
+  succeed: { value: 3 }
+}) {
+}
+
+// this is invalid because depends on SampleService1 and is not defined in the dependencies array
+export class InvalidService2 extends Effect.Service<InvalidService2>()("InvalidService2", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  })
+}) {
+}
+
+// this is invalid because depends on both SampleService1 and SampleService2 and only SampleService1 is defined in the dependencies array
+export class InvalidService3 extends Effect.Service<InvalidService3>()("InvalidService3", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    const sampleService2 = yield* SampleService2
+    return {
+      constant: Effect.succeed(sampleService1.value + sampleService2.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}

--- a/src/core/TypeCheckerApi.ts
+++ b/src/core/TypeCheckerApi.ts
@@ -282,6 +282,17 @@ export const unrollUnionMembers = (type: ts.Type) => {
   return result
 }
 
+/**
+ * Appends a type to a map of unique types, ensuring that the type is not already in the map.
+ *
+ * @param memory - The map that will be used as memory and updated as new types are encountered.
+ * @param initialType - The type to start with, unions will be unrolled.
+ * @param shouldExclude - A function that determines if a type should be excluded from the checking
+ * @returns An object with the following properties:
+ * - newIndexes: A set of new indexes that were added to the memory.
+ * - knownIndexes: A set of indexes that were already in the memory.
+ * - allIndexes: A set of all indexes that were encountered.
+ */
 export const appendToUniqueTypesMap = Nano.fn(
   "TypeCheckerApi.appendToUniqueTypesMap"
 )(

--- a/src/core/TypeParser.ts
+++ b/src/core/TypeParser.ts
@@ -104,6 +104,7 @@ export interface TypeParser {
       Identifier: ts.Type
       Service: ts.Type
       accessors: boolean | undefined
+      dependencies: ts.NodeArray<ts.Expression> | undefined
     },
     TypeParserIssue,
     never
@@ -1240,6 +1241,7 @@ export function make(
                   if (Option.isSome(parsedContextTag)) {
                     // try to parse some settings
                     let accessors: boolean | undefined = undefined
+                    let dependencies: ts.NodeArray<ts.Expression> | undefined = undefined
                     if (wholeCall.arguments.length >= 2) {
                       const args = wholeCall.arguments[1]
                       if (ts.isObjectLiteralExpression(args)) {
@@ -1251,6 +1253,13 @@ export function make(
                           ) {
                             accessors = true
                           }
+                          if (
+                            ts.isPropertyAssignment(property) && property.name && ts.isIdentifier(property.name) &&
+                            property.name.text === "dependencies" && property.initializer &&
+                            ts.isArrayLiteralExpression(property.initializer)
+                          ) {
+                            dependencies = property.initializer.elements
+                          }
                         }
                       }
                     }
@@ -1259,7 +1268,8 @@ export function make(
                       className: atLocation.name,
                       selfTypeNode,
                       args: wholeCall.arguments,
-                      accessors
+                      accessors,
+                      dependencies
                     })
                   }
                 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -7,6 +7,7 @@ import { importFromBarrel } from "./diagnostics/importFromBarrel.js"
 import { leakingRequirements } from "./diagnostics/leakingRequirements.js"
 import { missingEffectContext } from "./diagnostics/missingEffectContext.js"
 import { missingEffectError } from "./diagnostics/missingEffectError.js"
+import { missingEffectServiceDependency } from "./diagnostics/missingEffectServiceDependency.js"
 import { missingReturnYieldStar } from "./diagnostics/missingReturnYieldStar.js"
 import { missingStarInYieldEffectGen } from "./diagnostics/missingStarInYieldEffectGen.js"
 import { multipleEffectProvide } from "./diagnostics/multipleEffectProvide.js"
@@ -25,6 +26,7 @@ export const diagnostics = [
   duplicatePackage,
   missingEffectContext,
   missingEffectError,
+  missingEffectServiceDependency,
   floatingEffect,
   missingStarInYieldEffectGen,
   unnecessaryEffectGen,

--- a/src/diagnostics/missingEffectServiceDependency.ts
+++ b/src/diagnostics/missingEffectServiceDependency.ts
@@ -1,0 +1,125 @@
+import { pipe } from "effect/Function"
+import type ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const missingEffectServiceDependency = LSP.createDiagnostic({
+  name: "missingEffectServiceDependency",
+  code: 21,
+  severity: "off",
+  apply: Nano.fn("missingEffectServiceDependency.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+
+      // Check if this is a class declaration that extends Effect.Service
+      if (ts.isClassDeclaration(node) && node.name && node.heritageClauses) {
+        const serviceResult = yield* pipe(
+          typeParser.extendsEffectService(node),
+          Nano.orElse(() => Nano.void_)
+        )
+
+        if (serviceResult) {
+          const { className, dependencies } = serviceResult
+
+          // Get the class symbol and its type
+          const classSymbol = typeChecker.getSymbolAtLocation(className)
+          if (classSymbol) {
+            const classType = typeChecker.getTypeOfSymbol(classSymbol)
+
+            // Try to get DefaultWithoutDependencies first, then Default
+            const defaultWithoutDepsProperty = typeChecker.getPropertyOfType(classType, "DefaultWithoutDependencies")
+            const defaultProperty = defaultWithoutDepsProperty || typeChecker.getPropertyOfType(classType, "Default")
+
+            if (defaultProperty) {
+              const defaultType = typeChecker.getTypeOfSymbolAtLocation(defaultProperty, node)
+
+              // Parse the layer type to get RIN
+              const layerResult = yield* pipe(
+                typeParser.layerType(defaultType, node),
+                Nano.orElse(() => Nano.void_)
+              )
+
+              if (layerResult) {
+                // Use a single memory map for both required and provided services
+                const servicesMemory = new Map<string, ts.Type>()
+                const excludeNever = (type: ts.Type) => Nano.succeed((type.flags & ts.TypeFlags.Never) !== 0)
+
+                // Get all required service indexes
+                const { allIndexes: requiredIndexes } = yield* TypeCheckerApi.appendToUniqueTypesMap(
+                  servicesMemory,
+                  layerResult.RIn,
+                  excludeNever
+                )
+
+                // Process dependencies (treat undefined/null as empty array)
+                const providedIndexes = new Set<string>()
+                const dependenciesToProcess = dependencies || []
+
+                // Process each dependency to get what services they provide
+                for (const depExpression of dependenciesToProcess) {
+                  const depType = typeChecker.getTypeAtLocation(depExpression)
+
+                  // Try to parse as layer type
+                  const depLayerResult = yield* pipe(
+                    typeParser.layerType(depType, depExpression),
+                    Nano.orElse(() => Nano.void_)
+                  )
+
+                  if (depLayerResult) {
+                    // Add the ROut of this dependency to the same memory map
+                    const { allIndexes } = yield* TypeCheckerApi.appendToUniqueTypesMap(
+                      servicesMemory,
+                      depLayerResult.ROut,
+                      excludeNever
+                    )
+                    // Collect all provided indexes
+                    for (const index of allIndexes) {
+                      providedIndexes.add(index)
+                    }
+                  }
+                }
+
+                // Find missing services: required indexes not in provided indexes
+                const missingIndexes = requiredIndexes.filter((index) => !providedIndexes.has(index))
+
+                // Report diagnostic if there are missing dependencies
+                if (missingIndexes.length > 0) {
+                  const missingTypes = missingIndexes.map((index) => servicesMemory.get(index)!)
+                  const missingTypeNames = missingTypes.map((t) => typeChecker.typeToString(t))
+
+                  const message = missingTypeNames.length === 1
+                    ? `Service '${missingTypeNames[0]}' is required but not provided by dependencies`
+                    : `Services ${
+                      missingTypeNames.map((s) => `'${s}'`).join(", ")
+                    } are required but not provided by dependencies`
+
+                  report({
+                    location: className,
+                    messageText: message,
+                    fixes: []
+                  })
+                }
+              }
+            }
+          }
+        }
+      }
+
+      ts.forEachChild(node, appendNodeToVisit)
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -184,7 +184,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|classSelfMismatch,duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|classSelfMismatch,duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -195,7 +195,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",

--- a/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.codefixes
+++ b/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.codefixes
@@ -1,0 +1,4 @@
+missingEffectServiceDependency_skipNextLine from 1006 to 1021
+missingEffectServiceDependency_skipFile from 1006 to 1021
+missingEffectServiceDependency_skipNextLine from 1405 to 1420
+missingEffectServiceDependency_skipFile from 1405 to 1420

--- a/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipFile.from1006to1021.output
+++ b/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipFile.from1006to1021.output
@@ -1,0 +1,56 @@
+// code fix missingEffectServiceDependency_skipFile  output for range 1006 - 1021
+/** @effect-diagnostics missingEffectServiceDependency:skip-file */
+// @effect-diagnostics missingEffectServiceDependency:error
+import * as Effect from "effect/Effect"
+
+export class SampleService1 extends Effect.Service<SampleService1>()("SampleService1", {
+  succeed: { value: 1 }
+}) {
+}
+
+export class SampleService2 extends Effect.Service<SampleService2>()("SampleService2", {
+  succeed: { value: 2 }
+}) {
+}
+
+// this is valid because depends on SampleService1 and is defined in the dependencies array
+export class ValidService extends Effect.Service<ValidService>()("ValidService", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}
+
+// this is valid because it has no dependencies
+export class ValidService2 extends Effect.Service<ValidService2>()("ValidService2", {
+  succeed: { value: 3 }
+}) {
+}
+
+// this is invalid because depends on SampleService1 and is not defined in the dependencies array
+export class InvalidService2 extends Effect.Service<InvalidService2>()("InvalidService2", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  })
+}) {
+}
+
+// this is invalid because depends on both SampleService1 and SampleService2 and only SampleService1 is defined in the dependencies array
+export class InvalidService3 extends Effect.Service<InvalidService3>()("InvalidService3", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    const sampleService2 = yield* SampleService2
+    return {
+      constant: Effect.succeed(sampleService1.value + sampleService2.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}

--- a/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipFile.from1405to1420.output
+++ b/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipFile.from1405to1420.output
@@ -1,0 +1,56 @@
+// code fix missingEffectServiceDependency_skipFile  output for range 1405 - 1420
+/** @effect-diagnostics missingEffectServiceDependency:skip-file */
+// @effect-diagnostics missingEffectServiceDependency:error
+import * as Effect from "effect/Effect"
+
+export class SampleService1 extends Effect.Service<SampleService1>()("SampleService1", {
+  succeed: { value: 1 }
+}) {
+}
+
+export class SampleService2 extends Effect.Service<SampleService2>()("SampleService2", {
+  succeed: { value: 2 }
+}) {
+}
+
+// this is valid because depends on SampleService1 and is defined in the dependencies array
+export class ValidService extends Effect.Service<ValidService>()("ValidService", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}
+
+// this is valid because it has no dependencies
+export class ValidService2 extends Effect.Service<ValidService2>()("ValidService2", {
+  succeed: { value: 3 }
+}) {
+}
+
+// this is invalid because depends on SampleService1 and is not defined in the dependencies array
+export class InvalidService2 extends Effect.Service<InvalidService2>()("InvalidService2", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  })
+}) {
+}
+
+// this is invalid because depends on both SampleService1 and SampleService2 and only SampleService1 is defined in the dependencies array
+export class InvalidService3 extends Effect.Service<InvalidService3>()("InvalidService3", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    const sampleService2 = yield* SampleService2
+    return {
+      constant: Effect.succeed(sampleService1.value + sampleService2.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}

--- a/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipNextLine.from1006to1021.output
+++ b/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipNextLine.from1006to1021.output
@@ -1,0 +1,56 @@
+// code fix missingEffectServiceDependency_skipNextLine  output for range 1006 - 1021
+// @effect-diagnostics missingEffectServiceDependency:error
+import * as Effect from "effect/Effect"
+
+export class SampleService1 extends Effect.Service<SampleService1>()("SampleService1", {
+  succeed: { value: 1 }
+}) {
+}
+
+export class SampleService2 extends Effect.Service<SampleService2>()("SampleService2", {
+  succeed: { value: 2 }
+}) {
+}
+
+// this is valid because depends on SampleService1 and is defined in the dependencies array
+export class ValidService extends Effect.Service<ValidService>()("ValidService", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}
+
+// this is valid because it has no dependencies
+export class ValidService2 extends Effect.Service<ValidService2>()("ValidService2", {
+  succeed: { value: 3 }
+}) {
+}
+
+// this is invalid because depends on SampleService1 and is not defined in the dependencies array
+// @effect-diagnostics-next-line missingEffectServiceDependency:off
+export class InvalidService2 extends Effect.Service<InvalidService2>()("InvalidService2", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  })
+}) {
+}
+
+// this is invalid because depends on both SampleService1 and SampleService2 and only SampleService1 is defined in the dependencies array
+export class InvalidService3 extends Effect.Service<InvalidService3>()("InvalidService3", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    const sampleService2 = yield* SampleService2
+    return {
+      constant: Effect.succeed(sampleService1.value + sampleService2.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}

--- a/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipNextLine.from1405to1420.output
+++ b/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.missingEffectServiceDependency_skipNextLine.from1405to1420.output
@@ -1,0 +1,56 @@
+// code fix missingEffectServiceDependency_skipNextLine  output for range 1405 - 1420
+// @effect-diagnostics missingEffectServiceDependency:error
+import * as Effect from "effect/Effect"
+
+export class SampleService1 extends Effect.Service<SampleService1>()("SampleService1", {
+  succeed: { value: 1 }
+}) {
+}
+
+export class SampleService2 extends Effect.Service<SampleService2>()("SampleService2", {
+  succeed: { value: 2 }
+}) {
+}
+
+// this is valid because depends on SampleService1 and is defined in the dependencies array
+export class ValidService extends Effect.Service<ValidService>()("ValidService", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}
+
+// this is valid because it has no dependencies
+export class ValidService2 extends Effect.Service<ValidService2>()("ValidService2", {
+  succeed: { value: 3 }
+}) {
+}
+
+// this is invalid because depends on SampleService1 and is not defined in the dependencies array
+export class InvalidService2 extends Effect.Service<InvalidService2>()("InvalidService2", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    return {
+      constant: Effect.succeed(sampleService1.value)
+    }
+  })
+}) {
+}
+
+// this is invalid because depends on both SampleService1 and SampleService2 and only SampleService1 is defined in the dependencies array
+// @effect-diagnostics-next-line missingEffectServiceDependency:off
+export class InvalidService3 extends Effect.Service<InvalidService3>()("InvalidService3", {
+  effect: Effect.gen(function*() {
+    const sampleService1 = yield* SampleService1
+    const sampleService2 = yield* SampleService2
+    return {
+      constant: Effect.succeed(sampleService1.value + sampleService2.value)
+    }
+  }),
+  dependencies: [SampleService1.Default]
+}) {
+}

--- a/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.output
@@ -1,0 +1,5 @@
+InvalidService2
+33:13 - 33:28 | 1 | Service 'SampleService1' is required but not provided by dependencies
+
+InvalidService3
+44:13 - 44:28 | 1 | Service 'SampleService2' is required but not provided by dependencies


### PR DESCRIPTION
## Summary
- Add new diagnostic `missingEffectServiceDependency` that warns when Effect.Service declarations have missing service dependencies
- The diagnostic checks if all services used within a service's effect are properly declared in the dependencies array
- Added tests and documentation for the new diagnostic

## Example
```typescript
// This will show a warning because SampleService1 is used but not declared in dependencies
export class InvalidService extends Effect.Service<InvalidService>()("InvalidService", {
  effect: Effect.gen(function*() {
    const sampleService1 = yield* SampleService1
    return {
      constant: Effect.succeed(sampleService1.value)
    }
  })
  // Missing: dependencies: [SampleService1.Default]
}) {}
```

## Test plan
- [x] Run `pnpm lint-fix` - all formatting fixed
- [x] Run `pnpm check` - no type errors
- [x] Run `pnpm test` - all tests passing
- [x] Verified the diagnostic is mentioned in README.md
- [x] Regenerated all snapshots and verified changes are expected
- [x] Added changeset for version bump

🤖 Generated with Claude Code