### PR TITLE
Comply with ts-patch and vue-tsc patching mechanism

### DIFF
--- a/.changeset/old-hounds-kneel.md
+++ b/.changeset/old-hounds-kneel.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Comply with ts-patch and vue-tsc patching mechanism

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -70,8 +70,17 @@ export const getTypeScriptApisUtils = Effect.fn("getTypeScriptApisFile")(
   function*(dirPath: string) {
     const filePath = yield* getModuleFilePath(dirPath, "typescript")
     const sourceFile = yield* getUnpatchedSourceFile(filePath)
-    const patchWithWrappingFunction =
-      `var effectLspTypeScriptApis = (function(module){\n${sourceFile.text}\nreturn ts\n})(effectLspTypeScriptApis);`
+    const bodyWithoutBundlerComment = yield* omitBundlerSourceFileComment(
+      sourceFile.text.split("\n").map((line) => `    ${line}`).join("\n")
+    )
+    const patchWithWrappingFunction = `
+var _effectLspTypeScriptApis = undefined;
+function effectLspTypeScriptApis(){
+  if(!_effectLspTypeScriptApis){
+    _effectLspTypeScriptApis = (function(module){\n${bodyWithoutBundlerComment}\nreturn ts\n})(effectLspTypeScriptApis);
+  }
+  return _effectLspTypeScriptApis;
+}`
     return patchWithWrappingFunction
   }
 )
@@ -81,8 +90,17 @@ export const getEffectLspPatchUtils = Effect.fn("getEffectLspPatchUtils")(functi
   const fs = yield* FileSystem.FileSystem
   const effectLspPatchUtilsPath = path.resolve(__dirname, "effect-lsp-patch-utils.js")
   const effectLspPatchUtilsContent = yield* fs.readFileString(effectLspPatchUtilsPath)
-  const patchWithWrappingFunction =
-    `var effectLspPatchUtils = (function(module){\n${effectLspPatchUtilsContent}\nreturn module\n})(effectLspPatchUtils || {});`
+  const bodyWithoutBundlerComment = yield* omitBundlerSourceFileComment(
+    effectLspPatchUtilsContent.split("\n").map((line) => `    ${line}`).join("\n")
+  )
+  const patchWithWrappingFunction = `
+var _effectLspPatchUtils = undefined;
+function effectLspPatchUtils(){
+  if(!_effectLspPatchUtils){
+    _effectLspPatchUtils = (function(module){\n${bodyWithoutBundlerComment}\nreturn module\n})({});
+  }
+  return _effectLspPatchUtils.exports;
+}`
   return patchWithWrappingFunction
 })
 
@@ -199,3 +217,11 @@ export const getUnpatchedSourceFile = Effect.fn("getUnpatchedSourceFile")(functi
   )
   return newSourceFile
 })
+
+export const omitBundlerSourceFileComment = Effect.fn("omitBundlerSourceFileComment")(
+  function*(originalSourceText: string) {
+    return originalSourceText.split("\n").filter((line) => line.match(/^\s*\/\/\s*src\//gm) === null).join(
+      "\n"
+    )
+  }
+)


### PR DESCRIPTION
## Type

- [X] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR changes the way _tsc.js and typescript.js are patched in order to produce a more "standalone-like" output code.
This means that now fake "source sections" between `// src/XXXX.ts` are produced, so that ts-patch can still treat them as standalone typescript source files.
The utils have been moved from before the heading, to before the last "source section".
This allows vue-tsc to not get confused in which instance to patch to support arbitrary .vue file extensions.