### PR TITLE
Defer TypeScript loading in CLI

### DIFF
--- a/.changeset/old-rings-hang.md
+++ b/.changeset/old-rings-hang.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Defer typescript loading in CLI

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,12 +1,10 @@
-/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Command from "@effect/cli/Command"
 import * as Options from "@effect/cli/Options"
 import * as FileSystem from "@effect/platform/FileSystem"
 import { pipe } from "effect"
 import * as Array from "effect/Array"
 import * as Effect from "effect/Effect"
-import * as ts from "typescript"
-import { extractAppliedEffectLspPatches, getModuleFilePath, getPackageJsonData } from "./utils"
+import { extractAppliedEffectLspPatches, getModuleFilePath, getPackageJsonData, getTypeScript } from "./utils"
 
 const LOCAL_TYPESCRIPT_DIR = "./node_modules/typescript"
 
@@ -20,6 +18,7 @@ export const check = Command.make(
   { dirPath },
   Effect.fn("check")(function*({ dirPath }) {
     const fs = yield* FileSystem.FileSystem
+    const ts = yield* getTypeScript
 
     // read my data
     const { version: effectLspVersion } = yield* getPackageJsonData(__dirname)

--- a/src/cli/patch.ts
+++ b/src/cli/patch.ts
@@ -1,16 +1,16 @@
-/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Command from "@effect/cli/Command"
 import * as Options from "@effect/cli/Options"
 import * as FileSystem from "@effect/platform/FileSystem"
 import * as Data from "effect/Data"
 import * as Effect from "effect/Effect"
 import * as Option from "effect/Option"
-import * as ts from "typescript"
+import type * as ts from "typescript"
 import {
   applyTextChanges,
   getEffectLspPatchUtils,
   getModuleFilePath,
   getPackageJsonData,
+  getTypeScript,
   getTypeScriptApisUtils,
   getUnpatchedSourceFile,
   makeEffectLspPatchChange
@@ -41,6 +41,8 @@ const moduleNames = Options.choice("module", [
 
 const getPatchesForModule = Effect.fn("getPatchesForModule")(
   function*(moduleName: "tsc" | "typescript", dirPath: string, version: string, sourceFile: ts.SourceFile) {
+    const ts = yield* getTypeScript
+
     const patches: Array<ts.TextChange> = []
     let insertClearSourceFileEffectMetadataPosition: Option.Option<{ position: number }> = Option.none()
     let insertCheckSourceFilePosition: Option.Option<{ position: number }> = Option.none()


### PR DESCRIPTION
## Summary
- Refactored CLI utilities to dynamically load TypeScript package as an Effect
- Removed direct imports of TypeScript that violated `@typescript-eslint/no-restricted-imports` rule
- Added `getTypeScript` helper function that loads TypeScript on-demand

## Changes
- `src/cli/utils.ts`: Added `getTypeScript` Effect and `UnableToFindInstalledTypeScriptPackage` error type
- `src/cli/check.ts`: Updated to yield TypeScript from `getTypeScript` instead of direct import
- `src/cli/patch.ts`: Updated to yield TypeScript from `getTypeScript` instead of direct import
- Functions that use TypeScript APIs now yield the TypeScript instance when needed

## Test plan
- [x] All existing tests pass
- [x] No type errors from `pnpm check`
- [x] Linting passes with `pnpm lint-fix`
- [x] Snapshots regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)