### PR TITLE
Fix TypeScript module reference in patch utility

### DIFF
--- a/.changeset/fix-patch-tslib-name.md
+++ b/.changeset/fix-patch-tslib-name.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix TypeScript module reference in patch utility to use correct module name when patching TypeScript directly

--- a/src/cli/patch.ts
+++ b/src/cli/patch.ts
@@ -151,7 +151,9 @@ const getPatchesForModule = Effect.fn("getPatchesForModule")(
         sourceFile.text,
         insertCheckSourceFilePosition,
         insertCheckSourceFilePosition,
-        "effectLspPatchUtils.exports.checkSourceFile(effectLspTypeScriptApis, host, node, compilerOptions, diagnostics.add)\n",
+        `effectLspPatchUtils.exports.checkSourceFile(${
+          moduleName === "typescript" ? "module.exports" : "effectLspTypeScriptApis"
+        }, host, node, compilerOptions, diagnostics.add)\n`,
         "\n",
         version
       )


### PR DESCRIPTION
## Summary
- Fixed module reference when patching TypeScript directly to use `module.exports` instead of `effectLspTypeScriptApis`
- This ensures the correct module is referenced when working with TypeScript patches

## Test plan
- [x] All existing tests pass without modifications
- [x] TypeScript checks pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)