### PR TITLE
Improve missingReturnYieldStar diagnostic message

### DIFF
--- a/.changeset/better-return-yield-message.md
+++ b/.changeset/better-return-yield-message.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Improve diagnostic message for missingReturnYieldStar to better explain why return yield* is recommended for Effects that never succeed

--- a/src/diagnostics/missingReturnYieldStar.ts
+++ b/src/diagnostics/missingReturnYieldStar.ts
@@ -83,7 +83,8 @@ export const missingReturnYieldStar = LSP.createDiagnostic({
 
                 report({
                   location: node,
-                  messageText: `Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.`,
+                  messageText:
+                    `It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.`,
                   fixes: fix
                 })
               }

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.output
@@ -1,8 +1,8 @@
 yield* Effect.fail("no zero!")
-11:6 - 11:36 | 1 | Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.
+11:6 - 11:36 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.
 
 yield* Effect.interrupt
-18:4 - 18:27 | 1 | Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.
+18:4 - 18:27 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.
 
 yield* Effect.die("lol")
-19:4 - 19:28 | 1 | Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.
+19:4 - 19:28 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.


### PR DESCRIPTION
## Summary
- Improved the diagnostic message for `missingReturnYieldStar` to better explain why `return yield*` is recommended for Effects that never succeed
- The new message emphasizes the benefits for type narrowing and tooling support

## Changes
The diagnostic message was updated from:
> Yielded Effect never succeeds, so it is best to use a 'return yield*' instead.

To:
> It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.

## Example
When yielding an Effect that never succeeds (like `Effect.fail`, `Effect.die`, or `Effect.interrupt`), the diagnostic now provides clearer guidance:

```typescript
function* example() {
  if (someCondition) {
    yield* Effect.fail("error") // diagnostic appears here
  }
  // ...
}
```

The improved message helps developers understand that using `return yield*` in these cases:
- Signals a definitive exit point in the code
- Enables better type narrowing after the return statement
- Improves tooling support and static analysis

🤖 Generated with [Claude Code](https://claude.ai/code)