### PR TITLE
Add quickinfoEffectParameters configuration option

### DIFF
--- a/.changeset/quickinfo-effect-parameters.md
+++ b/.changeset/quickinfo-effect-parameters.md
@@ -1,0 +1,19 @@
+---
+"@effect/language-service": minor
+---
+
+Add `quickinfoEffectParameters` configuration option to control when Effect type parameters are displayed in quickinfo
+
+This new option allows users to configure when Effect type parameters are shown in hover information:
+- `"always"`: Always show type parameters
+- `"never"`: Never show type parameters  
+- `"whenTruncated"` (default): Only show when TypeScript truncates the type display
+
+Example configuration:
+```json
+{
+  "effectLanguageService": {
+    "quickinfoEffectParameters": "whenTruncated"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ Few options can be provided alongside the initialization of the Language Service
     "plugins": [
       {
         "name": "@effect/language-service",
+        "refactors": true, // controls Effect refactors (default: true)
         "diagnostics": true, // controls Effect diagnostics (default: true)
         "diagnosticSeverity": { // allows to change per-rule default severity of the diagnostic in the whole project
           "floatingEffect": "warning" // example for a rule, allowed values are off,error,warning,message,suggestion
         },
-        "quickinfo": true, // controls quickinfo over Effect (default: true)
+        "quickinfo": true, // controls Effect quickinfo (default: true)
+        "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
         "completions": true, // controls Effect completions (default: true)
         "goto": true, // controls Effect goto references (default: true)
         "allowedDuplicatedPackages": [], // list of package names that have effect in peer dependencies and are allowed to be duplicated (default: [])

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -7,8 +7,10 @@ import * as Nano from "./Nano"
 export type DiagnosticSeverity = "error" | "warning" | "message" | "suggestion"
 
 export interface LanguageServicePluginOptions {
+  refactors: boolean
   diagnostics: boolean
   diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
+  quickinfoEffectParameters: "always" | "never" | "whentruncated"
   quickinfo: boolean
   completions: boolean
   goto: boolean
@@ -34,41 +36,62 @@ function parseDiagnosticSeverity(config: Record<PropertyKey, unknown>): Record<s
   )
 }
 
+export const defaults: LanguageServicePluginOptions = {
+  refactors: true,
+  diagnostics: true,
+  diagnosticSeverity: {},
+  quickinfo: true,
+  quickinfoEffectParameters: "whentruncated",
+  completions: true,
+  goto: true,
+  allowedDuplicatedPackages: [],
+  namespaceImportPackages: [],
+  barrelImportPackages: [],
+  topLevelNamedReexports: "ignore"
+}
+
 export function parse(config: any): LanguageServicePluginOptions {
   return {
+    refactors: isObject(config) && hasProperty(config, "refactors") && isBoolean(config.refactors)
+      ? config.refactors
+      : defaults.refactors,
     diagnostics: isObject(config) && hasProperty(config, "diagnostics") && isBoolean(config.diagnostics)
       ? config.diagnostics
-      : true,
+      : defaults.diagnostics,
     diagnosticSeverity:
       isObject(config) && hasProperty(config, "diagnosticSeverity") && isRecord(config.diagnosticSeverity)
         ? parseDiagnosticSeverity(config.diagnosticSeverity)
-        : {},
+        : defaults.diagnosticSeverity,
     quickinfo: isObject(config) && hasProperty(config, "quickinfo") && isBoolean(config.quickinfo)
       ? config.quickinfo
-      : true,
+      : defaults.quickinfo,
+    quickinfoEffectParameters: isObject(config) && hasProperty(config, "quickinfoEffectParameters") &&
+        isString(config.quickinfoEffectParameters) &&
+        ["always", "never", "whentruncated"].includes(config.quickinfoEffectParameters.toLowerCase())
+      ? config.quickinfoEffectParameters.toLowerCase() as "always" | "never" | "whentruncated"
+      : defaults.quickinfoEffectParameters,
     completions: isObject(config) && hasProperty(config, "completions") && isBoolean(config.completions)
       ? config.completions
-      : true,
+      : defaults.completions,
     goto: isObject(config) && hasProperty(config, "goto") && isBoolean(config.goto)
       ? config.goto
-      : true,
+      : defaults.goto,
     allowedDuplicatedPackages: isObject(config) && hasProperty(config, "allowedDuplicatedPackages") &&
         isArray(config.allowedDuplicatedPackages) && config.allowedDuplicatedPackages.every(isString)
       ? config.allowedDuplicatedPackages.map((_) => _.toLowerCase())
-      : [],
+      : defaults.allowedDuplicatedPackages,
     namespaceImportPackages: isObject(config) && hasProperty(config, "namespaceImportPackages") &&
         isArray(config.namespaceImportPackages) && config.namespaceImportPackages.every(isString)
       ? config.namespaceImportPackages.map((_) => _.toLowerCase())
-      : [],
+      : defaults.namespaceImportPackages,
     barrelImportPackages: isObject(config) && hasProperty(config, "barrelImportPackages") &&
         isArray(config.barrelImportPackages) && config.barrelImportPackages.every(isString)
       ? config.barrelImportPackages.map((_) => _.toLowerCase())
-      : [],
+      : defaults.barrelImportPackages,
     topLevelNamedReexports: isObject(config) && hasProperty(config, "topLevelNamedReexports") &&
         isString(config.topLevelNamedReexports) &&
-        (config.topLevelNamedReexports.toLowerCase() === "ignore" ||
-          config.topLevelNamedReexports.toLowerCase() === "follow")
+        ["ignore", "follow"].includes(config.topLevelNamedReexports.toLowerCase())
       ? config.topLevelNamedReexports.toLowerCase() as "ignore" | "follow"
-      : "ignore"
+      : defaults.topLevelNamedReexports
   }
 }

--- a/src/quickinfo.ts
+++ b/src/quickinfo.ts
@@ -1,4 +1,5 @@
 import type ts from "typescript"
+import type * as LanguageServicePluginOptions from "./core/LanguageServicePluginOptions.js"
 import * as Nano from "./core/Nano.js"
 import type * as TypeCheckerApi from "./core/TypeCheckerApi.js"
 import type * as TypeParser from "./core/TypeParser.js"
@@ -15,7 +16,11 @@ export function quickInfo(
 ): Nano.Nano<
   ts.QuickInfo | undefined,
   never,
-  TypeScriptApi.TypeScriptApi | TypeScriptUtils.TypeScriptUtils | TypeCheckerApi.TypeCheckerApi | TypeParser.TypeParser
+  | TypeScriptApi.TypeScriptApi
+  | TypeScriptUtils.TypeScriptUtils
+  | TypeCheckerApi.TypeCheckerApi
+  | TypeParser.TypeParser
+  | LanguageServicePluginOptions.LanguageServicePluginOptions
 > {
   return Nano.gen(function*() {
     const deduped = yield* dedupeJsDocs(quickInfo)

--- a/src/quickinfo/effectTypeArgs.ts
+++ b/src/quickinfo/effectTypeArgs.ts
@@ -1,5 +1,6 @@
 import { pipe } from "effect/Function"
 import type ts from "typescript"
+import * as LanguageServicePluginOptions from "../core/LanguageServicePluginOptions.js"
 import * as Nano from "../core/Nano.js"
 import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
 import * as TypeParser from "../core/TypeParser.js"
@@ -15,6 +16,10 @@ export function effectTypeArgs(
       const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
       const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
       const typeParser = yield* Nano.service(TypeParser.TypeParser)
+      const options = yield* Nano.service(LanguageServicePluginOptions.LanguageServicePluginOptions)
+
+      // early exit
+      if (options.quickinfoEffectParameters === "never") return quickInfo
 
       function formatTypeForQuickInfo(channelType: ts.Type, channelName: string) {
         const stringRepresentation = typeChecker.typeToString(
@@ -82,7 +87,7 @@ export function effectTypeArgs(
           type: typeChecker.getTypeAtLocation(adjustedNode),
           atLocation: adjustedNode,
           node: adjustedNode,
-          shouldTry: quickInfo &&
+          shouldTry: options.quickinfoEffectParameters === "always" && quickInfo ? true : quickInfo &&
             ts.displayPartsToString(quickInfo.displayParts).indexOf("...") > -1
         }
       }

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -49,15 +49,12 @@ function testCompletionOnExample(
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
+      ...LanguageServicePluginOptions.defaults,
+      completions: true,
+      refactors: false,
       diagnostics: false,
-      diagnosticSeverity: {},
       quickinfo: false,
-      completions: false,
-      goto: false,
-      allowedDuplicatedPackages: [],
-      namespaceImportPackages: [],
-      barrelImportPackages: [],
-      topLevelNamedReexports: "ignore"
+      goto: false
     }),
     Nano.unsafeRun
   )

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -62,15 +62,13 @@ function testDiagnosticOnExample(
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
+      ...LanguageServicePluginOptions.defaults,
       diagnostics: true,
-      diagnosticSeverity: {},
+      refactors: false,
       quickinfo: false,
       completions: false,
       goto: false,
-      allowedDuplicatedPackages: [],
-      namespaceImportPackages: ["effect"],
-      barrelImportPackages: [],
-      topLevelNamedReexports: "ignore"
+      namespaceImportPackages: ["effect"]
     }),
     Nano.map(({ diagnostics }) => {
       // sort by start position
@@ -169,15 +167,13 @@ function testDiagnosticQuickfixesOnExample(
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
+      ...LanguageServicePluginOptions.defaults,
       diagnostics: true,
-      diagnosticSeverity: {},
+      refactors: false,
       quickinfo: false,
       completions: false,
       goto: false,
-      allowedDuplicatedPackages: [],
-      namespaceImportPackages: ["effect"],
-      barrelImportPackages: [],
-      topLevelNamedReexports: "ignore"
+      namespaceImportPackages: ["effect"]
     }),
     Nano.unsafeRun,
     async (result) => {

--- a/test/perf.ts
+++ b/test/perf.ts
@@ -37,15 +37,12 @@ function testAllDagnostics() {
         TypeScriptUtils.nanoLayer,
         Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
         Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
+          ...LanguageServicePluginOptions.defaults,
+          refactors: false,
           diagnostics: true,
-          diagnosticSeverity: {},
           quickinfo: false,
           completions: false,
-          goto: false,
-          allowedDuplicatedPackages: [],
-          namespaceImportPackages: [],
-          barrelImportPackages: [],
-          topLevelNamedReexports: "ignore"
+          goto: false
         }),
         Nano.unsafeRun,
         Either.getOrElse(() => "// no diagnostics")

--- a/test/refactors.test.ts
+++ b/test/refactors.test.ts
@@ -77,15 +77,12 @@ function testRefactorOnExample(
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
+      ...LanguageServicePluginOptions.defaults,
+      refactors: true,
       diagnostics: false,
-      diagnosticSeverity: {},
       quickinfo: false,
       completions: false,
-      goto: false,
-      allowedDuplicatedPackages: [],
-      namespaceImportPackages: [],
-      barrelImportPackages: [],
-      topLevelNamedReexports: "ignore"
+      goto: false
     }),
     Nano.unsafeRun
   )
@@ -103,15 +100,12 @@ function testRefactorOnExample(
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
     Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
+      ...LanguageServicePluginOptions.defaults,
+      refactors: true,
       diagnostics: false,
-      diagnosticSeverity: {},
       quickinfo: false,
       completions: false,
-      goto: false,
-      allowedDuplicatedPackages: [],
-      namespaceImportPackages: [],
-      barrelImportPackages: [],
-      topLevelNamedReexports: "ignore"
+      goto: false
     }),
     Nano.unsafeRun
   )


### PR DESCRIPTION
## Summary
- Adds new `quickinfoEffectParameters` configuration option to control when Effect type parameters are displayed in quickinfo
- Options are: `"always"`, `"never"`, or `"whenTruncated"` (default)
- Allows users to customize hover information display based on their preferences

## Example
When hovering over Effect types, users can now control parameter visibility:
```json
{
  "effectLanguageService": {
    "quickinfoEffectParameters": "whenTruncated"
  }
}
```

This helps manage the verbosity of type information in hover tooltips, especially for complex Effect types.

## Test plan
- [x] All existing tests pass
- [x] TypeScript type checking passes
- [x] Code formatting is correct
- [x] Documentation is updated in README.md
- [x] Changeset file is included for version management

🤖 Generated with [Claude Code](https://claude.ai/code)