### PR TITLE
Show previously provided layers as comment in Layer Magic refactor

### DIFF
--- a/.changeset/layer-magic-unused-comment.md
+++ b/.changeset/layer-magic-unused-comment.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Layer Magic refactor now shows previously provided layers as a comment in the generated type annotation.
+
+When using the Layer Magic "Prepare for reuse" refactor, layers that were already provided at the location are now shown as a trailing comment (e.g., `/* Foo | Bar */`) next to the newly introduced layer types. This helps developers understand which layers were already available and which ones are being newly introduced.

--- a/examples/refactors/layerMagic_prepareReuse.ts
+++ b/examples/refactors/layerMagic_prepareReuse.ts
@@ -1,0 +1,27 @@
+// 17:20,23:20
+import { Effect, Layer, pipe } from "effect"
+
+class DbConnection extends Effect.Service<DbConnection>()("DbConnection", {
+  succeed: {}
+}) {}
+class FileSystem extends Effect.Service<FileSystem>()("FileSystem", {
+  succeed: {}
+}) {}
+class Cache extends Effect.Service<Cache>()("Cache", {
+  effect: Effect.as(FileSystem, {})
+}) {}
+class UserRepository extends Effect.Service<UserRepository>()("UserRepository", {
+  effect: Effect.as(Effect.zipRight(DbConnection, Cache), {})
+}) {}
+
+export const prepareUser_commentCache = pipe(
+  UserRepository.Default,
+  Layer.provide(Cache.Default),
+  Layer.provide(FileSystem.Default)
+)
+
+export const prepareUserCache = pipe(
+  UserRepository.Default,
+  Layer.provideMerge(Cache.Default),
+  Layer.provide(FileSystem.Default)
+)

--- a/src/core/Nano.ts
+++ b/src/core/Nano.ts
@@ -349,11 +349,11 @@ const MatchProto: NanoPrimitive = {
   }
 }
 
-export const match = <A, B, E, R, C, E2, R2, E3, R3>(
+const match = <A, B, E, R, C, E2, R2, E3, R3>(
   fa: Nano<A, E, R>,
   opts: {
     onSuccess: (a: A) => Nano<B, E2, R2>
-    onFailure: (e: E) => Nano<C, E3, R3>
+    onFailure: (e: E | NanoDefectException) => Nano<C, E3, R3>
   }
 ): Nano<B, E | E2 | E3, R | R2 | R3> => {
   const nano = Object.create(MatchProto)
@@ -369,7 +369,7 @@ export const orElse = <E, B, E2, R2>(
 <A, R>(fa: Nano<A, E, R>): Nano<A | B, E2, R | R2> => {
   const nano = Object.create(MatchProto)
   nano[args] = fa
-  nano[contE] = f
+  nano[contE] = (_: E | NanoDefectException) => _ instanceof NanoDefectException ? fail(_) : f(_)
   return nano
 }
 
@@ -480,6 +480,14 @@ export const ignore = <A, E, R>(fa: Nano<A, E, R>): Nano<void, never, R> => {
   nano[args] = fa
   nano[contA] = (_: A) => void_
   nano[contE] = (_: E | NanoDefectException) => _ instanceof NanoDefectException ? fail(_) : void_
+  return nano
+}
+
+export const swap = <A, E, R>(fa: Nano<A, E, R>): Nano<E, A, R> => {
+  const nano = Object.create(MatchProto)
+  nano[args] = fa
+  nano[contA] = (_: A) => fail(_)
+  nano[contE] = (_: E | NanoDefectException) => _ instanceof NanoDefectException ? fail(_) : succeed(_)
   return nano
 }
 

--- a/test/__snapshots__/refactors/layerMagic_prepareReuse.ts.ln17col20.output
+++ b/test/__snapshots__/refactors/layerMagic_prepareReuse.ts.ln17col20.output
@@ -1,0 +1,23 @@
+// Result of running refactor layerMagic at position 17:20
+import { Effect, Layer, pipe } from "effect"
+
+class DbConnection extends Effect.Service<DbConnection>()("DbConnection", {
+  succeed: {}
+}) {}
+class FileSystem extends Effect.Service<FileSystem>()("FileSystem", {
+  succeed: {}
+}) {}
+class Cache extends Effect.Service<Cache>()("Cache", {
+  effect: Effect.as(FileSystem, {})
+}) {}
+class UserRepository extends Effect.Service<UserRepository>()("UserRepository", {
+  effect: Effect.as(Effect.zipRight(DbConnection, Cache), {})
+}) {}
+
+export const prepareUser_commentCache =[UserRepository.Default, Cache.Default, FileSystem.Default] as any as Layer.Layer<UserRepository /* Cache | FileSystem */>
+
+export const prepareUserCache = pipe(
+  UserRepository.Default,
+  Layer.provideMerge(Cache.Default),
+  Layer.provide(FileSystem.Default)
+)

--- a/test/__snapshots__/refactors/layerMagic_prepareReuse.ts.ln23col20.output
+++ b/test/__snapshots__/refactors/layerMagic_prepareReuse.ts.ln23col20.output
@@ -1,0 +1,23 @@
+// Result of running refactor layerMagic at position 23:20
+import { Effect, Layer, pipe } from "effect"
+
+class DbConnection extends Effect.Service<DbConnection>()("DbConnection", {
+  succeed: {}
+}) {}
+class FileSystem extends Effect.Service<FileSystem>()("FileSystem", {
+  succeed: {}
+}) {}
+class Cache extends Effect.Service<Cache>()("Cache", {
+  effect: Effect.as(FileSystem, {})
+}) {}
+class UserRepository extends Effect.Service<UserRepository>()("UserRepository", {
+  effect: Effect.as(Effect.zipRight(DbConnection, Cache), {})
+}) {}
+
+export const prepareUser_commentCache = pipe(
+  UserRepository.Default,
+  Layer.provide(Cache.Default),
+  Layer.provide(FileSystem.Default)
+)
+
+export const prepareUserCache =[UserRepository.Default, Cache.Default, FileSystem.Default] as any as Layer.Layer<Cache | UserRepository /* FileSystem */>


### PR DESCRIPTION
## Summary
- Enhanced Layer Magic "Prepare for reuse" refactor to show previously provided layers as trailing comments
- Added logic to partition layers into existing/newly-introduced based on what's already provided at the location
- Improved Nano error handling to properly propagate defect exceptions

## Test plan
- [x] Added new test case `layerMagic_prepareReuse.ts` with examples showing the comment functionality
- [x] All existing tests pass
- [x] Generated snapshots verified to show expected comment output

🤖 Generated with [Claude Code](https://claude.ai/code)