### PR TITLE
Fix wrapWithEffectGen refactor for class heritage clauses

### DIFF
--- a/.changeset/fix-wrap-effect-gen-heritage-clause.md
+++ b/.changeset/fix-wrap-effect-gen-heritage-clause.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Fix wrapWithEffectGen refactor not working on class heritage clauses
+
+The wrapWithEffectGen refactor now correctly skips expressions in heritage clauses (e.g., `extends` clauses in class declarations) to avoid wrapping them inappropriately.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The following steps can be skipped if no typescript file has been changed in thi
 - run "pnpm lint-fix" to fix code formatting
 - run "pnpm check" to see if you should fix some type errors
 - run "pnpm test" to validate that changes did not broke anything
-- when you think that you have finished it all, drop all the files from test/__snapshots__ and run "pnpm test". Look at the git changes in snapshot files and ensure that they are expected changes and there are no side effects.
+- when you think that you have finished it all, remove from disk all the files from test/__snapshots__ folder and run "pnpm test". Look at the git changes in snapshot files and ensure that they are expected changes and there are no side effects.
 
 ### 3. Documentation checks
 - if new diagnostics, completions or refactor are added, ensure they are already mentioned in the README.md. Ensure to read examples and test/__snapshots__ related to the change to ensure full understanding of whats changed
@@ -61,6 +61,6 @@ Description of the change with examples
 "${patchType}" should be replaced by "patch" if the PR contains only bugfixes or small changes; or "minor" if new diagnostics, refactors or features are added.
 
 ### 4. Pushing the PR to GitHub
-If all the preliminary checks pass, create a new github PR for the changes that:
+If all the preliminary checks pass, ask the user if some specific issue should be referenced, gather info on the issue and then create a new github PR for the changes that:
 - Provide a description of what changed, ensure to read examples and test/__snapshots__ related to the change to ensure full understanding of whats changed
 - If the change involve refactors or diagnostic, provide an example of the feature added/changed

--- a/examples/refactors/wrapWithEffectGen_noclass.ts
+++ b/examples/refactors/wrapWithEffectGen_noclass.ts
@@ -1,0 +1,6 @@
+// 4:36
+import { Effect } from "effect"
+
+export class Asd extends Effect.Service<Asd>()("Asd", {
+  succeed: {}
+}) {}

--- a/src/refactors/wrapWithEffectGen.ts
+++ b/src/refactors/wrapWithEffectGen.ts
@@ -21,6 +21,7 @@ export const wrapWithEffectGen = LSP.createRefactor({
     const findEffectToWrap = Nano.fn("wrapWithEffectGen.apply.findEffectToWrap")(
       function*(node: ts.Node) {
         if (!ts.isExpression(node)) return yield* Nano.fail("is not an expression")
+        if (node.parent && ts.isHeritageClause(node.parent)) return yield* Nano.fail("is in a heritage clause")
 
         const parent = node.parent
         if (
@@ -28,7 +29,7 @@ export const wrapWithEffectGen = LSP.createRefactor({
         ) return yield* Nano.fail("is LHS of variable declaration")
 
         const type = typeChecker.getTypeAtLocation(node)
-        yield* typeParser.effectType(type, node)
+        yield* typeParser.strictEffectType(type, node)
 
         return node
       }

--- a/test/__snapshots__/refactors/wrapWithEffectGen_noclass.ts.ln4col36.output
+++ b/test/__snapshots__/refactors/wrapWithEffectGen_noclass.ts.ln4col36.output
@@ -1,0 +1,6 @@
+// Result of running refactor wrapWithEffectGen at position 4:36
+import { Effect } from "effect"
+
+export class Asd extends Effect.Service<Asd>()("Asd", {
+  succeed: {}
+}) {}


### PR DESCRIPTION
## Summary

Fixes #391 - The `wrapWithEffectGen` refactor was incorrectly being offered on expressions within class heritage clauses (e.g., `extends` clauses), leading to invalid TypeScript code generation.

This PR adds proper filtering to skip expressions in heritage clauses and switches to using `strictEffectType` for more accurate type checking.

## Changes

- Added check to skip expressions when parent is a heritage clause
- Changed from `effectType` to `strictEffectType` for more precise type validation
- Added test case `wrapWithEffectGen_noclass.ts` demonstrating the fix

## Example

Before this fix, the refactor would incorrectly offer to wrap the `Effect.Service<Asd>()` call in this code:

```ts
export class Asd extends Effect.Service<Asd>()("Asd", {
  succeed: {}
}) {}
```

This would generate invalid code. Now the refactor correctly skips this scenario.

## Test plan

- ✅ All existing tests pass
- ✅ New snapshot test added for the heritage clause scenario
- ✅ TypeScript checks pass
- ✅ Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)