### PR TITLE
Fix resolveModulePattern fallback mechanism

### DIFF
--- a/.changeset/fallback-resolve-module-pattern.md
+++ b/.changeset/fallback-resolve-module-pattern.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix `resolveModulePattern` to use fallback mechanism for package scope resolution when primary method is unavailable

--- a/src/core/AutoImport.ts
+++ b/src/core/AutoImport.ts
@@ -164,7 +164,7 @@ export const makeAutoImportProvider: (
       topLevelNamedReexports: "ignore" | "follow"
     ) {
       for (const packagePattern of packagePatterns) {
-        const packageNames = tsUtils.resolveModulePattern(fromSourceFile, packagePattern)
+        const packageNames = tsUtils.resolveModulePattern(program, fromSourceFile, packagePattern)
         for (const packageName of packageNames) {
           const packageInfo = getPackageInfo(fromSourceFile.fileName, packageName)
           if (!packageInfo) continue

--- a/src/diagnostics/importFromBarrel.ts
+++ b/src/diagnostics/importFromBarrel.ts
@@ -22,7 +22,7 @@ export const importFromBarrel = LSP.createDiagnostic({
     const program = yield* Nano.service(TypeScriptApi.TypeScriptProgram)
     const packageNamesToCheck = Array.flatten(
       languageServicePluginOptions.namespaceImportPackages.map((packageName) =>
-        tsUtils.resolveModulePattern(sourceFile, packageName)
+        tsUtils.resolveModulePattern(program, sourceFile, packageName)
       )
     )
 


### PR DESCRIPTION
## Summary
- Added fallback mechanism to `resolveModulePattern` function for retrieving package scope information
- Improves robustness when primary method for accessing package scope is unavailable
- Fixes potential issues in environments where package scope information may not be directly available on the source file

## Changes
- Modified `resolveModulePattern` to accept `program` parameter
- Added fallback logic using TypeScript's `getPackageScopeForPath` and `getTemporaryModuleResolutionState` APIs when available
- Updated all callers of `resolveModulePattern` to pass the program parameter

## Test plan
- [x] All existing tests pass
- [x] Type checking passes
- [x] Linting passes
- [x] Test snapshots regenerated without unexpected changes

🤖 Generated with [Claude Code](https://claude.ai/code)