### PR TITLE
Add quickinfoMaximumLength option for type truncation control

### DIFF
--- a/.changeset/quickinfo-maximum-length.md
+++ b/.changeset/quickinfo-maximum-length.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add `quickinfoMaximumLength` option to control the maximum length of types displayed in quickinfo hover. This helps improve performance when dealing with very long types by allowing TypeScript to truncate them to a specified budget. Defaults to -1 (no truncation), but can be set to any positive number (e.g., 1000) to limit type display length.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Few options can be provided alongside the initialization of the Language Service
         },
         "quickinfo": true, // controls Effect quickinfo (default: true)
         "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
+        "quickinfoMaximumLength": -1, // controls how long can be the types in the quickinfo hover (helps with very long type to improve perfs, defaults to -1 for no truncation, can be any number eg. 1000 and TS will try to fit as much as possible in that budget, higher number means more info.)
         "completions": true, // controls Effect completions (default: true)
         "goto": true, // controls Effect goto references (default: true)
         "inlays": true, // controls Effect provided inlayHints (default: true)

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -1,7 +1,7 @@
 import { isArray } from "effect/Array"
 import * as Array from "effect/Array"
 import { pipe } from "effect/Function"
-import { hasProperty, isBoolean, isObject, isRecord, isString } from "effect/Predicate"
+import { hasProperty, isBoolean, isNumber, isObject, isRecord, isString } from "effect/Predicate"
 import * as Record from "effect/Record"
 import * as Nano from "./Nano"
 
@@ -13,6 +13,7 @@ export interface LanguageServicePluginOptions {
   diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
   quickinfoEffectParameters: "always" | "never" | "whentruncated"
   quickinfo: boolean
+  quickinfoMaximumLength: number
   completions: boolean
   goto: boolean
   inlays: boolean
@@ -47,6 +48,7 @@ export const defaults: LanguageServicePluginOptions = {
   diagnosticSeverity: {},
   quickinfo: true,
   quickinfoEffectParameters: "whentruncated",
+  quickinfoMaximumLength: -1,
   completions: true,
   goto: true,
   inlays: true,
@@ -79,6 +81,10 @@ export function parse(config: any): LanguageServicePluginOptions {
         ["always", "never", "whentruncated"].includes(config.quickinfoEffectParameters.toLowerCase())
       ? config.quickinfoEffectParameters.toLowerCase() as "always" | "never" | "whentruncated"
       : defaults.quickinfoEffectParameters,
+    quickinfoMaximumLength:
+      isObject(config) && hasProperty(config, "quickinfoMaximumLength") && isNumber(config.quickinfoMaximumLength)
+        ? config.quickinfoMaximumLength
+        : defaults.quickinfoMaximumLength,
     completions: isObject(config) && hasProperty(config, "completions") && isBoolean(config.completions)
       ? config.completions
       : defaults.completions,

--- a/src/quickinfo/effectTypeArgs.ts
+++ b/src/quickinfo/effectTypeArgs.ts
@@ -22,11 +22,22 @@ export function effectTypeArgs(
       if (options.quickinfoEffectParameters === "never") return quickInfo
 
       function formatTypeForQuickInfo(channelType: ts.Type, channelName: string) {
-        const stringRepresentation = typeChecker.typeToString(
-          channelType,
-          undefined,
-          ts.TypeFormatFlags.NoTruncation
-        )
+        let stringRepresentation = ""
+        if (options.quickinfoMaximumLength > 0) {
+          const typeNode = typeChecker.typeToTypeNode(
+            channelType,
+            undefined,
+            ts.NodeBuilderFlags.None,
+            // @ts-expect-error
+            undefined,
+            undefined,
+            options.quickinfoMaximumLength
+          )
+          const printer = ts.createPrinter({})
+          stringRepresentation = typeNode ? printer.printNode(ts.EmitHint.Unspecified, typeNode, sourceFile) : ""
+        } else {
+          stringRepresentation = typeChecker.typeToString(channelType, undefined, ts.TypeFormatFlags.NoTruncation)
+        }
         return `type ${channelName} = ${stringRepresentation}`
       }
 


### PR DESCRIPTION
## Summary
- Added a new `quickinfoMaximumLength` configuration option to control the maximum length of types displayed in quickinfo hover
- This feature helps improve performance when dealing with very long types
- The option defaults to -1 (no truncation) but can be set to any positive number (e.g., 1000) to limit type display length

## Changes
- Added `quickinfoMaximumLength` to `LanguageServicePluginOptions` interface
- Updated `effectTypeArgs` function in `src/quickinfo/effectTypeArgs.ts` to use the new option when formatting types
- Documented the new option in README.md with examples

## Example Usage
```json
{
  "plugins": [
    {
      "name": "@effect/language-service",
      "quickinfoMaximumLength": 1000
    }
  ]
}
```

When set to a positive number, TypeScript will try to fit as much type information as possible within the specified budget, truncating longer types to improve hover performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)