### PR TITLE
Add Effect.Tag completion for classes extending Effect

### DIFF
--- a/.changeset/add-effect-tag-completion.md
+++ b/.changeset/add-effect-tag-completion.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Add Effect.Tag completion for classes extending Effect
+
+When typing `Effect.` in a class that extends Effect, the completion now also suggests `Effect.Tag` alongside the existing `Effect.Service` completion. This provides an additional way to define tagged services using the Effect.Tag pattern.

--- a/src/completions/effectSelfInClasses.ts
+++ b/src/completions/effectSelfInClasses.ts
@@ -30,6 +30,12 @@ export const effectSelfInClasses = LSP.createCompletion({
       insertText: `${effectIdentifier}.Service<${name}>()("${name}", {${"${0}"}}){}`,
       replacementSpan,
       isSnippet: true
+    }, {
+      name: `Tag("${name}")`,
+      kind: ts.ScriptElementKind.constElement,
+      insertText: `${effectIdentifier}.Tag("${name}")<${name}, {${"${0}"}}>(){}`,
+      replacementSpan,
+      isSnippet: true
     }] satisfies Array<LSP.CompletionEntryDefinition>
   })
 })

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -319,6 +319,17 @@ exports[`Completion effectSelfInClasses > effectSelfInClasses.ts at 4:39 1`] = `
     },
     "sortText": "11",
   },
+  {
+    "insertText": "Effect.Tag("MyService")<MyService, {\${0}}>(){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "Tag("MyService")",
+    "replacementSpan": {
+      "length": 7,
+      "start": 141,
+    },
+    "sortText": "11",
+  },
 ]
 `;
 


### PR DESCRIPTION
## Summary
- Added Effect.Tag completion alongside existing Effect.Service completion for classes extending Effect
- Updates snapshot tests to include the new completion option

## Details
When typing `Effect.` in a class that extends Effect, the autocomplete now suggests both:
- `Effect.Service<ClassName>()`
- `Effect.Tag("ClassName")<ClassName, {}>()`

This provides developers with an additional way to define tagged services using the Effect.Tag pattern.

## Test plan
- [x] All existing tests pass
- [x] Snapshot tests updated to reflect new completion
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)