### PR TITLE
Improve floating effect diagnostic messages for Stream and other Effect subtypes

### DIFF
--- a/.changeset/floating-effect-stream-diagnostics.md
+++ b/.changeset/floating-effect-stream-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Improve floating effect diagnostic message to specify the actual type being flagged. When detecting floating Stream or other Effect subtypes, the error message now shows "Effect-able Stream<...>" instead of just "Effect", making it clearer what type needs to be handled.

--- a/examples/diagnostics/floatingEffect_stream.ts
+++ b/examples/diagnostics/floatingEffect_stream.ts
@@ -1,0 +1,6 @@
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
+
+export const shouldWarn = Effect.gen(function*() {
+  Stream.succeed(42)
+})

--- a/src/diagnostics/floatingEffect.ts
+++ b/src/diagnostics/floatingEffect.ts
@@ -57,9 +57,12 @@ export const floatingEffect = LSP.createDiagnostic({
           Nano.option
         )
         if (Option.isNone(allowedFloatingEffects)) {
+          // check if strictly an effect or a subtype to change the error message
+          const isStrictEffect = yield* Nano.option(typeParser.strictEffectType(type, node.expression))
+          const name = Option.isSome(isStrictEffect) ? "Effect" : "Effect-able " + typeChecker.typeToString(type)
           report({
             location: node,
-            messageText: `Effect must be yielded or assigned to a variable.`,
+            messageText: `${name} must be yielded or assigned to a variable.`,
             fixes: []
           })
         }

--- a/test/__snapshots__/diagnostics/floatingEffect_stream.ts.codefixes
+++ b/test/__snapshots__/diagnostics/floatingEffect_stream.ts.codefixes
@@ -1,0 +1,2 @@
+floatingEffect_skipNextLine from 134 to 152
+floatingEffect_skipFile from 134 to 152

--- a/test/__snapshots__/diagnostics/floatingEffect_stream.ts.floatingEffect_skipFile.from134to152.output
+++ b/test/__snapshots__/diagnostics/floatingEffect_stream.ts.floatingEffect_skipFile.from134to152.output
@@ -1,0 +1,8 @@
+// code fix floatingEffect_skipFile  output for range 134 - 152
+/** @effect-diagnostics floatingEffect:skip-file */
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
+
+export const shouldWarn = Effect.gen(function*() {
+  Stream.succeed(42)
+})

--- a/test/__snapshots__/diagnostics/floatingEffect_stream.ts.floatingEffect_skipNextLine.from134to152.output
+++ b/test/__snapshots__/diagnostics/floatingEffect_stream.ts.floatingEffect_skipNextLine.from134to152.output
@@ -1,0 +1,8 @@
+// code fix floatingEffect_skipNextLine  output for range 134 - 152
+import * as Effect from "effect/Effect"
+import * as Stream from "effect/Stream"
+
+export const shouldWarn = Effect.gen(function*() {
+  // @effect-diagnostics-next-line floatingEffect:off
+  Stream.succeed(42)
+})

--- a/test/__snapshots__/diagnostics/floatingEffect_stream.ts.output
+++ b/test/__snapshots__/diagnostics/floatingEffect_stream.ts.output
@@ -1,0 +1,2 @@
+Stream.succeed(42)
+5:2 - 5:20 | 1 | Effect-able Stream<number, never, never> must be yielded or assigned to a variable.


### PR DESCRIPTION
## Summary
- Enhanced the floating effect diagnostic to show more specific error messages when detecting floating Stream or other Effect subtypes
- The error message now displays "Effect-able Stream<...>" instead of just "Effect", making it clearer what type needs to be handled
- Added test case for floating Stream detection

## Example
Before: `Effect must be yielded or assigned to a variable.`
After: `Effect-able Stream<A, E, R> must be yielded or assigned to a variable.`

## Test plan
- [x] All existing tests pass
- [x] New test case added for floating Stream detection
- [x] Snapshots regenerated and verified

Closes #150

🤖 Generated with [Claude Code](https://claude.ai/code)