### PR TITLE
refactor: use TypeScript API helpers for identifier text extraction

### DIFF
--- a/.changeset/use-typescript-api-helpers.md
+++ b/.changeset/use-typescript-api-helpers.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Replace direct `.text` property access with TypeScript API helper `ts.idText()` for getting identifier text from nodes. This is a more robust approach that properly handles escaped identifiers and follows TypeScript's recommended practices.

--- a/src/completions/effectDataClasses.ts
+++ b/src/completions/effectDataClasses.ts
@@ -21,8 +21,8 @@ export const effectDataClasses = LSP.createCompletion({
     ) || "Data"
 
     // ensure accessed is an identifier
-    if (effectDataIdentifier !== accessedObject.text) return []
-    const name = className.text
+    if (effectDataIdentifier !== ts.idText(accessedObject)) return []
+    const name = ts.idText(className)
 
     return [{
       name: `TaggedError("${name}")`,

--- a/src/completions/effectSchemaSelfInClasses.ts
+++ b/src/completions/effectSchemaSelfInClasses.ts
@@ -21,8 +21,8 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
     ) || "Schema"
 
     // ensure accessed is an identifier
-    if (schemaIdentifier !== accessedObject.text) return []
-    const name = className.text
+    if (schemaIdentifier !== ts.idText(accessedObject)) return []
+    const name = ts.idText(className)
 
     return [{
       name: `Class<${name}>`,

--- a/src/completions/effectSelfInClasses.ts
+++ b/src/completions/effectSelfInClasses.ts
@@ -21,8 +21,8 @@ export const effectSelfInClasses = LSP.createCompletion({
     ) || "Effect"
 
     // ensure accessed is an identifier
-    if (effectIdentifier !== accessedObject.text) return []
-    const name = className.text
+    if (effectIdentifier !== ts.idText(accessedObject)) return []
+    const name = ts.idText(className)
 
     return [{
       name: `Service<${name}>`,

--- a/src/completions/fnFunctionStar.ts
+++ b/src/completions/fnFunctionStar.ts
@@ -30,7 +30,7 @@ export const fnFunctionStar = LSP.createCompletion({
     const maybeFnName: Array<LSP.CompletionEntryDefinition> = pipe(
       tsUtils.getAncestorNodesInRange(sourceFile, tsUtils.toTextRange(accessedObject.pos)),
       Array.filter(ts.isVariableDeclaration),
-      Array.map((_) => _.name && ts.isIdentifier(_.name) ? _.name.text : ""),
+      Array.map((_) => _.name && ts.isIdentifier(_.name) ? ts.idText(_.name) : ""),
       Array.filter((_) => _.length > 0),
       Array.head,
       Option.map((name) => [

--- a/src/completions/rpcMakeClasses.ts
+++ b/src/completions/rpcMakeClasses.ts
@@ -21,8 +21,8 @@ export const rpcMakeClasses = LSP.createCompletion({
     ) || "Rpc"
 
     // ensure accessed is an identifier
-    if (rpcIdentifier !== accessedObject.text) return []
-    const name = className.text
+    if (rpcIdentifier !== ts.idText(accessedObject)) return []
+    const name = ts.idText(className)
 
     return [{
       name: `make("${name}")`,

--- a/src/completions/schemaBrand.ts
+++ b/src/completions/schemaBrand.ts
@@ -24,7 +24,7 @@ export const schemaBrand = LSP.createCompletion({
       "Schema"
     ) || "Schema"
 
-    if (schemaName !== accessedObject.text) return []
+    if (schemaName !== ts.idText(accessedObject)) return []
 
     const span = ts.createTextSpan(
       accessedObject.end + 1,
@@ -34,7 +34,7 @@ export const schemaBrand = LSP.createCompletion({
     return pipe(
       tsUtils.getAncestorNodesInRange(sourceFile, tsUtils.toTextRange(accessedObject.pos)),
       Array.filter(ts.isVariableDeclaration),
-      Array.map((_) => _.name && ts.isIdentifier(_.name) ? _.name.text : ""),
+      Array.map((_) => _.name && ts.isIdentifier(_.name) ? ts.idText(_.name) : ""),
       Array.filter((_) => _.length > 0),
       Array.head,
       Option.map((name) => [

--- a/src/core/AutoImport.ts
+++ b/src/core/AutoImport.ts
@@ -78,7 +78,7 @@ export const makeAutoImportProvider: (
         namespaceExports.push({
           moduleSpecifier,
           exportClause,
-          name: exportClause.name.text
+          name: ts.idText(exportClause.name)
         })
       }
       if (ts.isNamedExports(exportClause)) {
@@ -89,8 +89,8 @@ export const makeAutoImportProvider: (
           namedExports.push({
             moduleSpecifier,
             exportClause,
-            name: exportName.text,
-            aliasName: exportSpecifier.name.text
+            name: ts.idText(exportName),
+            aliasName: ts.idText(exportSpecifier.name)
           })
         }
       }
@@ -396,7 +396,7 @@ export const parseImportOnlyChanges = Nano.fn("parseImportOnlyChanges")(function
           if (ts.isNamedImports(namedBindings)) {
             for (const importSpecifier of namedBindings.elements) {
               if (!ts.isIdentifier(importSpecifier.name)) return
-              const exportName = importSpecifier.name.text
+              const exportName = ts.idText(importSpecifier.name)
               imports.push({ moduleName, exportName })
               continue
             }
@@ -484,10 +484,11 @@ export const addImport = (
               const namedImports = importClause.namedBindings
               const existingImportSpecifier = namedImports.elements.find((element) => {
                 if (effectAutoImport.aliasName) {
-                  return element.name.text === effectAutoImport.name &&
-                    element.propertyName?.text === effectAutoImport.aliasName
+                  return ts.idText(element.name) === effectAutoImport.name && element.propertyName &&
+                    ts.isIdentifier(element.propertyName) &&
+                    ts.idText(element.propertyName) === effectAutoImport.aliasName
                 }
-                return element.name.text === effectAutoImport.name
+                return ts.idText(element.name) === effectAutoImport.name
               })
               // the import already exists, we can exit
               if (existingImportSpecifier) {

--- a/src/core/TypeParser.ts
+++ b/src/core/TypeParser.ts
@@ -581,7 +581,7 @@ export function make(
       }
       const propertyAccess = node.expression
       // gen
-      if (propertyAccess.name.text !== "gen") {
+      if (!(ts.isIdentifier(propertyAccess.name) && ts.idText(propertyAccess.name) === "gen")) {
         return typeParserIssue("Call expression name is not 'gen'", undefined, node)
       }
       // check Effect module
@@ -632,7 +632,7 @@ export function make(
       }
       const propertyAccess = node.expression
       // gen
-      if (propertyAccess.name.text !== "fnUntraced") {
+      if (!(ts.isIdentifier(propertyAccess.name) && ts.idText(propertyAccess.name) === "fnUntraced")) {
         return typeParserIssue(
           "Call expression name is not 'fnUntraced'",
           undefined,
@@ -694,7 +694,7 @@ export function make(
       }
       const propertyAccess = expressionToTest
       // fn
-      if (propertyAccess.name.text !== "fn") {
+      if (!(ts.isIdentifier(propertyAccess.name) && ts.idText(propertyAccess.name) === "fn")) {
         return typeParserIssue(
           "Call expression name is not 'fn'",
           undefined,
@@ -905,7 +905,7 @@ export function make(
 
       // pipe(A, B, ...)
       if (
-        ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "pipe" &&
+        ts.isCallExpression(node) && ts.isIdentifier(node.expression) && ts.idText(node.expression) === "pipe" &&
         node.arguments.length > 0
       ) {
         const [subject, ...args] = node.arguments

--- a/src/core/TypeScriptApi.ts
+++ b/src/core/TypeScriptApi.ts
@@ -145,6 +145,11 @@ declare module "typescript" {
   export interface TypeChecker {
     getUnionType(types: ReadonlyArray<ts.Type>): ts.Type
   }
+
+  interface Identifier {
+    /** @deprecated Use the `ts.idText(node)` method instead */
+    readonly text: string
+  }
 }
 
 type _TypeScriptApi = typeof ts

--- a/src/core/TypeScriptUtils.ts
+++ b/src/core/TypeScriptUtils.ts
@@ -381,7 +381,7 @@ export function makeTypeScriptUtils(ts: TypeScriptApi.TypeScriptApi): TypeScript
       fnCall = ts.factory.createCallExpression(
         fnCall,
         undefined,
-        [ts.factory.createStringLiteral(fnName.text)]
+        [ts.factory.createStringLiteral(ts.idText(fnName))]
       )
     }
     return tryPreserveDeclarationSemantics(
@@ -473,7 +473,7 @@ export function makeTypeScriptUtils(ts: TypeScriptApi.TypeScriptApi): TypeScript
       if (!namedBindings) continue
       if (ts.isNamespaceImport(namedBindings)) {
         if (test(namedBindings.name, statement.moduleSpecifier, Option.none())) {
-          return (namedBindings.name.text)
+          return ts.idText(namedBindings.name)
         }
       } else if (ts.isNamedImports(namedBindings)) {
         for (const importSpecifier of namedBindings.elements) {
@@ -481,7 +481,7 @@ export function makeTypeScriptUtils(ts: TypeScriptApi.TypeScriptApi): TypeScript
             Option.orElse(() => Option.some(importSpecifier.name))
           )
           if (test(importSpecifier.name, statement.moduleSpecifier, importProperty)) {
-            return (importSpecifier.name.text)
+            return ts.idText(importSpecifier.name)
           }
         }
       }
@@ -508,7 +508,7 @@ export function makeTypeScriptUtils(ts: TypeScriptApi.TypeScriptApi): TypeScript
         // import { Module as M } from "package"
         if (
           Option.isSome(importProperty) && ts.isIdentifier(importProperty.value) &&
-          importProperty.value.text === moduleName && ts.isStringLiteral(fromModule) &&
+          ts.idText(importProperty.value) === moduleName && ts.isStringLiteral(fromModule) &&
           fromModule.text === packageName
         ) {
           return true

--- a/src/goto/effectRpcDefinition.ts
+++ b/src/goto/effectRpcDefinition.ts
@@ -26,14 +26,15 @@ export function effectRpcDefinition(
 
     function isSymbolFromEffectRpcModule(symbol: ts.Symbol) {
       if (symbol.valueDeclaration) {
-        const sourceFile = symbol.valueDeclaration.getSourceFile()
-
-        const packageInfo = tsUtils.parsePackageContentNameAndVersionFromScope(sourceFile)
-        if (packageInfo && packageInfo.name === "@effect/rpc") {
-          const fileSymbol = typeChecker.getSymbolAtLocation(sourceFile)
-          return fileSymbol && fileSymbol.exports && fileSymbol.exports.has("isRpc" as any) &&
-            fileSymbol.exports.has("make" as any) &&
-            fileSymbol.exports.has("fromTaggedRequest" as any)
+        const sourceFile = tsUtils.getSourceFileOfNode(symbol.valueDeclaration)
+        if (sourceFile) {
+          const packageInfo = tsUtils.parsePackageContentNameAndVersionFromScope(sourceFile)
+          if (packageInfo && packageInfo.name === "@effect/rpc") {
+            const fileSymbol = typeChecker.getSymbolAtLocation(sourceFile)
+            return fileSymbol && fileSymbol.exports && fileSymbol.exports.has("isRpc" as any) &&
+              fileSymbol.exports.has("make" as any) &&
+              fileSymbol.exports.has("fromTaggedRequest" as any)
+          }
         }
       }
       return false
@@ -41,13 +42,14 @@ export function effectRpcDefinition(
 
     function isSymbolFromEffectRpcClientModule(symbol: ts.Symbol) {
       if (symbol.valueDeclaration) {
-        const sourceFile = symbol.valueDeclaration.getSourceFile()
-
-        const packageInfo = tsUtils.parsePackageContentNameAndVersionFromScope(sourceFile)
-        if (packageInfo && packageInfo.name === "@effect/rpc") {
-          const fileSymbol = typeChecker.getSymbolAtLocation(sourceFile)
-          return fileSymbol && fileSymbol.exports && fileSymbol.exports.has("RpcClient" as any) &&
-            fileSymbol.exports.has("make" as any)
+        const sourceFile = tsUtils.getSourceFileOfNode(symbol.valueDeclaration)
+        if (sourceFile) {
+          const packageInfo = tsUtils.parsePackageContentNameAndVersionFromScope(sourceFile)
+          if (packageInfo && packageInfo.name === "@effect/rpc") {
+            const fileSymbol = typeChecker.getSymbolAtLocation(sourceFile)
+            return fileSymbol && fileSymbol.exports && fileSymbol.exports.has("RpcClient" as any) &&
+              fileSymbol.exports.has("make" as any)
+          }
         }
       }
       return false
@@ -66,7 +68,7 @@ export function effectRpcDefinition(
         for (const callSig of typeChecker.getSignaturesOfType(type, ts.SignatureKind.Call)) {
           // we detect if it is an RPC api based on where the options simbol is declared from
           if (callSig.parameters.length >= 2 && isSymbolFromEffectRpcClientModule(callSig.parameters[1])) {
-            rpcName = node.name.text
+            rpcName = ts.idText(node.name)
             callNode = node.name
           }
         }
@@ -109,7 +111,7 @@ export function effectRpcDefinition(
         if (
           ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression) &&
           ts.isIdentifier(node.expression.name) &&
-          (node.expression.name.text === "make" || node.expression.name.text === "fromTaggedRequest")
+          (ts.idText(node.expression.name) === "make" || ts.idText(node.expression.name) === "fromTaggedRequest")
         ) {
           const symbol = typeChecker.getSymbolAtLocation(node.expression.name)
           if (symbol && isSymbolFromEffectRpcModule(symbol)) {

--- a/src/refactors/effectGenToFn.ts
+++ b/src/refactors/effectGenToFn.ts
@@ -66,7 +66,7 @@ export const effectGenToFn = LSP.createRefactor({
 
     return ({
       kind: "refactor.rewrite.effect.effectGenToFn",
-      description: fnIdentifier ? `Convert to Effect.fn("${fnIdentifier.text}")` : "Convert to Effect.fn",
+      description: fnIdentifier ? `Convert to Effect.fn("${ts.idText(fnIdentifier)}")` : "Convert to Effect.fn",
       apply: pipe(
         Nano.gen(function*() {
           const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
@@ -80,7 +80,7 @@ export const effectGenToFn = LSP.createRefactor({
                 "fn"
               ),
               undefined,
-              [ts.factory.createStringLiteral(fnIdentifier.text)]
+              [ts.factory.createStringLiteral(ts.idText(fnIdentifier))]
             ) :
             ts.factory.createPropertyAccessExpression(
               effectModule,

--- a/src/refactors/makeSchemaOpaque.ts
+++ b/src/refactors/makeSchemaOpaque.ts
@@ -172,15 +172,15 @@ export const makeSchemaOpaque = LSP.createRefactor({
             "Schema"
           ) || "Schema"
 
-          const newIdentifier = ts.factory.createIdentifier(identifier.text + "_")
+          const newIdentifier = ts.factory.createIdentifier(ts.idText(identifier) + "_")
           const { contextType, encodedType, opaqueType } = yield* _createOpaqueTypes(
             effectSchemaName,
-            newIdentifier.text,
+            ts.idText(newIdentifier),
             types.A,
-            identifier.text,
+            ts.idText(identifier),
             types.I,
-            identifier.text + "Encoded",
-            identifier.text + "Context"
+            ts.idText(identifier) + "Encoded",
+            ts.idText(identifier) + "Context"
           )
 
           changeTracker.replaceNode(
@@ -208,10 +208,10 @@ export const makeSchemaOpaque = LSP.createRefactor({
             variableStatement.modifiers,
             ts.factory.createVariableDeclarationList(
               [ts.factory.createVariableDeclaration(
-                identifier.text,
+                ts.idText(identifier),
                 undefined,
                 newSchemaType,
-                ts.factory.createIdentifier(newIdentifier.text)
+                ts.factory.createIdentifier(ts.idText(newIdentifier))
               )],
               variableDeclarationList.flags
             )

--- a/src/refactors/makeSchemaOpaqueWithNs.ts
+++ b/src/refactors/makeSchemaOpaqueWithNs.ts
@@ -29,12 +29,12 @@ export const makeSchemaOpaqueWithNs = LSP.createRefactor({
             "Schema"
           ) || "Schema"
 
-          const newIdentifier = ts.factory.createIdentifier(identifier.text + "_")
+          const newIdentifier = ts.factory.createIdentifier(ts.idText(identifier) + "_")
           const { contextType, encodedType, opaqueType } = yield* _createOpaqueTypes(
             effectSchemaName,
-            newIdentifier.text,
+            ts.idText(newIdentifier),
             types.A,
-            identifier.text,
+            ts.idText(identifier),
             types.I,
             "Encoded",
             "Context"
@@ -42,7 +42,7 @@ export const makeSchemaOpaqueWithNs = LSP.createRefactor({
 
           const namespace = ts.factory.createModuleDeclaration(
             [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-            ts.factory.createIdentifier(identifier.text),
+            ts.factory.createIdentifier(ts.idText(identifier)),
             ts.factory.createModuleBlock([
               encodedType,
               contextType
@@ -58,6 +58,8 @@ export const makeSchemaOpaqueWithNs = LSP.createRefactor({
           changeTracker.insertNodeAfter(sourceFile, variableStatement, opaqueType)
           changeTracker.insertNodeAfter(sourceFile, variableStatement, namespace)
 
+          const namespaceName = ts.isStringLiteral(namespace.name) ? namespace.name.text : ts.idText(namespace.name)
+
           // insert new declaration
           const newSchemaType = ts.factory.createTypeReferenceNode(
             ts.factory.createQualifiedName(
@@ -68,13 +70,15 @@ export const makeSchemaOpaqueWithNs = LSP.createRefactor({
               ts.factory.createTypeReferenceNode(opaqueType.name),
               ts.factory.createTypeReferenceNode(
                 ts.factory.createQualifiedName(
-                  ts.factory.createIdentifier(namespace.name.text),
-                  encodedType.name
+                  ts.factory.createIdentifier(
+                    namespaceName
+                  ),
+                  ts.idText(encodedType.name)
                 )
               ),
               ts.factory.createTypeReferenceNode(ts.factory.createQualifiedName(
-                ts.factory.createIdentifier(namespace.name.text),
-                contextType.name
+                ts.factory.createIdentifier(namespaceName),
+                ts.idText(contextType.name)
               ))
             ]
           )
@@ -82,10 +86,10 @@ export const makeSchemaOpaqueWithNs = LSP.createRefactor({
             variableStatement.modifiers,
             ts.factory.createVariableDeclarationList(
               [ts.factory.createVariableDeclaration(
-                identifier.text,
+                ts.idText(identifier),
                 undefined,
                 newSchemaType,
-                ts.factory.createIdentifier(newIdentifier.text)
+                ts.factory.createIdentifier(ts.idText(newIdentifier))
               )],
               variableDeclarationList.flags
             )

--- a/src/refactors/pipeableToDatafirst.ts
+++ b/src/refactors/pipeableToDatafirst.ts
@@ -20,7 +20,7 @@ export const pipeableToDatafirst = LSP.createRefactor({
       if (!ts.isCallExpression(node)) return false
       const expression = node.expression
       if (!ts.isIdentifier(expression)) return false
-      if (expression.text !== "pipe") return false
+      if (ts.idText(expression) !== "pipe") return false
       return true
     }
 

--- a/src/refactors/writeTagClassAccessors.ts
+++ b/src/refactors/writeTagClassAccessors.ts
@@ -41,7 +41,7 @@ export const generate = Nano.fn("writeTagClassAccessors.generate")(function*(
       ),
       undefined,
       [
-        ts.factory.createIdentifier(className.text),
+        ts.factory.createIdentifier(ts.idText(className)),
         ts.factory.createArrowFunction(
           undefined,
           undefined,
@@ -95,10 +95,10 @@ export const generate = Nano.fn("writeTagClassAccessors.generate")(function*(
       Nano.flatMap((returnedEffect) => {
         // the type is an effect, so we just need to add the service type to the context type
         const contextType = (returnedEffect.R.flags & ts.TypeFlags.Never) ?
-          ts.factory.createTypeReferenceNode(className.text) :
+          ts.factory.createTypeReferenceNode(ts.idText(className)) :
           ts.factory.createUnionTypeNode(
             [
-              ts.factory.createTypeReferenceNode(className.text),
+              ts.factory.createTypeReferenceNode(ts.idText(className)),
               typeChecker.typeToTypeNode(returnedEffect.R, atLocation, ts.NodeBuilderFlags.NoTruncation)!
             ]
           )
@@ -149,7 +149,7 @@ export const generate = Nano.fn("writeTagClassAccessors.generate")(function*(
                     ts.factory.createIdentifier("UnknownException")
                   )
                 ),
-                ts.factory.createTypeReferenceNode(className.text)
+                ts.factory.createTypeReferenceNode(ts.idText(className))
               ]
             ))
           })
@@ -167,7 +167,7 @@ export const generate = Nano.fn("writeTagClassAccessors.generate")(function*(
           [
             successType,
             ts.factory.createTypeReferenceNode("never"),
-            ts.factory.createTypeReferenceNode(className.text)
+            ts.factory.createTypeReferenceNode(ts.idText(className))
           ]
         )
 
@@ -265,7 +265,7 @@ export const parse = Nano.fn("writeTagClassAccessors.parse")(function*(node: ts.
 
   const hash = involvedMembers.map(({ property, propertyType }) => {
     return ts.symbolName(property) + ": " + typeChecker.typeToString(propertyType)
-  }).concat([className.text]).join("\n")
+  }).concat([ts.idText(className)]).join("\n")
 
   return { Service, className, atLocation: node, hash: LSP.cyrb53(hash), involvedMembers }
 })

--- a/src/renames/keyStrings.ts
+++ b/src/renames/keyStrings.ts
@@ -22,7 +22,7 @@ export const renameKeyStrings = (
 
     const node = tsUtils.findNodeAtPositionIncludingTrivia(sourceFile, position)
     if (node && ts.isIdentifier(node)) {
-      const textToReplace = node.text
+      const textToReplace = ts.idText(node)
       const parentClass = node.parent
       if (ts.isClassDeclaration(parentClass) && parentClass.name === node) {
         const baseIdentifier = yield* pipe(


### PR DESCRIPTION
## Summary
- Replace direct `.text` property access with `ts.idText()` for getting identifier text from TypeScript nodes
- Follows TypeScript's recommended practices for working with identifiers
- Ensures proper handling of escaped identifiers

## Test plan
- [x] All existing tests pass
- [x] No changes to test snapshots (regenerated to verify)
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)