### PR TITLE
Revert to previous transform logic

### DIFF
--- a/.changeset/fancy-walls-crash.md
+++ b/.changeset/fancy-walls-crash.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Revert to previous transform logic

--- a/README.md
+++ b/README.md
@@ -140,9 +140,8 @@ Your `tsconfig.json` should look like this:
 To get diagnostics you need to install `ts-patch` which will make it possible to run `tspc`.
 
 Running `tspc` in your project will now also run the plugin and give you the error diagnostics at compile time.
-Effect diagnostics in watch mode with noEmit enabled are not supported by ts-patch unfortunately.
-
-If you use incremental builds, after enabling ts-patch, a full rebuild may be necessary to invalidate the previous diagnostics cache.
+Effect error diagnostics will be shown only after standard TypeScript diagnostics have been satisfied.
+Beware that setting noEmit will completely skip the effect diagnostics.
 
 ```ts
 $ npx tspc
@@ -151,7 +150,7 @@ index.ts:3:1 - error TS3: Effect must be yielded or assigned to a variable.
 3 Effect.succeed(1)
   ~~~~~~~~~~~~~~~~~
 
-Found 1 error in index.ts:3 
+Found 1 error in index.ts:3 
 ```
 
 ## Configuring diagnostics

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -12,55 +12,39 @@ import * as TypeScriptApi from "./core/TypeScriptApi"
 import * as TypeScriptUtils from "./core/TypeScriptUtils"
 import { diagnostics } from "./diagnostics"
 
-const programsChecked = new WeakMap<ts.Program, Set<string>>()
-
 export default function(
   program: ts.Program,
   pluginConfig: PluginConfig,
   { addDiagnostic, ts: tsInstance }: TransformerExtras
 ) {
-  function runDiagnostics(program: ts.Program, sourceFile: ts.SourceFile) {
-    // avoid to double-process the same file
-    const checkedFiles = programsChecked.get(program) ?? new Set<string>()
-    programsChecked.set(program, checkedFiles)
-    if (checkedFiles.has(sourceFile.fileName)) return
-    checkedFiles.add(sourceFile.fileName)
+  return (_: ts.TransformationContext) => {
+    return (sourceFile: ts.SourceFile) => {
+      // run the diagnostics and pipe them into addDiagnostic
+      pipe(
+        LSP.getSemanticDiagnosticsWithCodeFixes(diagnostics, sourceFile),
+        TypeParser.nanoLayer,
+        TypeScriptUtils.nanoLayer,
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
+        Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
+        Nano.provideService(
+          LanguageServicePluginOptions.LanguageServicePluginOptions,
+          LanguageServicePluginOptions.parse(pluginConfig)
+        ),
+        Nano.run,
+        Either.map((_) => _.diagnostics),
+        Either.map(
+          Array.filter((_) =>
+            _.category === tsInstance.DiagnosticCategory.Error ||
+            _.category === tsInstance.DiagnosticCategory.Warning
+          )
+        ),
+        Either.getOrElse(() => []),
+        Array.map(addDiagnostic)
+      )
 
-    // run the diagnostics and pipe them into addDiagnostic
-    pipe(
-      LSP.getSemanticDiagnosticsWithCodeFixes(diagnostics, sourceFile),
-      TypeParser.nanoLayer,
-      TypeScriptUtils.nanoLayer,
-      Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
-      Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
-      Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
-      Nano.provideService(
-        LanguageServicePluginOptions.LanguageServicePluginOptions,
-        LanguageServicePluginOptions.parse(pluginConfig)
-      ),
-      Nano.run,
-      Either.map((_) => _.diagnostics),
-      Either.map(
-        Array.filter((_) =>
-          _.category === tsInstance.DiagnosticCategory.Error ||
-          _.category === tsInstance.DiagnosticCategory.Warning
-        )
-      ),
-      Either.getOrElse(() => []),
-      Array.map(addDiagnostic)
-    )
-  }
-
-  // process root files (works for noEmit: true)
-  const rootFileNames = program.getRootFileNames()
-  const sourceFiles = program.getSourceFiles().filter((_) => rootFileNames.indexOf(_.fileName) > -1)
-  for (const sourceFile of sourceFiles) {
-    runDiagnostics(program, sourceFile)
-  }
-
-  return (_: ts.TransformationContext) => (sourceFile: ts.SourceFile) => {
-    // just be sure to try process any way (for noEmit: false with non catched files)
-    runDiagnostics(program, sourceFile)
-    return sourceFile
+      // do not transform source ccde
+      return sourceFile
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Reverted the transform logic in src/transform.ts to its previous implementation
- Updated README.md to reflect the changes
- This change addresses potential issues introduced by recent modifications

## Changes
The main change is in the `src/transform.ts` file where the transform logic has been reverted to use the previous implementation pattern.

## Test plan
- [x] All existing tests pass without modification
- [x] No snapshot changes required (validated by dropping and regenerating snapshots)
- [x] TypeScript compilation succeeds
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)