### PR TITLE
Add support for Effect.Tag in diagnostics and refactors

### DIFF
--- a/.changeset/yummy-roses-notice.md
+++ b/.changeset/yummy-roses-notice.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add general support for Effect.Tag in various diagnostics/refactors

--- a/examples/diagnostics/classSelfMismatch_effectTag.ts
+++ b/examples/diagnostics/classSelfMismatch_effectTag.ts
@@ -1,0 +1,11 @@
+import * as Effect from "effect/Effect"
+
+interface ServiceShape {
+  value: number
+}
+
+// valid usage: <ValidContextTag, ServiceShape> is correct because the Self type parameter is the same as the class name
+export class ValidContextTag extends Effect.Tag("ValidContextTag")<ValidContextTag, ServiceShape>() {}
+
+// invalid usage: <ValidContextTag, ServiceShape> should be <InvalidContextTag, ServiceShape> because the Self type parameter is not the same as the class name
+export class InvalidContextTag extends Effect.Tag("ValidContextTag")<ValidContextTag, ServiceShape>() {}

--- a/examples/diagnostics/unsupportedServiceAccessors_effectTag.ts
+++ b/examples/diagnostics/unsupportedServiceAccessors_effectTag.ts
@@ -1,0 +1,45 @@
+import * as Effect from "effect/Effect"
+
+export class ValidService extends Effect.Tag("ValidService")<ValidService, {
+  constant: Effect.Effect<string, never, never>
+  method: (value: string) => Effect.Effect<string, never, never>
+}>() {
+}
+
+export class ValidServiceBecauseManuallyDefined
+  extends Effect.Tag("ValidServiceBecauseManuallyDefined")<ValidServiceBecauseManuallyDefined, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined>
+  }>()
+{
+  static method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined> = (...args) =>
+    Effect.andThen(ValidServiceBecauseManuallyDefined, (_) => _.method(...args))
+}
+
+// should warn because method has generics
+export class ShouldWarnMethodWithGenerics
+  extends Effect.Tag("ShouldWarnMethodWithGenerics")<ShouldWarnMethodWithGenerics, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A, _test: string) => Effect.Effect<A, never, ShouldWarnMethodWithGenerics>
+  }>()
+{
+}
+
+// should warn because method has multiple signatures with different return types
+export class ShouldWarnMethodWithMultipleSignatures
+  extends Effect.Tag("ShouldWarnMethodWithMultipleSignatures")<ShouldWarnMethodWithMultipleSignatures, {
+    constant: Effect.Effect<string, never, never>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string
+    ): Effect.Effect<string, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts: { discard: true }
+    ): Effect.Effect<void, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts?: { discard: true }
+    ): Effect.Effect<string | void>
+  }>()
+{
+}

--- a/examples/renames/keyStrings_contextTag.ts
+++ b/examples/renames/keyStrings_contextTag.ts
@@ -1,0 +1,4 @@
+// 4:20
+import * as Context from "effect/Context"
+
+export class MyClass extends Context.Tag("MyClass")<MyClass, {}>() {}

--- a/examples/renames/keyStrings_effectTag.ts
+++ b/examples/renames/keyStrings_effectTag.ts
@@ -1,0 +1,4 @@
+// 4:20
+import * as Effect from "effect/Effect"
+
+export class MyClass extends Effect.Tag("MyClass")<MyClass, {}>() {}

--- a/src/refactors/writeTagClassAccessors.ts
+++ b/src/refactors/writeTagClassAccessors.ts
@@ -248,6 +248,7 @@ export const parse = Nano.fn("writeTagClassAccessors.parse")(function*(node: ts.
 
   const { Service, accessors, className } = yield* pipe(
     typeParser.extendsEffectService(node),
+    Nano.orElse(() => Nano.map(typeParser.extendsEffectTag(node), (_) => ({ accessors: true, ..._ }))),
     Nano.orElse(() => Nano.fail("not a class extending Effect.Service call"))
   )
 

--- a/src/renames/keyStrings.ts
+++ b/src/renames/keyStrings.ts
@@ -28,6 +28,7 @@ export const renameKeyStrings = (
         const baseIdentifier = yield* pipe(
           Nano.map(typeParser.extendsContextTag(parentClass), (_) => [_.keyStringLiteral]),
           Nano.orElse(() => Nano.map(typeParser.extendsEffectService(parentClass), (_) => [_.keyStringLiteral])),
+          Nano.orElse(() => Nano.map(typeParser.extendsEffectTag(parentClass), (_) => [_.keyStringLiteral])),
           Nano.orElse(() =>
             Nano.map(typeParser.extendsSchemaTaggedClass(parentClass), (_) => [_.keyStringLiteral, _.tagStringLiteral])
           ),

--- a/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.classSelfMismatch_fix.from539to554.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.classSelfMismatch_fix.from539to554.output
@@ -1,0 +1,12 @@
+// code fix classSelfMismatch_fix  output for range 539 - 554
+import * as Effect from "effect/Effect"
+
+interface ServiceShape {
+  value: number
+}
+
+// valid usage: <ValidContextTag, ServiceShape> is correct because the Self type parameter is the same as the class name
+export class ValidContextTag extends Effect.Tag("ValidContextTag")<ValidContextTag, ServiceShape>() {}
+
+// invalid usage: <ValidContextTag, ServiceShape> should be <InvalidContextTag, ServiceShape> because the Self type parameter is not the same as the class name
+export class InvalidContextTag extends Effect.Tag("ValidContextTag")<InvalidContextTag, ServiceShape>() {}

--- a/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.classSelfMismatch_skipFile.from539to554.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.classSelfMismatch_skipFile.from539to554.output
@@ -1,0 +1,13 @@
+// code fix classSelfMismatch_skipFile  output for range 539 - 554
+/** @effect-diagnostics classSelfMismatch:skip-file */
+import * as Effect from "effect/Effect"
+
+interface ServiceShape {
+  value: number
+}
+
+// valid usage: <ValidContextTag, ServiceShape> is correct because the Self type parameter is the same as the class name
+export class ValidContextTag extends Effect.Tag("ValidContextTag")<ValidContextTag, ServiceShape>() {}
+
+// invalid usage: <ValidContextTag, ServiceShape> should be <InvalidContextTag, ServiceShape> because the Self type parameter is not the same as the class name
+export class InvalidContextTag extends Effect.Tag("ValidContextTag")<ValidContextTag, ServiceShape>() {}

--- a/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.classSelfMismatch_skipNextLine.from539to554.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.classSelfMismatch_skipNextLine.from539to554.output
@@ -1,0 +1,13 @@
+// code fix classSelfMismatch_skipNextLine  output for range 539 - 554
+import * as Effect from "effect/Effect"
+
+interface ServiceShape {
+  value: number
+}
+
+// valid usage: <ValidContextTag, ServiceShape> is correct because the Self type parameter is the same as the class name
+export class ValidContextTag extends Effect.Tag("ValidContextTag")<ValidContextTag, ServiceShape>() {}
+
+// invalid usage: <ValidContextTag, ServiceShape> should be <InvalidContextTag, ServiceShape> because the Self type parameter is not the same as the class name
+// @effect-diagnostics-next-line classSelfMismatch:off
+export class InvalidContextTag extends Effect.Tag("ValidContextTag")<ValidContextTag, ServiceShape>() {}

--- a/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.codefixes
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.codefixes
@@ -1,0 +1,3 @@
+classSelfMismatch_fix from 539 to 554
+classSelfMismatch_skipNextLine from 539 to 554
+classSelfMismatch_skipFile from 539 to 554

--- a/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.output
@@ -1,0 +1,2 @@
+ValidContextTag
+11:69 - 11:84 | 1 | Self type parameter should be 'InvalidContextTag'

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.codefixes
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.codefixes
@@ -1,0 +1,6 @@
+unsupportedServiceAccessors_enableCodegen from 783 to 811
+unsupportedServiceAccessors_skipNextLine from 783 to 811
+unsupportedServiceAccessors_skipFile from 783 to 811
+unsupportedServiceAccessors_enableCodegen from 1152 to 1190
+unsupportedServiceAccessors_skipNextLine from 1152 to 1190
+unsupportedServiceAccessors_skipFile from 1152 to 1190

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.output
@@ -1,0 +1,5 @@
+ShouldWarnMethodWithGenerics
+20:13 - 20:41 | 0 | Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.
+
+ShouldWarnMethodWithMultipleSignatures
+29:13 - 29:51 | 0 | Even if accessors are enabled, accessors for 'methodWithMultipleSignaturesNoGenerics' won't be available because the signature have generic type parameters or multiple call signatures.

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_enableCodegen.from1152to1190.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_enableCodegen.from1152to1190.output
@@ -1,0 +1,47 @@
+// code fix unsupportedServiceAccessors_enableCodegen  output for range 1152 - 1190
+import * as Effect from "effect/Effect"
+
+export class ValidService extends Effect.Tag("ValidService")<ValidService, {
+  constant: Effect.Effect<string, never, never>
+  method: (value: string) => Effect.Effect<string, never, never>
+}>() {
+}
+
+export class ValidServiceBecauseManuallyDefined
+  extends Effect.Tag("ValidServiceBecauseManuallyDefined")<ValidServiceBecauseManuallyDefined, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined>
+  }>()
+{
+  static method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined> = (...args) =>
+    Effect.andThen(ValidServiceBecauseManuallyDefined, (_) => _.method(...args))
+}
+
+// should warn because method has generics
+export class ShouldWarnMethodWithGenerics
+  extends Effect.Tag("ShouldWarnMethodWithGenerics")<ShouldWarnMethodWithGenerics, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A, _test: string) => Effect.Effect<A, never, ShouldWarnMethodWithGenerics>
+  }>()
+{
+}
+
+// should warn because method has multiple signatures with different return types
+// @effect-codegens accessors
+export class ShouldWarnMethodWithMultipleSignatures
+  extends Effect.Tag("ShouldWarnMethodWithMultipleSignatures")<ShouldWarnMethodWithMultipleSignatures, {
+    constant: Effect.Effect<string, never, never>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string
+    ): Effect.Effect<string, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts: { discard: true }
+    ): Effect.Effect<void, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts?: { discard: true }
+    ): Effect.Effect<string | void>
+  }>()
+{
+}

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_enableCodegen.from783to811.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_enableCodegen.from783to811.output
@@ -1,0 +1,47 @@
+// code fix unsupportedServiceAccessors_enableCodegen  output for range 783 - 811
+import * as Effect from "effect/Effect"
+
+export class ValidService extends Effect.Tag("ValidService")<ValidService, {
+  constant: Effect.Effect<string, never, never>
+  method: (value: string) => Effect.Effect<string, never, never>
+}>() {
+}
+
+export class ValidServiceBecauseManuallyDefined
+  extends Effect.Tag("ValidServiceBecauseManuallyDefined")<ValidServiceBecauseManuallyDefined, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined>
+  }>()
+{
+  static method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined> = (...args) =>
+    Effect.andThen(ValidServiceBecauseManuallyDefined, (_) => _.method(...args))
+}
+
+// should warn because method has generics
+// @effect-codegens accessors
+export class ShouldWarnMethodWithGenerics
+  extends Effect.Tag("ShouldWarnMethodWithGenerics")<ShouldWarnMethodWithGenerics, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A, _test: string) => Effect.Effect<A, never, ShouldWarnMethodWithGenerics>
+  }>()
+{
+}
+
+// should warn because method has multiple signatures with different return types
+export class ShouldWarnMethodWithMultipleSignatures
+  extends Effect.Tag("ShouldWarnMethodWithMultipleSignatures")<ShouldWarnMethodWithMultipleSignatures, {
+    constant: Effect.Effect<string, never, never>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string
+    ): Effect.Effect<string, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts: { discard: true }
+    ): Effect.Effect<void, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts?: { discard: true }
+    ): Effect.Effect<string | void>
+  }>()
+{
+}

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipFile.from1152to1190.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipFile.from1152to1190.output
@@ -1,0 +1,47 @@
+// code fix unsupportedServiceAccessors_skipFile  output for range 1152 - 1190
+/** @effect-diagnostics unsupportedServiceAccessors:skip-file */
+import * as Effect from "effect/Effect"
+
+export class ValidService extends Effect.Tag("ValidService")<ValidService, {
+  constant: Effect.Effect<string, never, never>
+  method: (value: string) => Effect.Effect<string, never, never>
+}>() {
+}
+
+export class ValidServiceBecauseManuallyDefined
+  extends Effect.Tag("ValidServiceBecauseManuallyDefined")<ValidServiceBecauseManuallyDefined, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined>
+  }>()
+{
+  static method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined> = (...args) =>
+    Effect.andThen(ValidServiceBecauseManuallyDefined, (_) => _.method(...args))
+}
+
+// should warn because method has generics
+export class ShouldWarnMethodWithGenerics
+  extends Effect.Tag("ShouldWarnMethodWithGenerics")<ShouldWarnMethodWithGenerics, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A, _test: string) => Effect.Effect<A, never, ShouldWarnMethodWithGenerics>
+  }>()
+{
+}
+
+// should warn because method has multiple signatures with different return types
+export class ShouldWarnMethodWithMultipleSignatures
+  extends Effect.Tag("ShouldWarnMethodWithMultipleSignatures")<ShouldWarnMethodWithMultipleSignatures, {
+    constant: Effect.Effect<string, never, never>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string
+    ): Effect.Effect<string, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts: { discard: true }
+    ): Effect.Effect<void, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts?: { discard: true }
+    ): Effect.Effect<string | void>
+  }>()
+{
+}

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipFile.from783to811.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipFile.from783to811.output
@@ -1,0 +1,47 @@
+// code fix unsupportedServiceAccessors_skipFile  output for range 783 - 811
+/** @effect-diagnostics unsupportedServiceAccessors:skip-file */
+import * as Effect from "effect/Effect"
+
+export class ValidService extends Effect.Tag("ValidService")<ValidService, {
+  constant: Effect.Effect<string, never, never>
+  method: (value: string) => Effect.Effect<string, never, never>
+}>() {
+}
+
+export class ValidServiceBecauseManuallyDefined
+  extends Effect.Tag("ValidServiceBecauseManuallyDefined")<ValidServiceBecauseManuallyDefined, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined>
+  }>()
+{
+  static method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined> = (...args) =>
+    Effect.andThen(ValidServiceBecauseManuallyDefined, (_) => _.method(...args))
+}
+
+// should warn because method has generics
+export class ShouldWarnMethodWithGenerics
+  extends Effect.Tag("ShouldWarnMethodWithGenerics")<ShouldWarnMethodWithGenerics, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A, _test: string) => Effect.Effect<A, never, ShouldWarnMethodWithGenerics>
+  }>()
+{
+}
+
+// should warn because method has multiple signatures with different return types
+export class ShouldWarnMethodWithMultipleSignatures
+  extends Effect.Tag("ShouldWarnMethodWithMultipleSignatures")<ShouldWarnMethodWithMultipleSignatures, {
+    constant: Effect.Effect<string, never, never>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string
+    ): Effect.Effect<string, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts: { discard: true }
+    ): Effect.Effect<void, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts?: { discard: true }
+    ): Effect.Effect<string | void>
+  }>()
+{
+}

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipNextLine.from1152to1190.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipNextLine.from1152to1190.output
@@ -1,0 +1,47 @@
+// code fix unsupportedServiceAccessors_skipNextLine  output for range 1152 - 1190
+import * as Effect from "effect/Effect"
+
+export class ValidService extends Effect.Tag("ValidService")<ValidService, {
+  constant: Effect.Effect<string, never, never>
+  method: (value: string) => Effect.Effect<string, never, never>
+}>() {
+}
+
+export class ValidServiceBecauseManuallyDefined
+  extends Effect.Tag("ValidServiceBecauseManuallyDefined")<ValidServiceBecauseManuallyDefined, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined>
+  }>()
+{
+  static method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined> = (...args) =>
+    Effect.andThen(ValidServiceBecauseManuallyDefined, (_) => _.method(...args))
+}
+
+// should warn because method has generics
+export class ShouldWarnMethodWithGenerics
+  extends Effect.Tag("ShouldWarnMethodWithGenerics")<ShouldWarnMethodWithGenerics, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A, _test: string) => Effect.Effect<A, never, ShouldWarnMethodWithGenerics>
+  }>()
+{
+}
+
+// should warn because method has multiple signatures with different return types
+// @effect-diagnostics-next-line unsupportedServiceAccessors:off
+export class ShouldWarnMethodWithMultipleSignatures
+  extends Effect.Tag("ShouldWarnMethodWithMultipleSignatures")<ShouldWarnMethodWithMultipleSignatures, {
+    constant: Effect.Effect<string, never, never>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string
+    ): Effect.Effect<string, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts: { discard: true }
+    ): Effect.Effect<void, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts?: { discard: true }
+    ): Effect.Effect<string | void>
+  }>()
+{
+}

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipNextLine.from783to811.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.unsupportedServiceAccessors_skipNextLine.from783to811.output
@@ -1,0 +1,47 @@
+// code fix unsupportedServiceAccessors_skipNextLine  output for range 783 - 811
+import * as Effect from "effect/Effect"
+
+export class ValidService extends Effect.Tag("ValidService")<ValidService, {
+  constant: Effect.Effect<string, never, never>
+  method: (value: string) => Effect.Effect<string, never, never>
+}>() {
+}
+
+export class ValidServiceBecauseManuallyDefined
+  extends Effect.Tag("ValidServiceBecauseManuallyDefined")<ValidServiceBecauseManuallyDefined, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined>
+  }>()
+{
+  static method: <A>(value: A) => Effect.Effect<A, never, ValidServiceBecauseManuallyDefined> = (...args) =>
+    Effect.andThen(ValidServiceBecauseManuallyDefined, (_) => _.method(...args))
+}
+
+// should warn because method has generics
+// @effect-diagnostics-next-line unsupportedServiceAccessors:off
+export class ShouldWarnMethodWithGenerics
+  extends Effect.Tag("ShouldWarnMethodWithGenerics")<ShouldWarnMethodWithGenerics, {
+    constant: Effect.Effect<string, never, never>
+    method: <A>(value: A, _test: string) => Effect.Effect<A, never, ShouldWarnMethodWithGenerics>
+  }>()
+{
+}
+
+// should warn because method has multiple signatures with different return types
+export class ShouldWarnMethodWithMultipleSignatures
+  extends Effect.Tag("ShouldWarnMethodWithMultipleSignatures")<ShouldWarnMethodWithMultipleSignatures, {
+    constant: Effect.Effect<string, never, never>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string
+    ): Effect.Effect<string, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts: { discard: true }
+    ): Effect.Effect<void, never, ShouldWarnMethodWithMultipleSignatures>
+    methodWithMultipleSignaturesNoGenerics(
+      value: string,
+      opts?: { discard: true }
+    ): Effect.Effect<string | void>
+  }>()
+{
+}

--- a/test/__snapshots__/renames/keyStrings_contextTag.ts.ln4col20.output
+++ b/test/__snapshots__/renames/keyStrings_contextTag.ts.ln4col20.output
@@ -1,0 +1,4 @@
+// Result of running rename keyStrings at position 4:20
+import * as Context from "effect/Context"
+
+export class MyClass extends Context.Tag("NewText")<MyClass, {}>() {}

--- a/test/__snapshots__/renames/keyStrings_effectTag.ts.ln4col20.output
+++ b/test/__snapshots__/renames/keyStrings_effectTag.ts.ln4col20.output
@@ -1,0 +1,4 @@
+// Result of running rename keyStrings at position 4:20
+import * as Effect from "effect/Effect"
+
+export class MyClass extends Effect.Tag("NewText")<MyClass, {}>() {}


### PR DESCRIPTION
## Summary
- Adds comprehensive support for Effect.Tag pattern across the language service
- Extends existing diagnostics and refactors to work with Effect.Tag
- Maintains backward compatibility with Context.Tag and other existing patterns

## Changes
- Extended TypeParser to recognize and parse Effect.Tag class declarations
- Added Effect.Tag support to `classSelfMismatch` diagnostic for detecting and fixing Self type mismatches
- Added Effect.Tag support to `unsupportedServiceAccessors` diagnostic for service accessor checks
- Added Effect.Tag support to `keyStrings` rename functionality for renaming tag identifiers
- Added Effect.Tag support to `writeTagClassAccessors` refactor for generating service accessors
- Included comprehensive test coverage with snapshots for all new functionality

## Test Plan
✅ All existing tests pass
✅ New test cases added for Effect.Tag patterns
✅ Snapshot tests verify expected behavior

## Example
Effect.Tag now works seamlessly with existing diagnostics and refactors:

```typescript
class MyService extends Effect.Tag("MyService")<
  MyService,
  { readonly value: number }
>() {}
```

The language service will now properly:
- Detect Self type mismatches in Effect.Tag classes
- Provide code fixes for Self type issues
- Support renaming of tag identifiers
- Generate proper service accessors
- Check for unsupported accessor patterns

🤖 Generated with [Claude Code](https://claude.ai/code)