### PR TITLE
feat: add inlay hints for Effect.gen-like middleware functions

### DIFF
--- a/.changeset/effect-gen-inlay-hints.md
+++ b/.changeset/effect-gen-inlay-hints.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": minor
+---
+
+feat: add inlay hints for Effect.gen-like middleware functions
+
+Improved inlay hints for Effect.gen-like middleware functions to reduce visual clutter by omitting redundant type annotations that TypeScript already provides.

--- a/examples/inlays/effectGenLike.ts
+++ b/examples/inlays/effectGenLike.ts
@@ -1,5 +1,9 @@
 import * as Effect from "effect/Effect"
 
+export function standardShouldAppear() {
+  return 42
+}
+
 export const sample = Effect.gen(function*() {
   const n = Math.random()
   if (n < 0.5) {

--- a/src/inlays/middlewareGenLike.ts
+++ b/src/inlays/middlewareGenLike.ts
@@ -1,7 +1,6 @@
 import { pipe } from "effect/Function"
 import type * as ts from "typescript"
 import * as Nano from "../core/Nano.js"
-import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
 import * as TypeParser from "../core/TypeParser.js"
 import * as TypeScriptApi from "../core/TypeScriptApi.js"
 import * as TypeScriptUtils from "../core/TypeScriptUtils.js"
@@ -20,35 +19,19 @@ export const middlewareGenLike = Nano.fn("middlewareGenLike")(function*(
   const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
   const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
   const typeParser = yield* Nano.service(TypeParser.TypeParser)
-  const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
   const result: Array<ts.InlayHint> = []
 
   // given a node, parses the type and eventual gen-like
   const parseType = (node: ts.Node) => {
     return pipe(
-      Nano.map(typeParser.effectGen(node), (_) => {
-        const type = typeChecker.getTypeAtLocation(_.node)
-        const typeString = typeChecker.typeToString(type, _.generatorFunction, ts.TypeFormatFlags.NoTruncation)
-        return { ..._, typeString }
-      }),
-      Nano.orElse(() =>
-        Nano.map(pipe(typeParser.effectFnGen(node), Nano.orElse(() => typeParser.effectFnUntracedGen(node))), (_) => {
-          const fnType = typeChecker.getTypeAtLocation(_.node)
-          const types: Array<string> = []
-          for (const callSig of fnType.getCallSignatures()) {
-            types.push(
-              typeChecker.typeToString(callSig.getReturnType(), _.generatorFunction, ts.TypeFormatFlags.NoTruncation)
-            )
-          }
-          return { ..._, typeString: types.join(" | ") }
-        })
-      )
+      typeParser.effectGen(node),
+      Nano.orElse(() => pipe(typeParser.effectFnGen(node), Nano.orElse(() => typeParser.effectFnUntracedGen(node))))
     )
   }
 
   // now we loop throgh them, and find the ones that refer to an Effect.gen like function
   for (const inlayHint of inlayHints) {
-    let modifiedInlayHint = inlayHint
+    let shouldOmit = false
     if (inlayHint.kind === ts.InlayHintKind.Type) {
       const node = tsUtils.findNodeAtPositionIncludingTrivia(sourceFile, inlayHint.position - 1)
       if (node && node.parent) {
@@ -61,18 +44,14 @@ export const middlewareGenLike = Nano.fn("middlewareGenLike")(function*(
               argsCloseParen && _.body && inlayHint.position >= argsCloseParen.getEnd() &&
               inlayHint.position <= _.body.getStart(sourceFile)
             ) {
-              const { displayParts: _displayParts, text: _text, ...toKeep } = inlayHint
-              modifiedInlayHint = {
-                ...toKeep,
-                text: ": " + _.typeString
-              }
+              shouldOmit = true
             }
           }),
           Nano.ignore
         )
       }
     }
-    result.push(modifiedInlayHint)
+    if (!shouldOmit) result.push(inlayHint)
   }
 
   return result


### PR DESCRIPTION
## Summary
- Improved inlay hints for Effect.gen-like middleware functions
- Reduced visual clutter by omitting redundant type annotations that TypeScript already provides
- Added changeset for proper versioning

## Example
The language service now omits inlay hints for return types of Effect.gen-like middleware functions when TypeScript already provides that information, making the code less cluttered while maintaining helpful type information where needed.

## Test plan
- [x] All existing tests pass
- [x] Snapshots have been regenerated and verified
- [x] TypeScript checks pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)