### PR TITLE
Fix auto-import barrel-to-barrel mapping for named re-exports

### DIFF
--- a/.changeset/fix-autoimport-barrel-mapping.md
+++ b/.changeset/fix-autoimport-barrel-mapping.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Fix auto-import barrel-to-barrel mapping for top-level named re-exports
+
+When `topLevelNamedReexports` is set to "follow", the auto-import provider now correctly maps barrel exports to their barrel modules, ensuring proper import suggestions for re-exported functions like `pipe` from `effect/Function`.

--- a/src/core/AutoImport.ts
+++ b/src/core/AutoImport.ts
@@ -233,6 +233,13 @@ export const makeAutoImportProvider: (
                       exportName: namedExport.name
                     }
                   })
+                  mapFromBarrelToBarrel.set(reexportedFile.resolvedModule.resolvedFileName, {
+                    ...(mapFromBarrelToBarrel.get(reexportedFile.resolvedModule.resolvedFileName) || {}),
+                    [namedExport.name]: {
+                      fileName: reexportedFile.resolvedModule.resolvedFileName,
+                      exportName: namedExport.name
+                    }
+                  })
                 }
               }
             }

--- a/test/autoimport.test.ts
+++ b/test/autoimport.test.ts
@@ -97,13 +97,28 @@ describe("autoimport", () => {
       })
     })
     it("import { pipe } from 'effect/Function'", () => {
-      const { result, toFilename } = testAutoImport("pipe", "effect/Function", { namespaceImportPackages: ["effect"] })
+      const { result, toFilename } = testAutoImport("pipe", "effect/Function", {
+        namespaceImportPackages: ["effect"]
+      })
       expect(result).toEqual({
         _tag: "NamespaceImport",
         fileName: toFilename("effect/Function"),
         moduleName: "effect/Function",
         name: "Function",
         introducedPrefix: "Function"
+      })
+    })
+    it("import { pipe } from 'effect/Function' with topLevelNamedReexports: follow", () => {
+      const { result, toFilename } = testAutoImport("pipe", "effect/Function", {
+        namespaceImportPackages: ["effect"],
+        topLevelNamedReexports: "follow"
+      })
+      expect(result).toEqual({
+        _tag: "NamedImport",
+        fileName: toFilename("effect/Function"),
+        moduleName: "effect/Function",
+        name: "pipe",
+        introducedPrefix: undefined
       })
     })
   })


### PR DESCRIPTION
## Summary
- Fixed auto-import mapping issue where barrel exports weren't properly mapped when `topLevelNamedReexports` is set to "follow"
- Added missing barrel-to-barrel mapping in the AutoImport provider
- Added test case to verify the fix works correctly

## Example
When `topLevelNamedReexports: "follow"` is configured, functions like `pipe` from `effect/Function` are now correctly suggested as named imports instead of namespace imports.

## Test plan
- [x] All existing tests pass
- [x] Added new test case for the specific scenario
- [x] Snapshots remain unchanged (no regression)
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)