### PR TITLE
Add support for importAliases configuration

### DIFF
--- a/.changeset/twelve-glasses-switch.md
+++ b/.changeset/twelve-glasses-switch.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add support for importAliases config

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Few options can be provided alongside the initialization of the Language Service
         "allowedDuplicatedPackages": [], // list of package names that have effect in peer dependencies and are allowed to be duplicated (default: [])
         "barrelImportPackages": [], // package names that should be preferred as imported from the top level barrel file (default: [])
         "namespaceImportPackages": [], // package names that should be preferred as imported with namespace imports e.g. ["effect", "@effect/*"] (default: [])
-        "topLevelNamedReexports": "ignore" // for namespaceImportPackages, how should top level named re-exports (e.g. {pipe} from "effect") be treated? "ignore" will leave them as is, "follow" will rewrite them to the re-exported module (e.g. {pipe} from "effect/Function")
+        "topLevelNamedReexports": "ignore", // for namespaceImportPackages, how should top level named re-exports (e.g. {pipe} from "effect") be treated? "ignore" will leave them as is, "follow" will rewrite them to the re-exported module (e.g. {pipe} from "effect/Function")
+        "importAliases": { "Array": "Arr" } // allows to chose some different names for import name aliases (only when not chosing to import the whole module) (default: {})
       }
     ]
   }

--- a/src/core/AutoImport.ts
+++ b/src/core/AutoImport.ts
@@ -464,7 +464,7 @@ export const addImport = (
     }
     case "NamedImport": {
       const importModule = effectAutoImport.moduleName || effectAutoImport.fileName
-      if(effectAutoImport.aliasName) {
+      if (effectAutoImport.aliasName) {
         description = `Import { ${effectAutoImport.name} as ${effectAutoImport.aliasName} } from "${importModule}"`
       } else {
         description = `Import { ${effectAutoImport.name} } from "${importModule}"`
@@ -483,8 +483,9 @@ export const addImport = (
             if (importClause && importClause.namedBindings && ts.isNamedImports(importClause.namedBindings)) {
               const namedImports = importClause.namedBindings
               const existingImportSpecifier = namedImports.elements.find((element) => {
-                if(effectAutoImport.aliasName){
-                  return element.name.text === effectAutoImport.name && element.propertyName?.text === effectAutoImport.aliasName
+                if (effectAutoImport.aliasName) {
+                  return element.name.text === effectAutoImport.name &&
+                    element.propertyName?.text === effectAutoImport.aliasName
                 }
                 return element.name.text === effectAutoImport.name
               })

--- a/src/core/AutoImport.ts
+++ b/src/core/AutoImport.ts
@@ -11,7 +11,8 @@ interface ImportKindNamed {
   moduleName: string | undefined
   fileName: string
   name: string
-  introducedPrefix?: string
+  aliasName: string | undefined
+  introducedPrefix: string | undefined
 }
 
 interface ImportKindNamespace {
@@ -19,6 +20,7 @@ interface ImportKindNamespace {
   moduleName: string | undefined
   fileName: string
   name: string
+  aliasName: string | undefined
   introducedPrefix: string | undefined
 }
 
@@ -271,6 +273,12 @@ export const makeAutoImportProvider: (
     return moduleSpecifier
   }
 
+  const resolveAliasName = (chosenName: string) => {
+    const aliasName = languageServicePluginOptions.importAliases[chosenName]
+    if (aliasName) return aliasName
+    return undefined
+  }
+
   const resolve = (exportFileName: string, exportName: string): ImportKindNamed | ImportKindNamespace | undefined => {
     // case 0) excluded
     const excludedExports = mapFilenameToExportExcludes.get(exportFileName)
@@ -284,7 +292,9 @@ export const makeAutoImportProvider: (
           _tag: "NamedImport",
           fileName: reexportedFile.fileName,
           moduleName: resolveModuleName(reexportedFile.fileName),
-          name: exportName
+          name: exportName,
+          aliasName: resolveAliasName(exportName),
+          introducedPrefix: undefined
         })
       }
     }
@@ -300,6 +310,7 @@ export const makeAutoImportProvider: (
             fileName: namespacedFileName,
             moduleName: resolveModuleName(namespacedFileName),
             name: introducedAlias,
+            aliasName: resolveAliasName(introducedAlias),
             introducedPrefix: undefined
           })
         }
@@ -313,7 +324,8 @@ export const makeAutoImportProvider: (
         fileName: exportFileName,
         moduleName: resolveModuleName(exportFileName),
         name: introducedAlias,
-        introducedPrefix: introducedAlias
+        aliasName: resolveAliasName(introducedAlias),
+        introducedPrefix: resolveAliasName(introducedAlias) || introducedAlias
       })
     }
     // case 4) barrel import { succeed } from "effect/Effect"
@@ -324,7 +336,8 @@ export const makeAutoImportProvider: (
         fileName: mapToBarrel.fileName,
         moduleName: resolveModuleName(mapToBarrel.fileName),
         name: mapToBarrel.alias,
-        introducedPrefix: mapToBarrel.alias
+        aliasName: resolveAliasName(mapToBarrel.alias),
+        introducedPrefix: resolveAliasName(mapToBarrel.alias) || mapToBarrel.alias
       })
     }
   }
@@ -429,8 +442,9 @@ export const addImport = (
   // add the import based on the style
   switch (effectAutoImport._tag) {
     case "NamespaceImport": {
+      const aliasName = effectAutoImport.aliasName || effectAutoImport.name
       const importModule = effectAutoImport.moduleName || effectAutoImport.fileName
-      description = `Import * as ${effectAutoImport.name} from "${importModule}"`
+      description = `Import * as ${aliasName} from "${importModule}"`
       ts.insertImports(
         changeTracker,
         sourceFile,
@@ -439,7 +453,7 @@ export const addImport = (
           ts.factory.createImportClause(
             false,
             undefined,
-            ts.factory.createNamespaceImport(ts.factory.createIdentifier(effectAutoImport.name))
+            ts.factory.createNamespaceImport(ts.factory.createIdentifier(aliasName))
           ),
           ts.factory.createStringLiteral(importModule)
         ),
@@ -450,7 +464,11 @@ export const addImport = (
     }
     case "NamedImport": {
       const importModule = effectAutoImport.moduleName || effectAutoImport.fileName
-      description = `Import { ${effectAutoImport.name} } from "${importModule}"`
+      if(effectAutoImport.aliasName) {
+        description = `Import { ${effectAutoImport.name} as ${effectAutoImport.aliasName} } from "${importModule}"`
+      } else {
+        description = `Import { ${effectAutoImport.name} } from "${importModule}"`
+      }
       // loop through the import declarations of the source file
       // and see if we can find the import declaration that is importing the barrel file
       let foundImportDeclaration = false
@@ -464,9 +482,12 @@ export const addImport = (
             const importClause = statement.importClause
             if (importClause && importClause.namedBindings && ts.isNamedImports(importClause.namedBindings)) {
               const namedImports = importClause.namedBindings
-              const existingImportSpecifier = namedImports.elements.find((element) =>
-                element.name.text === effectAutoImport.name
-              )
+              const existingImportSpecifier = namedImports.elements.find((element) => {
+                if(effectAutoImport.aliasName){
+                  return element.name.text === effectAutoImport.name && element.propertyName?.text === effectAutoImport.aliasName
+                }
+                return element.name.text === effectAutoImport.name
+              })
               // the import already exists, we can exit
               if (existingImportSpecifier) {
                 foundImportDeclaration = true
@@ -480,8 +501,8 @@ export const addImport = (
                   namedImports.elements.concat([
                     ts.factory.createImportSpecifier(
                       false,
-                      undefined,
-                      ts.factory.createIdentifier(effectAutoImport.name)
+                      effectAutoImport.aliasName ? ts.factory.createIdentifier(effectAutoImport.name) : undefined,
+                      ts.factory.createIdentifier(effectAutoImport.aliasName || effectAutoImport.name)
                     )
                   ])
                 )
@@ -505,8 +526,8 @@ export const addImport = (
                 [
                   ts.factory.createImportSpecifier(
                     false,
-                    undefined,
-                    ts.factory.createIdentifier(effectAutoImport.name)
+                    effectAutoImport.aliasName ? ts.factory.createIdentifier(effectAutoImport.name) : undefined,
+                    ts.factory.createIdentifier(effectAutoImport.aliasName || effectAutoImport.name)
                   )
                 ]
               )

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -2,8 +2,8 @@ import { isArray } from "effect/Array"
 import * as Array from "effect/Array"
 import { pipe } from "effect/Function"
 import { hasProperty, isBoolean, isObject, isRecord, isString } from "effect/Predicate"
-import * as Nano from "./Nano"
 import * as Record from "effect/Record"
+import * as Nano from "./Nano"
 
 export type DiagnosticSeverity = "error" | "warning" | "message" | "suggestion"
 

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -3,6 +3,7 @@ import * as Array from "effect/Array"
 import { pipe } from "effect/Function"
 import { hasProperty, isBoolean, isObject, isRecord, isString } from "effect/Predicate"
 import * as Nano from "./Nano"
+import * as Record from "effect/Record"
 
 export type DiagnosticSeverity = "error" | "warning" | "message" | "suggestion"
 
@@ -19,6 +20,7 @@ export interface LanguageServicePluginOptions {
   namespaceImportPackages: Array<string>
   topLevelNamedReexports: "ignore" | "follow"
   barrelImportPackages: Array<string>
+  importAliases: Record<string, string>
   renames: boolean
 }
 
@@ -49,8 +51,9 @@ export const defaults: LanguageServicePluginOptions = {
   inlays: true,
   allowedDuplicatedPackages: [],
   namespaceImportPackages: [],
-  barrelImportPackages: [],
   topLevelNamedReexports: "ignore",
+  barrelImportPackages: [],
+  importAliases: {},
   renames: true
 }
 
@@ -95,6 +98,9 @@ export function parse(config: any): LanguageServicePluginOptions {
         isArray(config.barrelImportPackages) && config.barrelImportPackages.every(isString)
       ? config.barrelImportPackages.map((_) => _.toLowerCase())
       : defaults.barrelImportPackages,
+    importAliases: isObject(config) && hasProperty(config, "importAliases") && isRecord(config.importAliases)
+      ? Record.map(config.importAliases, (value) => String(value))
+      : defaults.importAliases,
     topLevelNamedReexports: isObject(config) && hasProperty(config, "topLevelNamedReexports") &&
         isString(config.topLevelNamedReexports) &&
         ["ignore", "follow"].includes(config.topLevelNamedReexports.toLowerCase())

--- a/test/autoimport.test.ts
+++ b/test/autoimport.test.ts
@@ -58,6 +58,7 @@ function testAutoImport(
 }
 
 describe("autoimport", () => {
+  // NAMESPACE IMPORT
   describe("namespace import", () => {
     it("import { Effect } from 'effect'", () => {
       const { result, toFilename } = testAutoImport("Effect", "effect", { namespaceImportPackages: ["effect"] })
@@ -121,7 +122,20 @@ describe("autoimport", () => {
         introducedPrefix: undefined
       })
     })
+    it("import { Array as Arr } from 'effect/Array'", () => {
+      const { result, toFilename } = testAutoImport("fromIterable", "effect/Array", { namespaceImportPackages: ["effect"], importAliases: { Array: "Arr" } })
+      expect(result).toEqual({
+        _tag: "NamespaceImport",
+        fileName: toFilename("effect/Array"),
+        moduleName: "effect/Array",
+        name: "Array",
+        aliasName: "Arr",
+        introducedPrefix: "Arr"
+      })
+    })
   })
+
+  // BARREL IMPORT
   describe("barrel import", () => {
     it("import { succeed } from 'effect/Effect'", () => {
       const { result, toFilename } = testAutoImport("succeed", "effect/Effect", { barrelImportPackages: ["effect"] })
@@ -143,6 +157,17 @@ describe("autoimport", () => {
         topLevelNamedReexports: "follow"
       })
       expect(result).toBeUndefined()
+    })
+    it("import { Array as Arr } from 'effect/Array'", () => {
+      const { result, toFilename } = testAutoImport("fromIterable", "effect/Array", { barrelImportPackages: ["effect"], importAliases: { Array: "Arr" } })
+      expect(result).toEqual({
+        _tag: "NamedImport",
+        fileName: toFilename("effect"),
+        moduleName: "effect",
+        name: "Array",
+        aliasName: "Arr",
+        introducedPrefix: "Arr"
+      })
     })
   })
 })

--- a/test/autoimport.test.ts
+++ b/test/autoimport.test.ts
@@ -123,7 +123,10 @@ describe("autoimport", () => {
       })
     })
     it("import { Array as Arr } from 'effect/Array'", () => {
-      const { result, toFilename } = testAutoImport("fromIterable", "effect/Array", { namespaceImportPackages: ["effect"], importAliases: { Array: "Arr" } })
+      const { result, toFilename } = testAutoImport("fromIterable", "effect/Array", {
+        namespaceImportPackages: ["effect"],
+        importAliases: { Array: "Arr" }
+      })
       expect(result).toEqual({
         _tag: "NamespaceImport",
         fileName: toFilename("effect/Array"),
@@ -159,7 +162,10 @@ describe("autoimport", () => {
       expect(result).toBeUndefined()
     })
     it("import { Array as Arr } from 'effect/Array'", () => {
-      const { result, toFilename } = testAutoImport("fromIterable", "effect/Array", { barrelImportPackages: ["effect"], importAliases: { Array: "Arr" } })
+      const { result, toFilename } = testAutoImport("fromIterable", "effect/Array", {
+        barrelImportPackages: ["effect"],
+        importAliases: { Array: "Arr" }
+      })
       expect(result).toEqual({
         _tag: "NamedImport",
         fileName: toFilename("effect"),


### PR DESCRIPTION
## Summary
- Added support for `importAliases` configuration option to allow custom import name aliases (e.g., importing `Array` as `Arr`)
- Enhanced auto-import metadata handling to respect the configured aliases
- Added comprehensive tests for the new functionality

## Example
With configuration:
```json
{
  "importAliases": { "Array": "Arr" }
}
```

Auto-imports will generate:
```typescript
import { Array as Arr } from "effect"
```

## Test plan
- [x] All existing tests pass
- [x] Added new tests for importAliases functionality
- [x] Manual testing with various alias configurations

Closes #362 

🤖 Generated with [Claude Code](https://claude.ai/code)