### PR TITLE
Avoid adding empty comment for layers with no deps

### DIFF
--- a/.changeset/easy-corners-wash.md
+++ b/.changeset/easy-corners-wash.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Avoid adding comment for layers with no deps requires no provides

--- a/examples/quickinfo/layerInfo.ts
+++ b/examples/quickinfo/layerInfo.ts
@@ -23,3 +23,5 @@ export const liveWithPipeable = UserRepository.Default.pipe(
   Layer.provideMerge(Cache.Default),
   Layer.merge(DbConnection.Default)
 )
+
+export const NoComment = Layer.empty

--- a/src/quickinfo/layerInfo.ts
+++ b/src/quickinfo/layerInfo.ts
@@ -404,7 +404,7 @@ export function layerInfo(
               const providesNode = findInnermostGraphEdge(rootNode, "rout", providesKey)
               appendInfo(providesNode, graphCtx.services.get(providesKey)!, "provided")
             }
-            lines.push("")
+            if (lines.length > 0) lines.push("")
             for (const requiresKey of rootNode.rin) {
               const requiresNode = findInnermostGraphEdge(rootNode, "rin", requiresKey)
               appendInfo(requiresNode, graphCtx.services.get(requiresKey)!, "required")
@@ -418,6 +418,7 @@ export function layerInfo(
               linkParts.push({ kind: "link", text: "}" })
               linkParts.push({ kind: "space", text: "\n" })
             }
+            if (lines.length === 0) return linkParts
             return [
               {
                 kind: "text",


### PR DESCRIPTION
## Summary
- Fixed an issue where layers with no dependencies would show an empty comment block
- The fix prevents adding an empty line separator when there are no provides or requires to display

## Example
Before this change, a layer with no dependencies would show:
```typescript
const MyLayer = Layer.empty
//     ^?
```
With an empty comment block.

After this change, layers with no dependencies show no comment, which is cleaner and less confusing.

🤖 Generated with [Claude Code](https://claude.ai/code)