### PR TITLE
Add diagnostic for non-object Effect.Service type

### DIFF
--- a/.changeset/add-non-object-effect-service-type-diagnostic.md
+++ b/.changeset/add-non-object-effect-service-type-diagnostic.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add new diagnostic to warn when `Effect.Service` is used with a primitive type instead of an object type. This diagnostic helps prevent common mistakes where developers try to use primitive values (strings, numbers, etc.) as service types, which is not supported by `Effect.Service`. The diagnostic suggests wrapping the value in an object or manually using `Context.Tag` or `Effect.Tag` for primitive types.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Detect unnecessary pipe chains like `X.pipe(Y).pipe(Z)`
 - Warn when using `Effect.Service` with `accessors: true` but methods have generics or multiple signatures
 - Warn on missing service dependencies in `Effect.Service` declarations
+- Warn when `Effect.Service` is used with a primitive type instead of an object type
 - Warn when schema classes override the default constructor behavior
 
 ### Completions

--- a/examples/diagnostics/nonObjectEffectServiceType.ts
+++ b/examples/diagnostics/nonObjectEffectServiceType.ts
@@ -1,0 +1,52 @@
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -12,6 +12,7 @@ import { missingEffectServiceDependency } from "./diagnostics/missingEffectServi
 import { missingReturnYieldStar } from "./diagnostics/missingReturnYieldStar.js"
 import { missingStarInYieldEffectGen } from "./diagnostics/missingStarInYieldEffectGen.js"
 import { multipleEffectProvide } from "./diagnostics/multipleEffectProvide.js"
+import { nonObjectEffectServiceType } from "./diagnostics/nonObjectEffectServiceType.js"
 import { outdatedEffectCodegen } from "./diagnostics/outdatedEffectCodegen.js"
 import { overriddenSchemaConstructor } from "./diagnostics/overriddenSchemaConstructor.js"
 import { returnEffectInGen } from "./diagnostics/returnEffectInGen.js"
@@ -47,5 +48,6 @@ export const diagnostics = [
   multipleEffectProvide,
   outdatedEffectCodegen,
   overriddenSchemaConstructor,
-  unsupportedServiceAccessors
+  unsupportedServiceAccessors,
+  nonObjectEffectServiceType
 ]

--- a/src/diagnostics/missingEffectServiceDependency.ts
+++ b/src/diagnostics/missingEffectServiceDependency.ts
@@ -9,7 +9,7 @@ import * as TypeScriptApi from "../core/TypeScriptApi.js"
 
 export const missingEffectServiceDependency = LSP.createDiagnostic({
   name: "missingEffectServiceDependency",
-  code: 21,
+  code: 22,
   severity: "off",
   apply: Nano.fn("missingEffectServiceDependency.apply")(function*(sourceFile, report) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)

--- a/src/diagnostics/nonObjectEffectServiceType.ts
+++ b/src/diagnostics/nonObjectEffectServiceType.ts
@@ -1,0 +1,122 @@
+import { pipe } from "effect"
+import type ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeCheckerUtils from "../core/TypeCheckerUtils.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const nonObjectEffectServiceType = LSP.createDiagnostic({
+  name: "nonObjectEffectServiceType",
+  code: 24,
+  severity: "error",
+  apply: Nano.fn("nonObjectEffectServiceType.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+    const typeCheckerUtils = yield* Nano.service(TypeCheckerUtils.TypeCheckerUtils)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    function isPrimitiveType(type: ts.Type): boolean {
+      return typeCheckerUtils.unrollUnionMembers(type).some((type) =>
+        !!(
+          type.flags & ts.TypeFlags.String ||
+          type.flags & ts.TypeFlags.Number ||
+          type.flags & ts.TypeFlags.Boolean ||
+          type.flags & ts.TypeFlags.StringLiteral ||
+          type.flags & ts.TypeFlags.NumberLiteral ||
+          type.flags & ts.TypeFlags.BooleanLiteral ||
+          type.flags & ts.TypeFlags.Undefined ||
+          type.flags & ts.TypeFlags.Null
+        )
+      )
+    }
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+
+      if (ts.isClassDeclaration(node) && node.name && node.heritageClauses) {
+        const serviceResult = yield* pipe(
+          typeParser.extendsEffectService(node),
+          Nano.orElse(() => Nano.void_)
+        )
+
+        if (serviceResult && serviceResult.options && ts.isObjectLiteralExpression(serviceResult.options)) {
+          const options = serviceResult.options
+
+          for (const property of options.properties) {
+            if (!ts.isPropertyAssignment(property) || !ts.isIdentifier(property.name)) {
+              continue
+            }
+
+            const propertyName = ts.idText(property.name)
+            const propertyValue = property.initializer
+
+            const errorToReport = {
+              location: property.name,
+              messageText:
+                "Effect.Service requires the service type to be an object {} and not a primitive type. \nConsider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.",
+              fixes: []
+            }
+
+            if (propertyName === "succeed") {
+              const valueType = typeChecker.getTypeAtLocation(propertyValue)
+              if (isPrimitiveType(valueType)) {
+                report(errorToReport)
+              }
+            } else if (propertyName === "sync") {
+              const valueType = typeChecker.getTypeAtLocation(propertyValue)
+              const signatures = typeChecker.getSignaturesOfType(valueType, ts.SignatureKind.Call)
+
+              for (const signature of signatures) {
+                const returnType = typeChecker.getReturnTypeOfSignature(signature)
+                if (isPrimitiveType(returnType)) {
+                  report(errorToReport)
+                  break
+                }
+              }
+            } else if (propertyName === "effect" || propertyName === "scoped") {
+              const valueType = typeChecker.getTypeAtLocation(propertyValue)
+
+              const effectResult = yield* pipe(
+                typeParser.effectType(valueType, propertyValue),
+                Nano.orElse(() => Nano.void_)
+              )
+
+              if (effectResult) {
+                if (isPrimitiveType(effectResult.A)) {
+                  report(errorToReport)
+                  continue
+                }
+              } else {
+                const signatures = typeChecker.getSignaturesOfType(valueType, ts.SignatureKind.Call)
+                for (const signature of signatures) {
+                  const returnType = typeChecker.getReturnTypeOfSignature(signature)
+
+                  const effectReturnResult = yield* pipe(
+                    typeParser.effectType(returnType, propertyValue),
+                    Nano.orElse(() => Nano.void_)
+                  )
+
+                  if (effectReturnResult && isPrimitiveType(effectReturnResult.A)) {
+                    report(errorToReport)
+                    break
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      ts.forEachChild(node, appendNodeToVisit)
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -184,7 +184,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -195,7 +195,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.codefixes
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.codefixes
@@ -1,0 +1,14 @@
+nonObjectEffectServiceType_skipNextLine from 402 to 408
+nonObjectEffectServiceType_skipFile from 402 to 408
+nonObjectEffectServiceType_skipNextLine from 667 to 673
+nonObjectEffectServiceType_skipFile from 667 to 673
+nonObjectEffectServiceType_skipNextLine from 979 to 985
+nonObjectEffectServiceType_skipFile from 979 to 985
+nonObjectEffectServiceType_skipNextLine from 1266 to 1272
+nonObjectEffectServiceType_skipFile from 1266 to 1272
+nonObjectEffectServiceType_skipNextLine from 1578 to 1584
+nonObjectEffectServiceType_skipFile from 1578 to 1584
+nonObjectEffectServiceType_skipNextLine from 1840 to 1847
+nonObjectEffectServiceType_skipFile from 1840 to 1847
+nonObjectEffectServiceType_skipNextLine from 2077 to 2081
+nonObjectEffectServiceType_skipFile from 2077 to 2081

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from1266to1272.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from1266to1272.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipFile  output for range 1266 - 1272
+/** @effect-diagnostics nonObjectEffectServiceType:skip-file */
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from1578to1584.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from1578to1584.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipFile  output for range 1578 - 1584
+/** @effect-diagnostics nonObjectEffectServiceType:skip-file */
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from1840to1847.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from1840to1847.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipFile  output for range 1840 - 1847
+/** @effect-diagnostics nonObjectEffectServiceType:skip-file */
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from2077to2081.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from2077to2081.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipFile  output for range 2077 - 2081
+/** @effect-diagnostics nonObjectEffectServiceType:skip-file */
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from402to408.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from402to408.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipFile  output for range 402 - 408
+/** @effect-diagnostics nonObjectEffectServiceType:skip-file */
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from667to673.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from667to673.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipFile  output for range 667 - 673
+/** @effect-diagnostics nonObjectEffectServiceType:skip-file */
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from979to985.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipFile.from979to985.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipFile  output for range 979 - 985
+/** @effect-diagnostics nonObjectEffectServiceType:skip-file */
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1266to1272.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1266to1272.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipNextLine  output for range 1266 - 1272
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+// @effect-diagnostics-next-line nonObjectEffectServiceType:off
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1578to1584.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1578to1584.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipNextLine  output for range 1578 - 1584
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+// @effect-diagnostics-next-line nonObjectEffectServiceType:off
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1840to1847.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1840to1847.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipNextLine  output for range 1840 - 1847
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+// @effect-diagnostics-next-line nonObjectEffectServiceType:off
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from2077to2081.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from2077to2081.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipNextLine  output for range 2077 - 2081
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+// @effect-diagnostics-next-line nonObjectEffectServiceType:off
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from402to408.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from402to408.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipNextLine  output for range 402 - 408
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+// @effect-diagnostics-next-line nonObjectEffectServiceType:off
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from667to673.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from667to673.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipNextLine  output for range 667 - 673
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+// @effect-diagnostics-next-line nonObjectEffectServiceType:off
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from979to985.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from979to985.output
@@ -1,0 +1,54 @@
+// code fix nonObjectEffectServiceType_skipNextLine  output for range 979 - 985
+import * as Effect from "effect/Effect"
+
+// should not warn
+export class ObjectService extends Effect.Service<ObjectService>()("ObjectService", {
+  effect: Effect.succeed({})
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as ("test" | "other"))
+}) {}
+
+// should warn on "effect" key because it returns an effect that resolves to a primitive
+export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
+  // @ts-expect-error
+  effect: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
+// @effect-diagnostics-next-line nonObjectEffectServiceType:off
+export class UsesStringValueLazyEffect
+  extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
+    // @ts-expect-error
+    effect: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "scoped" key because it returns an effect that resolves to a primitive
+export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
+  // @ts-expect-error
+  scoped: Effect.succeed("test" as const)
+}) {}
+
+// should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
+export class UsesStringValueLazyScoped
+  extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
+    // @ts-expect-error
+    scoped: (_: string) => Effect.succeed("test" as const)
+  })
+{}
+
+// should warn on "succeed" key because it is a primitive
+export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
+  // @ts-expect-error
+  succeed: "test" as const
+}) {}
+
+// should warn on "sync" key because it is function that returns a primitive
+export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
+  // @ts-expect-error
+  sync: () => "test" as const
+}) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.output
@@ -1,0 +1,27 @@
+effect
+11:2 - 11:8 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+
+effect
+17:2 - 17:8 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+
+effect
+24:4 - 24:10 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+
+scoped
+31:2 - 31:8 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+
+scoped
+38:4 - 38:10 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+
+succeed
+45:2 - 45:9 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+
+sync
+51:2 - 51:6 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -225,4 +225,17 @@ function testAllDagnostics() {
   }
 }
 
+describe("Diagnostics", () => {
+  it("the diagnostic code should be unique among all diagnostics", () => {
+    const codes = diagnostics.reduce((acc, d) => {
+      acc[d.code] = (acc[d.code] || 0) + 1
+      return acc
+    }, {} as Record<number, number>)
+    for (const [code, count] of Object.entries(codes)) {
+      if (code === "1") continue // skip the diagnostic code 1 which is used for missingEffectContext and missingEffectError
+      expect(count, "code " + code + " should be unique").toEqual(1)
+    }
+  })
+})
+
 testAllDagnostics()


### PR DESCRIPTION
## Summary

- Adds a new diagnostic that warns when `Effect.Service` is used with a primitive type instead of an object type
- Includes comprehensive test coverage and examples
- Updates documentation in README.md

## Details

`Effect.Service` requires service types to be objects. Using primitive types (strings, numbers, booleans, etc.) causes runtime issues and is not supported by the Effect framework. This diagnostic helps developers catch this mistake early during development.

The diagnostic detects primitive types in:
- `effect` property returning an Effect resolving to a primitive
- `scoped` property returning an Effect resolving to a primitive
- `succeed` property with a primitive value
- `sync` property returning a primitive value
- Functions returning Effects that resolve to primitives

## Example

### Before (Error)
```typescript
class StringService extends Effect.Service<StringService>()("StringService", {
  effect: Effect.succeed("test")  // ❌ Diagnostic: primitive type
}) {}
```

### After (Fixed)
```typescript
class StringService extends Effect.Service<StringService>()("StringService", {
  effect: Effect.succeed({ value: "test" })  // ✓ Object type
}) {}
```

Or use `Context.Tag` / `Effect.Tag` for primitives:
```typescript
const StringTag = Context.Tag<string>()("StringService")
```

## Test Plan

- [x] All existing tests pass
- [x] New diagnostic tests added with comprehensive examples
- [x] Test snapshots regenerated and verified
- [x] TypeScript compilation successful
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)