### PR TITLE
Add shebang to CLI entry point

### DIFF
--- a/.changeset/cli-shebang-update.md
+++ b/.changeset/cli-shebang-update.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add shebang to CLI entry point for proper executable support and bump version

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import * as Command from "@effect/cli/Command"
 import * as NodeContext from "@effect/platform-node/NodeContext"
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
@@ -15,7 +17,7 @@ const cliCommand = Command.make(
 
 const main = Command.run(cliCommand, {
   name: "effect-language-service",
-  version: "0.0.1"
+  version: "0.0.2"
 })
 
 main(process.argv).pipe(


### PR DESCRIPTION
## Summary
- Add `#!/usr/bin/env node` shebang to `src/cli.ts` for proper executable support
- Update CLI version from 0.0.1 to 0.0.2

## Example
The shebang allows the CLI to be executed directly as a script when installed globally or through npx:
```bash
#!/usr/bin/env node
```

## Test plan
- [x] All existing tests pass
- [x] No snapshot changes (verified)
- [x] Type checks pass
- [x] Linting passes