### PR TITLE
Add effectGenUsesAdapter diagnostic

### DIFF
--- a/.changeset/effect-gen-uses-adapter-diagnostic.md
+++ b/.changeset/effect-gen-uses-adapter-diagnostic.md
@@ -1,0 +1,15 @@
+---
+"@effect/language-service": minor
+---
+
+Add new diagnostic: `effectGenUsesAdapter` - warns when using `Effect.gen` with the generator adapter pattern (function*(_)) instead of using `pipe()`
+
+The generator adapter pattern `function*(_)` is an old pattern. Users should use `pipe()` for composing effects or `Effect.gen(function*())` without the adapter for generator-based code.
+
+Example that will trigger the warning:
+```ts
+const example = Effect.gen(function*(_) {
+  const result = yield* _(Effect.succeed(42))
+  return result
+})
+```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Warn on subsequent `Effect.provide` anti-pattern
 - Detect wrong `Self` type parameter for APIs like `Effect.Service` or `Schema.TaggedError` and similar 
 - Unnecessary usages of `Effect.gen` or `pipe()`
+- Warn when using `Effect.gen` with the old generator adapter pattern
 - Warn when importing from a barrel file instead of from the module directly
 - Warn on usage of try/catch inside `Effect.gen` and family
 - Detect unnecessary pipe chains like `X.pipe(Y).pipe(Z)`

--- a/examples/diagnostics/effectGenUsesAdapter.ts
+++ b/examples/diagnostics/effectGenUsesAdapter.ts
@@ -1,0 +1,12 @@
+import * as Effect from "effect/Effect"
+
+export const isValid = Effect.gen(function*() {
+  const x = yield* Effect.succeed(1)
+  return x
+})
+
+// when the adapter usage is detected, warn
+export const isNotValid = Effect.gen(function*(_) {
+  const x = yield* Effect.succeed(1)
+  return x
+})

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,5 +1,6 @@
 import { classSelfMismatch } from "./diagnostics/classSelfMismatch.js"
 import { duplicatePackage } from "./diagnostics/duplicatePackage.js"
+import { effectGenUsesAdapter } from "./diagnostics/effectGenUsesAdapter.js"
 import { effectInVoidSuccess } from "./diagnostics/effectInVoidSuccess.js"
 import { floatingEffect } from "./diagnostics/floatingEffect.js"
 import { genericEffectServices } from "./diagnostics/genericEffectServices.js"
@@ -25,6 +26,7 @@ import { unsupportedServiceAccessors } from "./diagnostics/unsupportedServiceAcc
 export const diagnostics = [
   classSelfMismatch,
   duplicatePackage,
+  effectGenUsesAdapter,
   missingEffectContext,
   missingEffectError,
   missingEffectServiceDependency,

--- a/src/diagnostics/effectGenUsesAdapter.ts
+++ b/src/diagnostics/effectGenUsesAdapter.ts
@@ -1,0 +1,47 @@
+import { pipe } from "effect/Function"
+import type ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const effectGenUsesAdapter = LSP.createDiagnostic({
+  name: "effectGenUsesAdapter",
+  code: 23,
+  severity: "warning",
+  apply: Nano.fn("effectGenUsesAdapter.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+      ts.forEachChild(node, appendNodeToVisit)
+
+      if (ts.isCallExpression(node)) {
+        yield* pipe(
+          typeParser.effectGen(node),
+          Nano.map(({ generatorFunction }) => {
+            // Check if the generator function has parameters and if the first parameter (adapter) is used
+            if (generatorFunction.parameters.length > 0) {
+              const adapter = generatorFunction.parameters[0]
+              // Report diagnostic at the adapter parameter location
+              report({
+                location: adapter,
+                messageText: `The adapter of Effect.gen is not required anymore, it is now just an alias of pipe.`,
+                fixes: []
+              })
+            }
+          }),
+          Nano.ignore
+        )
+      }
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -184,7 +184,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|classSelfMismatch,duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -195,7 +195,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,duplicatePackage,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",

--- a/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.codefixes
+++ b/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.codefixes
@@ -1,0 +1,2 @@
+effectGenUsesAdapter_skipNextLine from 232 to 233
+effectGenUsesAdapter_skipFile from 232 to 233

--- a/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.effectGenUsesAdapter_skipFile.from232to233.output
+++ b/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.effectGenUsesAdapter_skipFile.from232to233.output
@@ -1,0 +1,14 @@
+// code fix effectGenUsesAdapter_skipFile  output for range 232 - 233
+/** @effect-diagnostics effectGenUsesAdapter:skip-file */
+import * as Effect from "effect/Effect"
+
+export const isValid = Effect.gen(function*() {
+  const x = yield* Effect.succeed(1)
+  return x
+})
+
+// when the adapter usage is detected, warn
+export const isNotValid = Effect.gen(function*(_) {
+  const x = yield* Effect.succeed(1)
+  return x
+})

--- a/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.effectGenUsesAdapter_skipNextLine.from232to233.output
+++ b/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.effectGenUsesAdapter_skipNextLine.from232to233.output
@@ -1,0 +1,14 @@
+// code fix effectGenUsesAdapter_skipNextLine  output for range 232 - 233
+import * as Effect from "effect/Effect"
+
+export const isValid = Effect.gen(function*() {
+  const x = yield* Effect.succeed(1)
+  return x
+})
+
+// when the adapter usage is detected, warn
+// @effect-diagnostics-next-line effectGenUsesAdapter:off
+export const isNotValid = Effect.gen(function*(_) {
+  const x = yield* Effect.succeed(1)
+  return x
+})

--- a/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.output
+++ b/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.output
@@ -1,0 +1,2 @@
+_
+9:47 - 9:48 | 0 | The adapter of Effect.gen is not required anymore, it is now just an alias of pipe.


### PR DESCRIPTION
## Summary
- Adds a new diagnostic `effectGenUsesAdapter` that warns when using the old generator adapter pattern with `Effect.gen`
- The diagnostic suggests using `pipe()` for composing effects or `Effect.gen(function*())` without the adapter

## Example
The diagnostic will warn on code like this:
```ts
const example = Effect.gen(function*(_) {
  const result = yield* _(Effect.succeed(42))
  return result
})
```

Users should instead use `pipe()` for composing effects or `Effect.gen(function*())` without the adapter for generator-based code.

## Test plan
- [x] Added test cases for the new diagnostic
- [x] Added quickfix test cases  
- [x] Updated completion snapshots
- [x] All tests pass
- [x] Documentation updated in README.md

🤖 Generated with [Claude Code](https://claude.ai/code)