### PR TITLE
Add deterministicKeys diagnostic and contextSelfInClasses identifier key completion

### DIFF
--- a/.changeset/add-deterministic-keys-diagnostic.md
+++ b/.changeset/add-deterministic-keys-diagnostic.md
@@ -1,0 +1,30 @@
+---
+"@effect/language-service": minor
+---
+
+Add deterministicKeys diagnostic to enforce consistent key patterns for Services and Errors
+
+This new diagnostic helps maintain consistent and unique keys for Effect Services and Tagged Errors by validating them against configurable patterns. The diagnostic is disabled by default and can be enabled via the `deterministicKeys` diagnosticSeverity setting.
+
+Two patterns are supported:
+- `default`: Constructs keys from package name + file path + class identifier (e.g., `@effect/package/FileName/ClassIdentifier`)
+- `package-identifier`: Uses package name + identifier for flat project structures
+
+Example configuration:
+
+```jsonc
+{
+  "diagnosticSeverity": {
+    "deterministicKeys": "error"
+  },
+  "keyPatterns": [
+    {
+      "target": "service",
+      "pattern": "default",
+      "skipLeadingPath": ["src/"]
+    }
+  ]
+}
+```
+
+The diagnostic also provides auto-fix code actions to update keys to match the configured patterns.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ The following steps can be skipped if no typescript file has been changed in thi
 
 ### 3. Documentation checks
 - if new diagnostics, completions or refactor are added, ensure they are already mentioned in the README.md. Ensure to read examples and test/__snapshots__ related to the change to ensure full understanding of whats changed
-- If in the git changes does not exists a new changeset file to be added, create a new one in the .changeset folder, the patt<ern is something like this:
+- If in the git changes does not exists a new changeset file to be added, create a new one in the .changeset folder, the pattern is something like this:
 ```
 ---
 "@effect/language-service": ${patchType}

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Few options can be provided alongside the initialization of the Language Service
         "namespaceImportPackages": [], // package names that should be preferred as imported with namespace imports e.g. ["effect", "@effect/*"] (default: [])
         "topLevelNamedReexports": "ignore", // for namespaceImportPackages, how should top level named re-exports (e.g. {pipe} from "effect") be treated? "ignore" will leave them as is, "follow" will rewrite them to the re-exported module (e.g. {pipe} from "effect/Function")
         "importAliases": { "Array": "Arr" }, // allows to chose some different names for import name aliases (only when not chosing to import the whole module) (default: {})
-        "noExternal": false // disables features that provides links to external websites (such as links to mermaidchart.com) (default: false)
+        "noExternal": false, // disables features that provides links to external websites (such as links to mermaidchart.com) (default: false)
+        "keyPatterns": [{ "target": "service", "pattern": "default", "skipLeadingPath": ["src/"] }] // configure the key patterns; recommended reading more on the section "Configuring Key Patterns"
       }
     ]
   }
@@ -229,6 +230,56 @@ or you can set the severity for the entire project in the global plugin configur
   }
 }
 ```
+
+## Configuring Key Patterns
+
+Effect uses string keys for Services, Error Tags, RPC Methods, and more.
+It can happen that sometimes, after some refactors or copy/paste, you may end up having wrong or non unique keys in your services.
+
+To avoid that, the LSP suggests deterministic patterns for keys; that can be configured by the "keyPatterns" option.
+
+To enable reporting of wrong or outdated keys, the rule "deterministicKeys" must be enabled first (off by default). To do so, adjust its diagnosticSeverity to error.
+
+The keyPatterns key can then contain an array of the configured patterns.
+
+```jsonc
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        // ...
+        "diagnosticSeverity": {
+          "deterministicKeys": "error" // enables reporting of wrong keys
+          // ...
+        },
+        "keyPatterns": [
+          {
+            "target": "service", // what key type to target between service|error
+            "pattern": "default", // the chosen pattern
+            "skipLeadingPath": ["src/"] // other pattern specific configs
+          }
+        ]
+        
+      }
+    ]
+  }
+}
+```
+
+### Pattern: default
+
+This pattern constructs keys by chaining package name + file path + class identifier.
+
+E.g. `@effect/package/subpath-relative-to-package-root/FileName/ClassIdentifier`
+
+If the filename and the class identifier are the same, they won't be repeated, but used only once.
+
+The skipLeadingPath array can contain a set of prefixes to remove from the subpath part of the path. By default "src/" is removed for example.
+
+### Pattern: package-identifier
+
+This pattern uses the package name + identifier. This usually works great if you have a flat structure, with one file per service/error.
 
 ## Known gotchas
 

--- a/examples/completions/contextSelfInClasses_identifierKey.ts
+++ b/examples/completions/contextSelfInClasses_identifierKey.ts
@@ -1,0 +1,5 @@
+// 5:40
+// @test-config { "keyPatterns": [ { "pattern": "package-identifier", "target": "service" } ] }
+import * as Context from "effect/Context"
+
+export class MyService extends Context.

--- a/examples/diagnostics/deterministicKeys.ts
+++ b/examples/diagnostics/deterministicKeys.ts
@@ -1,0 +1,10 @@
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default" }, { "target": "error", "pattern": "default" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/examples/diagnostics/deterministicKeys_packageIdentifier.ts
+++ b/examples/diagnostics/deterministicKeys_packageIdentifier.ts
@@ -1,0 +1,10 @@
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "package-identifier" }, { "target": "error", "pattern": "package-identifier" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/src/completions/contextSelfInClasses.ts
+++ b/src/completions/contextSelfInClasses.ts
@@ -1,3 +1,4 @@
+import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
 import * as TypeScriptApi from "../core/TypeScriptApi"
@@ -24,10 +25,13 @@ export const contextSelfInClasses = LSP.createCompletion({
     if (contextIdentifier !== ts.idText(accessedObject)) return []
     const name = ts.idText(className)
 
+    // create the expected identifier
+    const tagKey = (yield* KeyBuilder.createString(sourceFile, name, "service")) || name
+
     return [{
       name: `Tag("${name}")`,
       kind: ts.ScriptElementKind.constElement,
-      insertText: `${contextIdentifier}.Tag("${name}")<${name}, ${"${0}"}>(){}`,
+      insertText: `${contextIdentifier}.Tag("${tagKey}")<${name}, ${"${0}"}>(){}`,
       replacementSpan,
       isSnippet: true
     }] satisfies Array<LSP.CompletionEntryDefinition>

--- a/src/completions/effectDataClasses.ts
+++ b/src/completions/effectDataClasses.ts
@@ -1,3 +1,4 @@
+import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
 import * as TypeScriptApi from "../core/TypeScriptApi"
@@ -24,10 +25,13 @@ export const effectDataClasses = LSP.createCompletion({
     if (effectDataIdentifier !== ts.idText(accessedObject)) return []
     const name = ts.idText(className)
 
+    // create the expected identifier
+    const errorTagKey = (yield* KeyBuilder.createString(sourceFile, name, "error")) || name
+
     return [{
       name: `TaggedError("${name}")`,
       kind: ts.ScriptElementKind.constElement,
-      insertText: `${effectDataIdentifier}.TaggedError("${name}")<{${"${0}"}}>{}`,
+      insertText: `${effectDataIdentifier}.TaggedError("${errorTagKey}")<{${"${0}"}}>{}`,
       replacementSpan,
       isSnippet: true
     }, {

--- a/src/completions/effectSchemaSelfInClasses.ts
+++ b/src/completions/effectSchemaSelfInClasses.ts
@@ -1,3 +1,4 @@
+import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
 import * as TypeScriptApi from "../core/TypeScriptApi"
@@ -24,6 +25,9 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
     if (schemaIdentifier !== ts.idText(accessedObject)) return []
     const name = ts.idText(className)
 
+    // create the expected identifier
+    const errorTagKey = (yield* KeyBuilder.createString(sourceFile, name, "error")) || name
+
     return [{
       name: `Class<${name}>`,
       kind: ts.ScriptElementKind.constElement,
@@ -33,7 +37,7 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
     }, {
       name: `TaggedError<${name}>`,
       kind: ts.ScriptElementKind.constElement,
-      insertText: `${schemaIdentifier}.TaggedError<${name}>("${name}")("${name}", {${"${0}"}}){}`,
+      insertText: `${schemaIdentifier}.TaggedError<${name}>("${errorTagKey}")("${errorTagKey}", {${"${0}"}}){}`,
       replacementSpan,
       isSnippet: true
     }, {

--- a/src/completions/effectSelfInClasses.ts
+++ b/src/completions/effectSelfInClasses.ts
@@ -1,3 +1,4 @@
+import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
 import * as TypeScriptApi from "../core/TypeScriptApi"
@@ -24,16 +25,19 @@ export const effectSelfInClasses = LSP.createCompletion({
     if (effectIdentifier !== ts.idText(accessedObject)) return []
     const name = ts.idText(className)
 
+    // create the expected identifier
+    const tagKey = (yield* KeyBuilder.createString(sourceFile, name, "service")) || name
+
     return [{
       name: `Service<${name}>`,
       kind: ts.ScriptElementKind.constElement,
-      insertText: `${effectIdentifier}.Service<${name}>()("${name}", {${"${0}"}}){}`,
+      insertText: `${effectIdentifier}.Service<${name}>()("${tagKey}", {${"${0}"}}){}`,
       replacementSpan,
       isSnippet: true
     }, {
       name: `Tag("${name}")`,
       kind: ts.ScriptElementKind.constElement,
-      insertText: `${effectIdentifier}.Tag("${name}")<${name}, {${"${0}"}}>(){}`,
+      insertText: `${effectIdentifier}.Tag("${tagKey}")<${name}, {${"${0}"}}>(){}`,
       replacementSpan,
       isSnippet: true
     }] satisfies Array<LSP.CompletionEntryDefinition>

--- a/src/core/KeyBuilder.ts
+++ b/src/core/KeyBuilder.ts
@@ -1,0 +1,89 @@
+import type ts from "typescript"
+import * as LanguageServicePluginOptions from "./LanguageServicePluginOptions.js"
+import * as Nano from "./Nano.js"
+import * as TypeScriptApi from "./TypeScriptApi.js"
+import * as TypeScriptUtils from "./TypeScriptUtils.js"
+
+export type KeyBuilderKind = "service" | "error"
+
+export interface KeyBuilder {
+  createString(identifier: string, kind: KeyBuilderKind): string | undefined
+}
+
+export const makeKeyBuilder = Nano.fn("KeyBuilder")(
+  function*(sourceFile: ts.SourceFile) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
+    const program = yield* Nano.service(TypeScriptApi.TypeScriptProgram)
+    const options = yield* Nano.service(LanguageServicePluginOptions.LanguageServicePluginOptions)
+
+    // Get package info for this source file, skip validation if not available
+    const packageInfo = tsUtils.resolveModuleWithPackageInfoFromSourceFile(program, sourceFile)
+
+    function createString(classNameText: string, kind: KeyBuilderKind): string | undefined {
+      if (!packageInfo) return
+
+      for (const keyPattern of options.keyPatterns) {
+        // ensure this pattern applies for this kind
+        if (keyPattern.target !== kind) continue
+
+        // simple package identifier + name
+        if (keyPattern.pattern === "package-identifier") {
+          return packageInfo.name + "/" + classNameText
+        }
+        // gets the dirname of the source file
+        const dirPath = TypeScriptApi.getDirectoryPath(ts, sourceFile.fileName)
+        if (!dirPath.startsWith(packageInfo.packageDirectory)) return
+        let subDirectory = dirPath.slice(packageInfo.packageDirectory.length)
+        if (subDirectory.startsWith("/")) subDirectory = subDirectory.slice(1)
+        const lastIndex = sourceFile.fileName.lastIndexOf("/")
+        let subModule = lastIndex === -1 ? "" : sourceFile.fileName.slice(lastIndex + 1)
+        for (const extension of [".ts", ".tsx", ".js", ".jsx"]) {
+          if (subModule.toLowerCase().endsWith(extension)) {
+            subModule = subModule.slice(0, -extension.length)
+            break
+          }
+        }
+        if (subModule.toLowerCase().endsWith("/index")) subModule = subModule.slice(0, -6)
+        if (subModule.startsWith("/")) subModule = subModule.slice(1)
+
+        // remove the configured prefixes
+        for (const prefix of keyPattern.skipLeadingPath) {
+          if (subDirectory.startsWith(prefix)) {
+            subDirectory = subDirectory.slice(prefix.length)
+            break
+          }
+        }
+
+        // construct the parts of the expected identifier
+        const parts = [packageInfo.name, subDirectory, subModule].concat(
+          subModule.toLowerCase() === classNameText.toLowerCase() ? [] : [classNameText]
+        )
+
+        return parts.filter((_) => String(_).trim().length > 0).join("/")
+      }
+    }
+
+    return {
+      createString
+    }
+  }
+)
+
+const keyBuilderCache = new Map<string, KeyBuilder>()
+
+export const getOrMakeKeyBuilder = Nano.fn("getOrMakeKeyBuilder")(function*(
+  sourceFile: ts.SourceFile
+) {
+  const keyBuilder = keyBuilderCache.get(sourceFile.fileName) ||
+    (yield* makeKeyBuilder(sourceFile))
+  keyBuilderCache.set(sourceFile.fileName, keyBuilder)
+  return keyBuilder
+})
+
+export function createString(sourceFile: ts.SourceFile, identifier: string, kind: KeyBuilderKind) {
+  return Nano.map(
+    getOrMakeKeyBuilder(sourceFile),
+    (identifierBuilder) => identifierBuilder.createString(identifier, kind)
+  )
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,4 +1,5 @@
 import { classSelfMismatch } from "./diagnostics/classSelfMismatch.js"
+import { deterministicKeys } from "./diagnostics/deterministicKeys.js"
 import { duplicatePackage } from "./diagnostics/duplicatePackage.js"
 import { effectGenUsesAdapter } from "./diagnostics/effectGenUsesAdapter.js"
 import { effectInVoidSuccess } from "./diagnostics/effectInVoidSuccess.js"
@@ -49,5 +50,6 @@ export const diagnostics = [
   outdatedEffectCodegen,
   overriddenSchemaConstructor,
   unsupportedServiceAccessors,
-  nonObjectEffectServiceType
+  nonObjectEffectServiceType,
+  deterministicKeys
 ]

--- a/src/diagnostics/deterministicKeys.ts
+++ b/src/diagnostics/deterministicKeys.ts
@@ -1,0 +1,87 @@
+import { pipe } from "effect"
+import type ts from "typescript"
+import * as KeyBuilder from "../core/KeyBuilder.js"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const deterministicKeys = LSP.createDiagnostic({
+  name: "deterministicKeys",
+  code: 25,
+  severity: "off",
+  apply: Nano.fn("deterministicKeys.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+
+      // Check if this is a class declaration that extends Effect.Service, Context.Tag, or Effect.Tag
+      if (ts.isClassDeclaration(node) && node.name && node.heritageClauses) {
+        // Try to parse as one of the supported tag/service types
+        // @effect-diagnostics-next-line unnecessaryPipeChain:off
+        const result = yield* pipe(
+          pipe(
+            typeParser.extendsEffectService(node),
+            Nano.orElse(() => typeParser.extendsContextTag(node)),
+            Nano.orElse(() => typeParser.extendsEffectTag(node)),
+            Nano.map(({ className, keyStringLiteral }) => ({ keyStringLiteral, className, target: "service" as const }))
+          ),
+          Nano.orElse(() =>
+            pipe(
+              typeParser.extendsDataTaggedError(node),
+              Nano.orElse(() => typeParser.extendsSchemaTaggedError(node)),
+              Nano.map(({ className, keyStringLiteral }) => ({ keyStringLiteral, className, target: "error" as const }))
+            )
+          ),
+          Nano.orElse(() => Nano.void_)
+        )
+
+        if (result && result.keyStringLiteral) {
+          const { className, keyStringLiteral } = result
+
+          // Get the class name text
+          const classNameText = ts.idText(className)
+
+          // build the expected identifier
+          const expectedKey = yield* KeyBuilder.createString(sourceFile, classNameText, result.target)
+          if (!expectedKey) return
+
+          // Get the actual identifier from the keyStringLiteral
+          const actualIdentifier = keyStringLiteral.text
+
+          // Report diagnostic if they don't match
+          if (actualIdentifier !== expectedKey) {
+            report({
+              location: keyStringLiteral,
+              messageText: `Key should be '${expectedKey}'`,
+              fixes: [{
+                fixName: "deterministicKeys_fix",
+                description: `Replace '${actualIdentifier}' with '${expectedKey}'`,
+                apply: Nano.gen(function*() {
+                  const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+
+                  // Create a new string literal with the correct identifier
+                  const newStringLiteral = ts.factory.createStringLiteral(expectedKey)
+
+                  // Replace the incorrect string literal with the correct one
+                  changeTracker.replaceNode(sourceFile, keyStringLiteral, newStringLiteral)
+                })
+              }]
+            })
+          }
+        }
+      }
+
+      ts.forEachChild(node, appendNodeToVisit)
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -3,13 +3,29 @@
 exports[`Completion contextSelfInClasses > contextSelfInClasses.ts at 4:40 1`] = `
 [
   {
-    "insertText": "Context.Tag("MyService")<MyService, \${0}>(){}",
+    "insertText": "Context.Tag("@effect/language-service/MyService")<MyService, \${0}>(){}",
     "isSnippet": true,
     "kind": "const",
     "name": "Tag("MyService")",
     "replacementSpan": {
       "length": 8,
       "start": 144,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion contextSelfInClasses > contextSelfInClasses_identifierKey.ts at 5:40 1`] = `
+[
+  {
+    "insertText": "Context.Tag("@effect/language-service/MyService")<MyService, \${0}>(){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "Tag("MyService")",
+    "replacementSpan": {
+      "length": 8,
+      "start": 240,
     },
     "sortText": "11",
   },
@@ -184,7 +200,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -195,7 +211,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",
@@ -309,7 +325,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_tagg.t
 exports[`Completion effectSelfInClasses > effectSelfInClasses.ts at 4:39 1`] = `
 [
   {
-    "insertText": "Effect.Service<MyService>()("MyService", {\${0}}){}",
+    "insertText": "Effect.Service<MyService>()("@effect/language-service/MyService", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "Service<MyService>",
@@ -320,7 +336,7 @@ exports[`Completion effectSelfInClasses > effectSelfInClasses.ts at 4:39 1`] = `
     "sortText": "11",
   },
   {
-    "insertText": "Effect.Tag("MyService")<MyService, {\${0}}>(){}",
+    "insertText": "Effect.Tag("@effect/language-service/MyService")<MyService, {\${0}}>(){}",
     "isSnippet": true,
     "kind": "const",
     "name": "Tag("MyService")",

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.codefixes
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.codefixes
@@ -1,0 +1,6 @@
+deterministicKeys_fix from 317 to 344
+deterministicKeys_skipNextLine from 317 to 344
+deterministicKeys_skipFile from 317 to 344
+deterministicKeys_fix from 428 to 436
+deterministicKeys_skipNextLine from 428 to 436
+deterministicKeys_skipFile from 428 to 436

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_fix.from317to344.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_fix.from317to344.output
@@ -1,0 +1,11 @@
+// code fix deterministicKeys_fix  output for range 317 - 344
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default" }, { "target": "error", "pattern": "default" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("@effect/language-service/ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_fix.from428to436.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_fix.from428to436.output
@@ -1,0 +1,11 @@
+// code fix deterministicKeys_fix  output for range 428 - 436
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default" }, { "target": "error", "pattern": "default" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("@effect/language-service/ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipFile.from317to344.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipFile.from317to344.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipFile  output for range 317 - 344
+/** @effect-diagnostics deterministicKeys:skip-file */
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default" }, { "target": "error", "pattern": "default" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipFile.from428to436.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipFile.from428to436.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipFile  output for range 428 - 436
+/** @effect-diagnostics deterministicKeys:skip-file */
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default" }, { "target": "error", "pattern": "default" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipNextLine.from317to344.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipNextLine.from317to344.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipNextLine  output for range 317 - 344
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default" }, { "target": "error", "pattern": "default" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+// @effect-diagnostics-next-line deterministicKeys:off
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipNextLine.from428to436.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.deterministicKeys_skipNextLine.from428to436.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipNextLine  output for range 428 - 436
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default" }, { "target": "error", "pattern": "default" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+// @effect-diagnostics-next-line deterministicKeys:off
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.output
@@ -1,0 +1,5 @@
+"ExpectedServiceIdentifier"
+7:22 - 7:49 | 1 | Key should be '@effect/language-service/ExpectedServiceIdentifier'
+
+"ErrorA"
+10:45 - 10:53 | 1 | Key should be '@effect/language-service/ErrorA'

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.codefixes
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.codefixes
@@ -1,0 +1,6 @@
+deterministicKeys_fix from 339 to 366
+deterministicKeys_skipNextLine from 339 to 366
+deterministicKeys_skipFile from 339 to 366
+deterministicKeys_fix from 450 to 458
+deterministicKeys_skipNextLine from 450 to 458
+deterministicKeys_skipFile from 450 to 458

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_fix.from339to366.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_fix.from339to366.output
@@ -1,0 +1,11 @@
+// code fix deterministicKeys_fix  output for range 339 - 366
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "package-identifier" }, { "target": "error", "pattern": "package-identifier" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("@effect/language-service/ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_fix.from450to458.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_fix.from450to458.output
@@ -1,0 +1,11 @@
+// code fix deterministicKeys_fix  output for range 450 - 458
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "package-identifier" }, { "target": "error", "pattern": "package-identifier" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("@effect/language-service/ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipFile.from339to366.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipFile.from339to366.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipFile  output for range 339 - 366
+/** @effect-diagnostics deterministicKeys:skip-file */
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "package-identifier" }, { "target": "error", "pattern": "package-identifier" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipFile.from450to458.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipFile.from450to458.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipFile  output for range 450 - 458
+/** @effect-diagnostics deterministicKeys:skip-file */
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "package-identifier" }, { "target": "error", "pattern": "package-identifier" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipNextLine.from339to366.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipNextLine.from339to366.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipNextLine  output for range 339 - 366
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "package-identifier" }, { "target": "error", "pattern": "package-identifier" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+// @effect-diagnostics-next-line deterministicKeys:off
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipNextLine.from450to458.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.deterministicKeys_skipNextLine.from450to458.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipNextLine  output for range 450 - 458
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "package-identifier" }, { "target": "error", "pattern": "package-identifier" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+// @effect-diagnostics-next-line deterministicKeys:off
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.output
@@ -1,0 +1,5 @@
+"ExpectedServiceIdentifier"
+7:22 - 7:49 | 1 | Key should be '@effect/language-service/ExpectedServiceIdentifier'
+
+"ErrorA"
+10:45 - 10:53 | 1 | Key should be '@effect/language-service/ErrorA'

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -13,7 +13,7 @@ import * as fs from "fs"
 import * as path from "path"
 import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
-import { createServicesWithMockedVFS } from "./utils/mocks.js"
+import { configFromSourceComment, createServicesWithMockedVFS } from "./utils/mocks.js"
 
 const getExamplesCompletionsDir = () => path.join(__dirname, "..", "examples", "completions")
 
@@ -50,14 +50,18 @@ function testCompletionOnExample(
     Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
-    Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
-      ...LanguageServicePluginOptions.defaults,
-      completions: true,
-      refactors: false,
-      diagnostics: false,
-      quickinfo: false,
-      goto: false
-    }),
+    Nano.provideService(
+      LanguageServicePluginOptions.LanguageServicePluginOptions,
+      LanguageServicePluginOptions.parse({
+        ...LanguageServicePluginOptions.defaults,
+        completions: true,
+        refactors: false,
+        diagnostics: false,
+        quickinfo: false,
+        goto: false,
+        ...configFromSourceComment(sourceText)
+      })
+    ),
     Nano.unsafeRun
   )
 

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -13,7 +13,7 @@ import * as fs from "fs"
 import * as path from "path"
 import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
-import { applyEdits, createServicesWithMockedVFS } from "./utils/mocks.js"
+import { applyEdits, configFromSourceComment, createServicesWithMockedVFS } from "./utils/mocks.js"
 
 const getExamplesDiagnosticsDir = () => path.join(__dirname, "..", "examples", "diagnostics")
 
@@ -63,15 +63,19 @@ function testDiagnosticOnExample(
     Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
-    Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
-      ...LanguageServicePluginOptions.defaults,
-      diagnostics: true,
-      refactors: false,
-      quickinfo: false,
-      completions: false,
-      goto: false,
-      namespaceImportPackages: ["effect"]
-    }),
+    Nano.provideService(
+      LanguageServicePluginOptions.LanguageServicePluginOptions,
+      LanguageServicePluginOptions.parse({
+        ...LanguageServicePluginOptions.defaults,
+        diagnostics: true,
+        refactors: false,
+        quickinfo: false,
+        completions: false,
+        goto: false,
+        namespaceImportPackages: ["effect"],
+        ...configFromSourceComment(sourceText)
+      })
+    ),
     Nano.map(({ diagnostics }) => {
       // sort by start position
       diagnostics.sort((a, b) => (a.start || 0) - (b.start || 0))
@@ -169,15 +173,19 @@ function testDiagnosticQuickfixesOnExample(
     Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
-    Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
-      ...LanguageServicePluginOptions.defaults,
-      diagnostics: true,
-      refactors: false,
-      quickinfo: false,
-      completions: false,
-      goto: false,
-      namespaceImportPackages: ["effect"]
-    }),
+    Nano.provideService(
+      LanguageServicePluginOptions.LanguageServicePluginOptions,
+      LanguageServicePluginOptions.parse({
+        ...LanguageServicePluginOptions.defaults,
+        diagnostics: true,
+        refactors: false,
+        quickinfo: false,
+        completions: false,
+        goto: false,
+        namespaceImportPackages: ["effect"],
+        ...configFromSourceComment(sourceText)
+      })
+    ),
     Nano.unsafeRun,
     async (result) => {
       expect(Either.isRight(result), "should run with no error " + result).toEqual(true)

--- a/test/internals.test.ts
+++ b/test/internals.test.ts
@@ -1,8 +1,23 @@
 import * as Nano from "@effect/language-service/core/Nano"
 import * as Either from "effect/Either"
 import { pipe } from "effect/Function"
+import { configFromSourceComment } from "./utils/mocks"
 
 import { describe, expect, it } from "vitest"
+
+describe("configFromSourceComment", () => {
+  it("should return the config from the source comment", () => {
+    const config = configFromSourceComment(`
+      // @test-config { "key": "value" }
+      console.log("hello")
+      `)
+    expect(config).toEqual({ key: "value" })
+  })
+  it("should return an empty object if there is no config", () => {
+    const config = configFromSourceComment("console.log('hello')")
+    expect(config).toEqual({})
+  })
+})
 
 describe("nano", () => {
   it("flatMap-ping", () => {

--- a/test/refactors.test.ts
+++ b/test/refactors.test.ts
@@ -13,7 +13,7 @@ import * as fs from "fs"
 import * as path from "path"
 import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
-import { applyEdits, createServicesWithMockedVFS } from "./utils/mocks.js"
+import { applyEdits, configFromSourceComment, createServicesWithMockedVFS } from "./utils/mocks.js"
 
 const getExamplesRefactorsDir = () => path.join(__dirname, "..", "examples", "refactors")
 
@@ -78,14 +78,18 @@ function testRefactorOnExample(
     Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
-    Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
-      ...LanguageServicePluginOptions.defaults,
-      refactors: true,
-      diagnostics: false,
-      quickinfo: false,
-      completions: false,
-      goto: false
-    }),
+    Nano.provideService(
+      LanguageServicePluginOptions.LanguageServicePluginOptions,
+      LanguageServicePluginOptions.parse({
+        ...LanguageServicePluginOptions.defaults,
+        refactors: true,
+        diagnostics: false,
+        quickinfo: false,
+        completions: false,
+        goto: false,
+        ...configFromSourceComment(sourceText)
+      })
+    ),
     Nano.unsafeRun
   )
 
@@ -102,14 +106,18 @@ function testRefactorOnExample(
     Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
-    Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
-      ...LanguageServicePluginOptions.defaults,
-      refactors: true,
-      diagnostics: false,
-      quickinfo: false,
-      completions: false,
-      goto: false
-    }),
+    Nano.provideService(
+      LanguageServicePluginOptions.LanguageServicePluginOptions,
+      LanguageServicePluginOptions.parse({
+        ...LanguageServicePluginOptions.defaults,
+        refactors: true,
+        diagnostics: false,
+        quickinfo: false,
+        completions: false,
+        goto: false,
+        ...configFromSourceComment(sourceText)
+      })
+    ),
     Nano.unsafeRun
   )
 

--- a/test/renames.test.ts
+++ b/test/renames.test.ts
@@ -12,7 +12,7 @@ import * as fs from "fs"
 import * as path from "path"
 import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
-import { applyEdits, createServicesWithMockedVFS } from "./utils/mocks.js"
+import { applyEdits, configFromSourceComment, createServicesWithMockedVFS } from "./utils/mocks.js"
 
 interface RenameRunner {
   (
@@ -96,14 +96,18 @@ function testRenamesOnExample(
     Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
     Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
     Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
-    Nano.provideService(LanguageServicePluginOptions.LanguageServicePluginOptions, {
-      ...LanguageServicePluginOptions.defaults,
-      refactors: true,
-      diagnostics: false,
-      quickinfo: false,
-      completions: false,
-      goto: false
-    }),
+    Nano.provideService(
+      LanguageServicePluginOptions.LanguageServicePluginOptions,
+      LanguageServicePluginOptions.parse({
+        ...LanguageServicePluginOptions.defaults,
+        refactors: true,
+        diagnostics: false,
+        quickinfo: false,
+        completions: false,
+        goto: false,
+        ...configFromSourceComment(sourceText)
+      })
+    ),
     Nano.unsafeRun
   )
 

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -102,3 +102,15 @@ export function applyEdits(
   }
   return sourceText
 }
+
+export function configFromSourceComment(
+  sourceText: string
+): Record<string, unknown> {
+  let commentPosition = sourceText.indexOf("@test-config")
+  if (commentPosition === -1) return {}
+  commentPosition += "@test-config".length
+  const commentEndPosition = sourceText.indexOf("\n", commentPosition)
+  if (commentEndPosition === -1) return {}
+  const commentText = sourceText.substring(commentPosition, commentEndPosition)
+  return JSON.parse(commentText.trim())
+}


### PR DESCRIPTION
## Summary

This PR introduces a new diagnostic `deterministicKeys` to enforce consistent and deterministic key patterns for Effect Services and Tagged Errors. Additionally, it enhances the `contextSelfInClasses` completion to automatically suggest keys using the configured patterns.

### Features Added

#### 1. **deterministicKeys Diagnostic** 
A new diagnostic that validates Service and Error keys against configurable patterns. The diagnostic is disabled by default and can be enabled via configuration.

**Supported Patterns:**
- **`default`**: Constructs keys from `package name + file path + class identifier`
  - Example: `@effect/language-service/FileName/ClassIdentifier`
  - Supports `skipLeadingPath` option to remove common prefixes (e.g., `src/`)
  
- **`package-identifier`**: Uses `package name + identifier` for flat project structures
  - Example: `@effect/language-service/ServiceName`

**Example Configuration:**
```jsonc
{
  "diagnosticSeverity": {
    "deterministicKeys": "error"
  },
  "keyPatterns": [
    {
      "target": "service",
      "pattern": "default",
      "skipLeadingPath": ["src/"]
    }
  ]
}
```

**Example Diagnostic Output:**

For this code:
```typescript
export class ExpectedServiceIdentifier
  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
{}
```

The diagnostic reports:
```
Key should be '@effect/language-service/ExpectedServiceIdentifier'
```

The diagnostic provides auto-fix code actions:
- **Fix**: Updates the key to match the configured pattern
- **Skip next line**: Adds a comment to disable the check for the next line
- **Skip file**: Adds a comment to disable the check for the entire file

#### 2. **contextSelfInClasses Completion Enhancement**
The completion now automatically suggests keys based on the configured `keyPatterns`, making it easier to use deterministic keys from the start.

**Example:**
When typing `Context.` inside a class, the completion suggests:
```typescript
Tag("@effect/language-service/MyService")<MyService, ${0}>(){}
```

### Documentation

- Added comprehensive documentation in README.md under "Configuring Key Patterns"
- Added example files demonstrating both patterns
- All tests passing with snapshot updates

## Test plan
- [x] Run `pnpm lint-fix` to fix formatting
- [x] Run `pnpm check` to verify type errors
- [x] Run `pnpm test` to validate all tests pass
- [x] Regenerate snapshots and verify expected changes
- [x] Verify README.md documentation is complete
- [x] Create changeset file

🤖 Generated with [Claude Code](https://claude.com/claude-code)