### PR TITLE
Fix async/await to Effect.fn refactor to use correct function reference

### DIFF
--- a/.changeset/fix-async-await-to-fn-refactor.md
+++ b/.changeset/fix-async-await-to-fn-refactor.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Fix async/await to Effect.fn refactor to use correct function name
+
+Previously, the refactor would incorrectly use the function's own name instead of `Effect.fn` when transforming async functions. This patch fixes the issue to properly generate `Effect.fn("functionName")` in the refactored code.

--- a/examples/refactors/asyncAwaitToFn_fetch.ts
+++ b/examples/refactors/asyncAwaitToFn_fetch.ts
@@ -1,0 +1,7 @@
+// 3:30
+
+export async function getUserName(userId: string) {
+  const user = await fetch(`https://api.example.com/users/${userId}`)
+  const userData = await user.json()
+  return userData.name
+}

--- a/src/core/TypeScriptUtils.ts
+++ b/src/core/TypeScriptUtils.ts
@@ -375,7 +375,7 @@ export function makeTypeScriptUtils(ts: TypeScriptApi.TypeScriptApi): TypeScript
     )
     if (fnName) {
       fnCall = ts.factory.createCallExpression(
-        fnName,
+        fnCall,
         undefined,
         [ts.factory.createStringLiteral(fnName.text)]
       )

--- a/test/__snapshots__/refactors/asyncAwaitToFn.ts.ln4col28.output
+++ b/test/__snapshots__/refactors/asyncAwaitToFn.ts.ln4col28.output
@@ -1,6 +1,6 @@
 // Result of running refactor asyncAwaitToFn at position 4:28
 import * as T from "effect/Effect"
 
-export const refactorMe = refactorMe("refactorMe")(function*(arg: string) {
+export const refactorMe = T.fn("refactorMe")(function*(arg: string) {
     return yield* T.promise(() => Promise.resolve(1))
 })

--- a/test/__snapshots__/refactors/asyncAwaitToFnTryPromise.ts.ln4col28.output
+++ b/test/__snapshots__/refactors/asyncAwaitToFnTryPromise.ts.ln4col28.output
@@ -1,6 +1,6 @@
 // Result of running refactor asyncAwaitToFnTryPromise at position 4:28
 import * as T from "effect/Effect"
 
-export const refactorMe = refactorMe("refactorMe")(function*(arg: string) {
+export const refactorMe = T.fn("refactorMe")(function*(arg: string) {
     return yield* T.tryPromise({ try: () => Promise.resolve(arg), catch: error => ({ _tag: "Error1" as const, error }) })
 })

--- a/test/__snapshots__/refactors/asyncAwaitToFn_fetch.ts.ln3col30.output
+++ b/test/__snapshots__/refactors/asyncAwaitToFn_fetch.ts.ln3col30.output
@@ -1,0 +1,7 @@
+// Result of running refactor asyncAwaitToFn at position 3:30
+
+export const getUserName = Effect.fn("getUserName")(function*(userId: string) {
+    const user = yield* Effect.promise(() => fetch(`https://api.example.com/users/${userId}`))
+    const userData = yield* Effect.promise(() => user.json())
+    return userData.name
+})

--- a/test/__snapshots__/refactors/asyncAwaitToFn_generics.ts.ln4col28.output
+++ b/test/__snapshots__/refactors/asyncAwaitToFn_generics.ts.ln4col28.output
@@ -1,6 +1,6 @@
 // Result of running refactor asyncAwaitToFn at position 4:28
 import * as Effect from "effect/Effect"
 
-export const refactorMe = refactorMe("refactorMe")(function* <X>(arg: X) {
+export const refactorMe = Effect.fn("refactorMe")(function* <X>(arg: X) {
     return yield* Effect.promise(() => Promise.resolve(arg))
 })


### PR DESCRIPTION
## Summary
- Fixed the async/await to Effect.fn refactor that was incorrectly using the function's own name instead of `Effect.fn`
- Added test case for fetch-like patterns to ensure the refactor handles various async/await scenarios correctly

## Example
Before this fix, the refactor would generate incorrect code:
```typescript
// Original
export const refactorMe = async (arg: string) => {
    return await Promise.resolve(1)
}

// Incorrectly refactored (before fix)
export const refactorMe = refactorMe("refactorMe")(function*(arg: string) {
    return yield* T.promise(() => Promise.resolve(1))
})

// Correctly refactored (after fix)
export const refactorMe = T.fn("refactorMe")(function*(arg: string) {
    return yield* T.promise(() => Promise.resolve(1))
})
```

## Test plan
- [x] All existing tests pass
- [x] Added new test case for fetch pattern
- [x] Verified snapshot outputs are correct

🤖 Generated with [Claude Code](https://claude.ai/code)