### PR TITLE
Add Effect LSP patch mode

### DIFF
--- a/.changeset/wide-mirrors-type.md
+++ b/.changeset/wide-mirrors-type.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add LSP patch mode

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import * as NodeContext from "@effect/platform-node/NodeContext"
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
 import * as Console from "effect/Console"
 import * as Effect from "effect/Effect"
+import { check } from "./cli/check"
 import { patch } from "./cli/patch"
 import { unpatch } from "./cli/unpatch"
 
@@ -10,7 +11,7 @@ const cliCommand = Command.make(
   "effect-language-service",
   {},
   () => Console.log("Please select a command or run --help.")
-).pipe(Command.withSubcommands([patch, unpatch]))
+).pipe(Command.withSubcommands([patch, unpatch, check]))
 
 const main = Command.run(cliCommand, {
   name: "effect-language-service",

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,0 +1,54 @@
+import * as Command from "@effect/cli/Command"
+import * as Options from "@effect/cli/Options"
+import * as FileSystem from "@effect/platform/FileSystem"
+import { pipe } from "effect"
+import * as Array from "effect/Array"
+import * as Effect from "effect/Effect"
+import * as ts from "typescript"
+import { extractAppliedEffectLspPatches, getModuleFilePath, getPackageJsonData } from "./utils"
+
+const LOCAL_TYPESCRIPT_DIR = "./node_modules/typescript"
+
+const dirPath = Options.directory("dir").pipe(
+  Options.withDefault(LOCAL_TYPESCRIPT_DIR),
+  Options.withDescription("The directory of the typescript package to patch.")
+)
+
+export const check = Command.make(
+  "check",
+  { dirPath },
+  Effect.fn("check")(function*({ dirPath }) {
+    const fs = yield* FileSystem.FileSystem
+
+    // read my data
+    const { version: effectLspVersion } = yield* getPackageJsonData(__dirname)
+    yield* Effect.logDebug(`Found @effect/language-service version ${effectLspVersion}!`)
+
+    // search for typescript
+    yield* Effect.logDebug(`Searching for typescript in ${dirPath}...`)
+    const { version: typescriptVersion } = yield* getPackageJsonData(dirPath)
+    yield* Effect.logDebug(`Found typescript version ${typescriptVersion}!`)
+
+    for (const moduleName of ["typescript", "tsc"] as const) {
+      // get the unpatched source file
+      yield* Effect.logDebug(`Searching ${moduleName}...`)
+      const filePath = yield* getModuleFilePath(dirPath, moduleName)
+
+      yield* Effect.logDebug(`Reading ${moduleName} from ${filePath}...`)
+      const sourceText = yield* fs.readFileString(filePath)
+      const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.ES2022, true)
+
+      // construct the patches to apply
+      yield* Effect.logDebug(`Collecting patches for ${moduleName}...`)
+      const { patches } = yield* extractAppliedEffectLspPatches(sourceFile)
+
+      const patchesVersion = pipe(patches, Array.map((patch) => patch.version), Array.dedupe)
+
+      if (patchesVersion.length === 0) {
+        yield* Effect.logInfo(`${filePath} is not patched.`)
+      } else {
+        yield* Effect.logInfo(`${filePath} patched with version ${patchesVersion.join(", ")}`)
+      }
+    }
+  })
+)

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -10,10 +10,14 @@ const tsUtils = TypeScriptUtils.makeTypeScriptUtils(ts)
 
 const PackageJsonSchema = Schema.Struct({
   name: Schema.String,
-  version: Schema.String
+  version: Schema.String,
+  scripts: Schema.optional(Schema.Record({
+    key: Schema.String,
+    value: Schema.String
+  }))
 })
 
-export class UnableFindTsPackageError extends Data.TaggedError("UnableToFindPackageError")<{
+export class UnableToFindPackageJsonError extends Data.TaggedError("UnableToFindPackageError")<{
   packageJsonPath: string
   cause: unknown
 }> {
@@ -45,7 +49,7 @@ export const getPackageJsonData = Effect.fn("getPackageJsonData")(function*(pack
   const fs = yield* FileSystem.FileSystem
   const packageJsonPath = path.resolve(packageDir, "package.json")
   const packageJsonContent = yield* fs.readFileString(packageJsonPath).pipe(
-    Effect.mapError((cause) => new UnableFindTsPackageError({ packageJsonPath, cause }))
+    Effect.mapError((cause) => new UnableToFindPackageJsonError({ packageJsonPath, cause }))
   )
   const packageJsonData = yield* Schema.decode(Schema.parseJson(PackageJsonSchema))(packageJsonContent).pipe(
     Effect.mapError((cause) => new MalformedPackageJsonError({ packageJsonPath, cause }))

--- a/src/effect-lsp-patch-utils.ts
+++ b/src/effect-lsp-patch-utils.ts
@@ -21,11 +21,14 @@ export function checkSourceFileWorker(
   compilerOptions: ts.CompilerOptions,
   addDiagnostic: (diagnostic: ts.Diagnostic) => void
 ) {
+  // check if the plugin is enabled
   const pluginOptions = pipe(
     (compilerOptions.plugins || []) as Array<any>,
-    Array.findFirst((_) => Predicate.hasProperty(_, "name") && _.name === "@effect/language-service"),
-    Option.getOrElse(() => ({}))
+    Array.findFirst((_) => Predicate.hasProperty(_, "name") && _.name === "@effect/language-service")
   )
+  if (Option.isNone(pluginOptions)) {
+    return
+  }
   // run the diagnostics and pipe them into addDiagnostic
   pipe(
     LSP.getSemanticDiagnosticsWithCodeFixes(diagnostics, sourceFile),
@@ -53,7 +56,4 @@ export function checkSourceFileWorker(
     }),
     Array.map(addDiagnostic)
   )
-
-  // do not transform source ccde
-  return sourceFile
 }


### PR DESCRIPTION
## Type



- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This option works by modifing directly the source code of the tsc compiler and the typescript library in your project node_modules. This allows to get effect's diagnostics even when noEmit is enabled, for composite and incremental projects as well.

After having installed and configured the LSP for editor usage, you can run the following command inside the folder that contains your local project typescript installation:

`effect-language-service patch`

If everything goes smoothly, something along these lines should be printed out:

```
/node_modules/typescript/lib/typescript.js patched successfully.
/node_modules/typescript/lib/_tsc.js patched successfully.
```

Now the CLI has patched the tsc binary and the typescript library to raise effect diagnostics even at build time if the plugin is configured in your tsconfig!

As the command output suggests, you may need to delete your tsbuildinfo files or perform a full rebuild in order to re-check previously existing files.

To make the patch persistent across package installations and updates, we recommend adding the patch command to your package.json prepare scripts:

```jsonc
  "scripts": {
    "prepare": "effect-language-service patch"
  }
```

so that across updates the patch will be re-applied again.