### PR TITLE
Add diagnosticsName option to include rule names in diagnostic messages

### DIFF
--- a/.changeset/eleven-bugs-judge.md
+++ b/.changeset/eleven-bugs-judge.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add `diagnosticsName` option to include rule names in diagnostic messages. When enabled (default: true), diagnostic messages will display the rule name at the end, e.g., "Effect must be yielded or assigned to a variable.    effect(floatingEffect)"

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Few options can be provided alongside the initialization of the Language Service
         "diagnosticSeverity": { // allows to change per-rule default severity of the diagnostic in the whole project
           "floatingEffect": "warning" // example for a rule, allowed values are off,error,warning,message,suggestion
         },
+        "diagnosticsName": true, // controls whether to include the rule name in diagnostic messages (default: true)
         "quickinfo": true, // controls Effect quickinfo (default: true)
         "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
         "quickinfoMaximumLength": -1, // controls how long can be the types in the quickinfo hover (helps with very long type to improve perfs, defaults to -1 for no truncation, can be any number eg. 1000 and TS will try to fit as much as possible in that budget, higher number means more info.)

--- a/src/core/LSP.ts
+++ b/src/core/LSP.ts
@@ -377,7 +377,9 @@ const createDiagnosticExecutor = Nano.fn("LSP.createCommentDirectivesProcessor")
             : tsUtils.findNodeAtPositionIncludingTrivia(sourceFile, entry.location.pos)
           applicableDiagnostics.push({
             range,
-            messageText: entry.messageText,
+            messageText: pluginOptions.diagnosticsName
+              ? `${entry.messageText}    effect(${rule.name})`
+              : entry.messageText,
             fixes: entry.fixes.concat(node ? [fixByDisableNextLine(node)] : []).concat([fixByDisableEntireFile])
           })
         })

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -17,6 +17,7 @@ export interface LanguageServicePluginOptions {
   refactors: boolean
   diagnostics: boolean
   diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
+  diagnosticsName: boolean
   quickinfoEffectParameters: "always" | "never" | "whentruncated"
   quickinfo: boolean
   quickinfoMaximumLength: number
@@ -53,6 +54,7 @@ export const defaults: LanguageServicePluginOptions = {
   refactors: true,
   diagnostics: true,
   diagnosticSeverity: {},
+  diagnosticsName: true,
   quickinfo: true,
   quickinfoEffectParameters: "whentruncated",
   quickinfoMaximumLength: -1,
@@ -107,6 +109,9 @@ export function parse(config: any): LanguageServicePluginOptions {
       isObject(config) && hasProperty(config, "diagnosticSeverity") && isRecord(config.diagnosticSeverity)
         ? parseDiagnosticSeverity(config.diagnosticSeverity)
         : defaults.diagnosticSeverity,
+    diagnosticsName: isObject(config) && hasProperty(config, "diagnosticsName") && isBoolean(config.diagnosticsName)
+      ? config.diagnosticsName
+      : defaults.diagnosticsName,
     quickinfo: isObject(config) && hasProperty(config, "quickinfo") && isBoolean(config.quickinfo)
       ? config.quickinfo
       : defaults.quickinfo,

--- a/test/__snapshots__/diagnostics/classSelfMismatch.ts.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch.ts.output
@@ -1,2 +1,2 @@
 ValidServiceSelfParameter
-13:25 - 13:50 | 1 | Self type parameter should be 'InvalidServiceSelfParameter'
+13:25 - 13:50 | 1 | Self type parameter should be 'InvalidServiceSelfParameter'    effect(classSelfMismatch)

--- a/test/__snapshots__/diagnostics/classSelfMismatch_contextTag.ts.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_contextTag.ts.output
@@ -1,2 +1,2 @@
 ValidContextTag
-11:70 - 11:85 | 1 | Self type parameter should be 'InvalidContextTag'
+11:70 - 11:85 | 1 | Self type parameter should be 'InvalidContextTag'    effect(classSelfMismatch)

--- a/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_effectTag.ts.output
@@ -1,2 +1,2 @@
 ValidContextTag
-11:69 - 11:84 | 1 | Self type parameter should be 'InvalidContextTag'
+11:69 - 11:84 | 1 | Self type parameter should be 'InvalidContextTag'    effect(classSelfMismatch)

--- a/test/__snapshots__/diagnostics/classSelfMismatch_schema.ts.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_schema.ts.output
@@ -1,11 +1,11 @@
 ValidSchemaClass
-9:53 - 9:69 | 1 | Self type parameter should be 'InvalidSchemaClass'
+9:53 - 9:69 | 1 | Self type parameter should be 'InvalidSchemaClass'    effect(classSelfMismatch)
 
 ValidSchemaTaggedClass
-21:29 - 21:51 | 1 | Self type parameter should be 'InvalidSchemaTaggedClass'
+21:29 - 21:51 | 1 | Self type parameter should be 'InvalidSchemaTaggedClass'    effect(classSelfMismatch)
 
 ValidSchemaTaggedError
-34:29 - 34:51 | 1 | Self type parameter should be 'InvalidSchemaTaggedError'
+34:29 - 34:51 | 1 | Self type parameter should be 'InvalidSchemaTaggedError'    effect(classSelfMismatch)
 
 ValidSchemaTaggedRequest
-49:31 - 49:55 | 1 | Self type parameter should be 'InvalidSchemaTaggedRequest'
+49:31 - 49:55 | 1 | Self type parameter should be 'InvalidSchemaTaggedRequest'    effect(classSelfMismatch)

--- a/test/__snapshots__/diagnostics/classSelfMismatch_unionGiven.ts.output
+++ b/test/__snapshots__/diagnostics/classSelfMismatch_unionGiven.ts.output
@@ -1,2 +1,2 @@
 MyService | OtherService
-9:56 - 9:80 | 1 | Self type parameter should be 'MyService'
+9:56 - 9:80 | 1 | Self type parameter should be 'MyService'    effect(classSelfMismatch)

--- a/test/__snapshots__/diagnostics/deterministicKeys.ts.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys.ts.output
@@ -1,5 +1,5 @@
 "ExpectedServiceIdentifier"
-7:22 - 7:49 | 1 | Key should be '@effect/language-service/ExpectedServiceIdentifier'
+7:22 - 7:49 | 1 | Key should be '@effect/language-service/ExpectedServiceIdentifier'    effect(deterministicKeys)
 
 "ErrorA"
-10:45 - 10:53 | 1 | Key should be '@effect/language-service/ErrorA'
+10:45 - 10:53 | 1 | Key should be '@effect/language-service/ErrorA'    effect(deterministicKeys)

--- a/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_packageIdentifier.ts.output
@@ -1,5 +1,5 @@
 "ExpectedServiceIdentifier"
-7:22 - 7:49 | 1 | Key should be '@effect/language-service/ExpectedServiceIdentifier'
+7:22 - 7:49 | 1 | Key should be '@effect/language-service/ExpectedServiceIdentifier'    effect(deterministicKeys)
 
 "ErrorA"
-10:45 - 10:53 | 1 | Key should be '@effect/language-service/ErrorA'
+10:45 - 10:53 | 1 | Key should be '@effect/language-service/ErrorA'    effect(deterministicKeys)

--- a/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.output
+++ b/test/__snapshots__/diagnostics/effectGenUsesAdapter.ts.output
@@ -1,2 +1,2 @@
 _
-9:47 - 9:48 | 0 | The adapter of Effect.gen is not required anymore, it is now just an alias of pipe.
+9:47 - 9:48 | 0 | The adapter of Effect.gen is not required anymore, it is now just an alias of pipe.    effect(effectGenUsesAdapter)

--- a/test/__snapshots__/diagnostics/effectInVoidSuccess.ts.output
+++ b/test/__snapshots__/diagnostics/effectInVoidSuccess.ts.output
@@ -1,5 +1,5 @@
 shouldReport
-4:13 - 4:25 | 0 | There is a nested 'Effect<number, never, never>' in the 'void' success channel, beware that this could lead to nested Effect<Effect<...>> that won't be executed.
+4:13 - 4:25 | 0 | There is a nested 'Effect<number, never, never>' in the 'void' success channel, beware that this could lead to nested Effect<Effect<...>> that won't be executed.    effect(effectInVoidSuccess)
 
 return Stream.empty.pipe(
     Stream.runCollect,
@@ -9,4 +9,4 @@ return Stream.empty.pipe(
       onFailure: () => Effect.fail("error")
     })
   )
-7:2 - 14:3 | 0 | There is a nested 'Effect<never, string, never>' in the 'void' success channel, beware that this could lead to nested Effect<Effect<...>> that won't be executed.
+7:2 - 14:3 | 0 | There is a nested 'Effect<never, string, never>' in the 'void' success channel, beware that this could lead to nested Effect<Effect<...>> that won't be executed.    effect(effectInVoidSuccess)

--- a/test/__snapshots__/diagnostics/floatingEffect.ts.output
+++ b/test/__snapshots__/diagnostics/floatingEffect.ts.output
@@ -1,8 +1,8 @@
 Effect.succeed("floating")
-5:0 - 5:26 | 1 | Effect must be yielded or assigned to a variable.
+5:0 - 5:26 | 1 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)
 
 Effect.never
-7:0 - 7:12 | 1 | Effect must be yielded or assigned to a variable.
+7:0 - 7:12 | 1 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)
 
 Effect.never
-11:2 - 11:14 | 1 | Effect must be yielded or assigned to a variable.
+11:2 - 11:14 | 1 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)

--- a/test/__snapshots__/diagnostics/floatingEffect_disableNextLine.ts.output
+++ b/test/__snapshots__/diagnostics/floatingEffect_disableNextLine.ts.output
@@ -1,5 +1,5 @@
 Effect.succeed(true)
-3:0 - 3:20 | 1 | Effect must be yielded or assigned to a variable.
+3:0 - 3:20 | 1 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)
 
 Effect.succeed(false)
-6:0 - 6:21 | 1 | Effect must be yielded or assigned to a variable.
+6:0 - 6:21 | 1 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)

--- a/test/__snapshots__/diagnostics/floatingEffect_disableNextLineFix.ts.output
+++ b/test/__snapshots__/diagnostics/floatingEffect_disableNextLineFix.ts.output
@@ -1,2 +1,2 @@
 Effect.succeed(42)
-4:2 - 4:20 | 1 | Effect must be yielded or assigned to a variable.
+4:2 - 4:20 | 1 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)

--- a/test/__snapshots__/diagnostics/floatingEffect_disabled.ts.output
+++ b/test/__snapshots__/diagnostics/floatingEffect_disabled.ts.output
@@ -1,8 +1,8 @@
 Effect.succeed(1)
-4:0 - 4:17 | 0 | Effect must be yielded or assigned to a variable.
+4:0 - 4:17 | 0 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)
 
 Effect.succeed(1)
-12:0 - 12:17 | 1 | Effect must be yielded or assigned to a variable.
+12:0 - 12:17 | 1 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)
 
 Effect.succeed(1)
-16:0 - 16:17 | 2 | Effect must be yielded or assigned to a variable.
+16:0 - 16:17 | 2 | Effect must be yielded or assigned to a variable.    effect(floatingEffect)

--- a/test/__snapshots__/diagnostics/floatingEffect_stream.ts.output
+++ b/test/__snapshots__/diagnostics/floatingEffect_stream.ts.output
@@ -1,2 +1,2 @@
 Stream.succeed(42)
-5:2 - 5:20 | 1 | Effect-able Stream<number, never, never> must be yielded or assigned to a variable.
+5:2 - 5:20 | 1 | Effect-able Stream<number, never, never> must be yielded or assigned to a variable.    effect(floatingEffect)

--- a/test/__snapshots__/diagnostics/genericEffectServices.ts.output
+++ b/test/__snapshots__/diagnostics/genericEffectServices.ts.output
@@ -1,2 +1,2 @@
 ShouldReport
-7:13 - 7:25 | 0 | Effect Services with type parameters are not supported because they cannot be properly discriminated at runtime, which may cause unexpected behavior.
+7:13 - 7:25 | 0 | Effect Services with type parameters are not supported because they cannot be properly discriminated at runtime, which may cause unexpected behavior.    effect(genericEffectServices)

--- a/test/__snapshots__/diagnostics/importFromBarrel.ts.output
+++ b/test/__snapshots__/diagnostics/importFromBarrel.ts.output
@@ -1,5 +1,5 @@
 Effect
-2:9 - 2:15 | 1 | Importing from barrel module effect is not allowed.
+2:9 - 2:15 | 1 | Importing from barrel module effect is not allowed.    effect(importFromBarrel)
 
 Predicate as P
-3:9 - 3:23 | 1 | Importing from barrel module effect is not allowed.
+3:9 - 3:23 | 1 | Importing from barrel module effect is not allowed.    effect(importFromBarrel)

--- a/test/__snapshots__/diagnostics/leakingRequirements.ts.output
+++ b/test/__snapshots__/diagnostics/leakingRequirements.ts.output
@@ -1,9 +1,9 @@
 LeakingDeps
 8:13 - 8:24 | 2 | This Service is leaking the FileSystem requirement.
 If these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can safely disable this diagnostic for this line through quickfixes.
-More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage
+More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)
 
 _LocalLeaking
 18:8 - 18:21 | 2 | This Service is leaking the FileSystem requirement.
 If these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can safely disable this diagnostic for this line through quickfixes.
-More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage
+More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)

--- a/test/__snapshots__/diagnostics/leakingRequirements_genericTag.ts.output
+++ b/test/__snapshots__/diagnostics/leakingRequirements_genericTag.ts.output
@@ -1,4 +1,4 @@
 Context.GenericTag<LeakingService>("LeakingService")
 13:26 - 13:78 | 2 | This Service is leaking the FileSystem requirement.
 If these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can safely disable this diagnostic for this line through quickfixes.
-More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage
+More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)

--- a/test/__snapshots__/diagnostics/missingEffectContext_arrowReturnType.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectContext_arrowReturnType.ts.output
@@ -1,2 +1,2 @@
 Effect.void.pipe(Effect.andThen(eff))
-19:2 - 19:39 | 1 | Missing 'R' in the expected Effect context.
+19:2 - 19:39 | 1 | Missing 'R' in the expected Effect context.    effect(missingEffectContext)

--- a/test/__snapshots__/diagnostics/missingEffectContext_callExpression.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectContext_callExpression.ts.output
@@ -1,5 +1,5 @@
 effectWithServices
-22:7 - 22:25 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.
+22:7 - 22:25 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.    effect(missingEffectContext)
 
 effectWithServices
-29:20 - 29:38 | 1 | Missing 'ServiceC' in the expected Effect context.
+29:20 - 29:38 | 1 | Missing 'ServiceC' in the expected Effect context.    effect(missingEffectContext)

--- a/test/__snapshots__/diagnostics/missingEffectContext_conciseBody.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectContext_conciseBody.ts.output
@@ -1,2 +1,2 @@
 effectWithServices
-10:62 - 10:80 | 1 | Missing 'ServiceA' in the expected Effect context.
+10:62 - 10:80 | 1 | Missing 'ServiceA' in the expected Effect context.    effect(missingEffectContext)

--- a/test/__snapshots__/diagnostics/missingEffectContext_lazy.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectContext_lazy.ts.output
@@ -1,2 +1,2 @@
 return Effect.onExit(evaluate(), () => Effect.void)
-19:2 - 19:53 | 1 | Missing 'ServiceA' in the expected Effect context.
+19:2 - 19:53 | 1 | Missing 'ServiceA' in the expected Effect context.    effect(missingEffectContext)

--- a/test/__snapshots__/diagnostics/missingEffectContext_plainAssignment.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectContext_plainAssignment.ts.output
@@ -1,14 +1,14 @@
 missingAllServices
-21:13 - 21:31 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.
+21:13 - 21:31 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.    effect(missingEffectContext)
 
 missingServiceC
-24:13 - 24:28 | 1 | Missing 'ServiceC' in the expected Effect context.
+24:13 - 24:28 | 1 | Missing 'ServiceC' in the expected Effect context.    effect(missingEffectContext)
 
 missingServiceCWithSubtyping
-29:13 - 29:41 | 1 | Missing 'ServiceC' in the expected Effect context.
+29:13 - 29:41 | 1 | Missing 'ServiceC' in the expected Effect context.    effect(missingEffectContext)
 
 missingServiceA
-33:8 - 33:23 | 1 | Missing 'A' in the expected Effect context.
+33:8 - 33:23 | 1 | Missing 'A' in the expected Effect context.    effect(missingEffectContext)
 
 effectWithServices
-38:10 - 38:28 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.
+38:10 - 38:28 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.    effect(missingEffectContext)

--- a/test/__snapshots__/diagnostics/missingEffectContext_returnSignature.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectContext_returnSignature.ts.output
@@ -1,8 +1,8 @@
 return effectWithServices
-19:2 - 19:27 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.
+19:2 - 19:27 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.    effect(missingEffectContext)
 
 effectWithServices
-23:62 - 23:80 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.
+23:62 - 23:80 | 1 | Missing 'ServiceA | ServiceB | ServiceC' in the expected Effect context.    effect(missingEffectContext)
 
 effectWithServices
-27:2 - 27:20 | 1 | Missing 'ServiceC' in the expected Effect context.
+27:2 - 27:20 | 1 | Missing 'ServiceC' in the expected Effect context.    effect(missingEffectContext)

--- a/test/__snapshots__/diagnostics/missingEffectError_callExpression.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectError_callExpression.ts.output
@@ -1,5 +1,5 @@
 effectWithErrors
-23:7 - 23:23 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.
+23:7 - 23:23 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.    effect(missingEffectError)
 
 effectWithErrors
-30:20 - 30:36 | 1 | Missing 'ErrorC' in the expected Effect errors.
+30:20 - 30:36 | 1 | Missing 'ErrorC' in the expected Effect errors.    effect(missingEffectError)

--- a/test/__snapshots__/diagnostics/missingEffectError_plainAssignment.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectError_plainAssignment.ts.output
@@ -1,14 +1,14 @@
 missingAllErrors
-21:13 - 21:29 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.
+21:13 - 21:29 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.    effect(missingEffectError)
 
 missingErrorC
-24:13 - 24:26 | 1 | Missing 'ErrorC' in the expected Effect errors.
+24:13 - 24:26 | 1 | Missing 'ErrorC' in the expected Effect errors.    effect(missingEffectError)
 
 missingErrorCWithSubtyping
-29:13 - 29:39 | 1 | Missing 'ErrorC' in the expected Effect errors.
+29:13 - 29:39 | 1 | Missing 'ErrorC' in the expected Effect errors.    effect(missingEffectError)
 
 missingErrorA
-33:8 - 33:21 | 1 | Missing 'A' in the expected Effect errors.
+33:8 - 33:21 | 1 | Missing 'A' in the expected Effect errors.    effect(missingEffectError)
 
 effectWithErrors
-38:10 - 38:26 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.
+38:10 - 38:26 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.    effect(missingEffectError)

--- a/test/__snapshots__/diagnostics/missingEffectError_returnSignature.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectError_returnSignature.ts.output
@@ -1,8 +1,8 @@
 return effectWithErrors
-20:2 - 20:25 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.
+20:2 - 20:25 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.    effect(missingEffectError)
 
 effectWithErrors
-24:62 - 24:78 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.
+24:62 - 24:78 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.    effect(missingEffectError)
 
 effectWithErrors
-27:94 - 27:110 | 1 | Missing 'ErrorC' in the expected Effect errors.
+27:94 - 27:110 | 1 | Missing 'ErrorC' in the expected Effect errors.    effect(missingEffectError)

--- a/test/__snapshots__/diagnostics/missingEffectError_tagged.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectError_tagged.ts.output
@@ -1,5 +1,5 @@
 effectWithErrors
-19:62 - 19:78 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.
+19:62 - 19:78 | 1 | Missing 'ErrorA | ErrorB | ErrorC' in the expected Effect errors.    effect(missingEffectError)
 
 effectWithErrors
-22:71 - 22:87 | 1 | Missing 'ErrorA | ErrorC' in the expected Effect errors.
+22:71 - 22:87 | 1 | Missing 'ErrorA | ErrorC' in the expected Effect errors.    effect(missingEffectError)

--- a/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.output
+++ b/test/__snapshots__/diagnostics/missingEffectServiceDependency.ts.output
@@ -1,8 +1,8 @@
 InvalidService2
-33:13 - 33:28 | 1 | Service 'SampleService1' is required but not provided by dependencies
+33:13 - 33:28 | 1 | Service 'SampleService1' is required but not provided by dependencies    effect(missingEffectServiceDependency)
 
 InvalidService3
-44:13 - 44:28 | 1 | Service 'SampleService2' is required but not provided by dependencies
+44:13 - 44:28 | 1 | Service 'SampleService2' is required but not provided by dependencies    effect(missingEffectServiceDependency)
 
 InvalidService4
-71:13 - 71:28 | 1 | Service 'SampleService2' is required but not provided by dependencies
+71:13 - 71:28 | 1 | Service 'SampleService2' is required but not provided by dependencies    effect(missingEffectServiceDependency)

--- a/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.output
+++ b/test/__snapshots__/diagnostics/missingReturnYieldStar.ts.output
@@ -1,8 +1,8 @@
 yield* Effect.fail("no zero!")
-11:6 - 11:36 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.
+11:6 - 11:36 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.    effect(missingReturnYieldStar)
 
 yield* Effect.interrupt
-18:4 - 18:27 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.
+18:4 - 18:27 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.    effect(missingReturnYieldStar)
 
 yield* Effect.die("lol")
-19:4 - 19:28 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.
+19:4 - 19:28 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.    effect(missingReturnYieldStar)

--- a/test/__snapshots__/diagnostics/missingStarInYieldEffectGen.ts.output
+++ b/test/__snapshots__/diagnostics/missingStarInYieldEffectGen.ts.output
@@ -1,38 +1,38 @@
 function
-8:45 - 8:53 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.
+8:45 - 8:53 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.    effect(missingStarInYieldEffectGen)
 
 yield Effect.succeed(1)
-9:2 - 9:25 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+9:2 - 9:25 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.    effect(missingStarInYieldEffectGen)
 
 function
-13:53 - 13:61 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.
+13:53 - 13:61 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.    effect(missingStarInYieldEffectGen)
 
 yield Effect.succeed(1)
-14:2 - 14:25 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+14:2 - 14:25 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.    effect(missingStarInYieldEffectGen)
 
 yield Effect.succeed(2)
-15:2 - 15:25 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+15:2 - 15:25 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.    effect(missingStarInYieldEffectGen)
 
 function
-20:20 - 20:28 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.
+20:20 - 20:28 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.    effect(missingStarInYieldEffectGen)
 
 yield Effect.succeed(1)
-21:4 - 21:27 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+21:4 - 21:27 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.    effect(missingStarInYieldEffectGen)
 
 function
-31:39 - 31:47 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.
+31:39 - 31:47 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.    effect(missingStarInYieldEffectGen)
 
 yield Effect.never
-32:2 - 32:20 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+32:2 - 32:20 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.    effect(missingStarInYieldEffectGen)
 
 function
-36:68 - 36:76 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.
+36:68 - 36:76 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.    effect(missingStarInYieldEffectGen)
 
 yield Effect.never
-37:2 - 37:20 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+37:2 - 37:20 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.    effect(missingStarInYieldEffectGen)
 
 function
-41:55 - 41:63 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.
+41:55 - 41:63 | 1 | Seems like you used yield instead of yield* inside this Effect.gen.    effect(missingStarInYieldEffectGen)
 
 yield Effect.never
-42:2 - 42:20 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.
+42:2 - 42:20 | 1 | When yielding Effects inside Effect.gen, you should use yield* instead of yield.    effect(missingStarInYieldEffectGen)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide.ts.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide.ts.output
@@ -1,11 +1,11 @@
 Effect.provide(MyService1.Default)
-17:2 - 17:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.
+17:2 - 17:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.    effect(multipleEffectProvide)
 
 Effect.provide(MyService1.Default)
-22:2 - 22:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.
+22:2 - 22:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.    effect(multipleEffectProvide)
 
 Effect.provide(MyService1.Default)
-25:2 - 25:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.
+25:2 - 25:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.    effect(multipleEffectProvide)
 
 Effect.provide(MyService1.Default)
-30:2 - 30:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.
+30:2 - 30:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.    effect(multipleEffectProvide)

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.output
@@ -1,27 +1,27 @@
 effect
 11:2 - 11:8 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
-Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.    effect(nonObjectEffectServiceType)
 
 effect
 17:2 - 17:8 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
-Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.    effect(nonObjectEffectServiceType)
 
 effect
 24:4 - 24:10 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
-Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.    effect(nonObjectEffectServiceType)
 
 scoped
 31:2 - 31:8 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
-Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.    effect(nonObjectEffectServiceType)
 
 scoped
 38:4 - 38:10 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
-Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.    effect(nonObjectEffectServiceType)
 
 succeed
 45:2 - 45:9 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
-Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.    effect(nonObjectEffectServiceType)
 
 sync
 51:2 - 51:6 | 1 | Effect.Service requires the service type to be an object {} and not a primitive type. 
-Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.
+Consider wrapping the value in an object, or manually using Context.Tag or Effect.Tag if you want to use a primitive instead.    effect(nonObjectEffectServiceType)

--- a/test/__snapshots__/diagnostics/outdatedEffectCodegen.ts.output
+++ b/test/__snapshots__/diagnostics/outdatedEffectCodegen.ts.output
@@ -1,2 +1,2 @@
 accessors:67e9af40a9b0bd25
-3:20 - 3:46 | 0 | Codegen accessors result is outdated
+3:20 - 3:46 | 0 | Codegen accessors result is outdated    effect(outdatedEffectCodegen)

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.output
@@ -1,9 +1,9 @@
 constructor() {
     super({ a: 42 })
   }
-29:2 - 31:3 | 1 | Classes extending Schema must not override the constructor
+29:2 - 31:3 | 1 | Classes extending Schema must not override the constructor    effect(overriddenSchemaConstructor)
 
 constructor() {
     super({} as any as never)
   }
-36:2 - 38:3 | 1 | Classes extending Schema must not override the constructor
+36:2 - 38:3 | 1 | Classes extending Schema must not override the constructor    effect(overriddenSchemaConstructor)

--- a/test/__snapshots__/diagnostics/returnEffectInGen_warn.ts.output
+++ b/test/__snapshots__/diagnostics/returnEffectInGen_warn.ts.output
@@ -1,4 +1,4 @@
 return Effect.fail("error")
 4:2 - 4:29 | 2 | You are returning an Effect-able type inside a generator function, and will result in nested Effect<Effect<...>>.
 Maybe you wanted to return yield* instead?
-Nested Effect-able types may be intended if you plan to later manually flatten or unwrap this Effect, if so you can safely disable this diagnostic for this line through quickfixes.
+Nested Effect-able types may be intended if you plan to later manually flatten or unwrap this Effect, if so you can safely disable this diagnostic for this line through quickfixes.    effect(returnEffectInGen)

--- a/test/__snapshots__/diagnostics/scopeInLayerEffect.ts.output
+++ b/test/__snapshots__/diagnostics/scopeInLayerEffect.ts.output
@@ -5,7 +5,7 @@ export class MyService2 extends Effect.Service<MyService2>()("MyService2", {
   })
 }) {}
 13:0 - 18:5 | 0 | Seems like you are constructing a layer with a scope in the requirements.
-Consider using "scoped" instead to get rid of the scope in the requirements.
+Consider using "scoped" instead to get rid of the scope in the requirements.    effect(scopeInLayerEffect)
 
 export class MyService3 extends Effect.Service<MyService3>()("MyService2", {
   effect: Effect.gen(function*() {
@@ -15,7 +15,7 @@ export class MyService3 extends Effect.Service<MyService3>()("MyService2", {
   })
 }) {}
 20:0 - 26:5 | 0 | Seems like you are constructing a layer with a scope in the requirements.
-Consider using "scoped" instead to get rid of the scope in the requirements.
+Consider using "scoped" instead to get rid of the scope in the requirements.    effect(scopeInLayerEffect)
 
 Layer.effect(
   MyService,
@@ -25,7 +25,7 @@ Layer.effect(
   })
 )
 36:23 - 42:1 | 0 | Seems like you are constructing a layer with a scope in the requirements.
-Consider using "scoped" instead to get rid of the scope in the requirements.
+Consider using "scoped" instead to get rid of the scope in the requirements.    effect(scopeInLayerEffect)
 
 Layer.effect(
   MyService,
@@ -36,4 +36,4 @@ Layer.effect(
   })
 )
 44:24 - 51:1 | 0 | Seems like you are constructing a layer with a scope in the requirements.
-Consider using "scoped" instead to get rid of the scope in the requirements.
+Consider using "scoped" instead to get rid of the scope in the requirements.    effect(scopeInLayerEffect)

--- a/test/__snapshots__/diagnostics/strictBooleanExpressions.ts.output
+++ b/test/__snapshots__/diagnostics/strictBooleanExpressions.ts.output
@@ -1,32 +1,32 @@
 testString
-3:36 - 3:46 | 1 | Unexpected `string` type in condition, expected strictly a boolean instead.
+3:36 - 3:46 | 1 | Unexpected `string` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 myVar
-6:44 - 6:49 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.
+6:44 - 6:49 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 myVar3
-9:39 - 9:45 | 1 | Unexpected `null` type in condition, expected strictly a boolean instead.
+9:39 - 9:45 | 1 | Unexpected `null` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 myVar4
-12:44 - 12:50 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.
+12:44 - 12:50 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 myVar4
-14:41 - 14:47 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.
+14:41 - 14:47 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 testString
-16:54 - 16:64 | 1 | Unexpected `string` type in condition, expected strictly a boolean instead.
+16:54 - 16:64 | 1 | Unexpected `string` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 (myVar8 || (myVar9 && fn()))
-21:29 - 21:57 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.
+21:29 - 21:57 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 testString
-22:53 - 22:63 | 1 | Unexpected `string` type in condition, expected strictly a boolean instead.
+22:53 - 22:63 | 1 | Unexpected `string` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 myVar3 || myVar4
-24:4 - 24:20 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.
+24:4 - 24:20 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 myVar3
-24:4 - 24:10 | 1 | Unexpected `null` type in condition, expected strictly a boolean instead.
+24:4 - 24:10 | 1 | Unexpected `null` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)
 
 myVar4
-24:14 - 24:20 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.
+24:14 - 24:20 | 1 | Unexpected `undefined` type in condition, expected strictly a boolean instead.    effect(strictBooleanExpressions)

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen.ts.output
@@ -4,18 +4,18 @@ try {
   } catch (error) {
     console.error(error)
   }
-4:2 - 9:3 | 2 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).
+4:2 - 9:3 | 2 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).    effect(tryCatchInEffectGen)
 
 try {
     yield* Effect.succeed("hello")
   } catch (e) {
     console.error(e)
   }
-14:2 - 18:3 | 2 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).
+14:2 - 18:3 | 2 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).    effect(tryCatchInEffectGen)
 
 try {
       return yield* Effect.succeed(1)
     } catch (e) {
       console.error(e)
     }
-39:4 - 43:5 | 2 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).
+39:4 - 43:5 | 2 | Avoid using try/catch inside Effect generators. Use Effect's error handling mechanisms instead (e.g., Effect.try, Effect.tryPromise, Effect.catchAll, Effect.catchTag).    effect(tryCatchInEffectGen)

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen.ts.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen.ts.output
@@ -1,4 +1,4 @@
 Effect.gen(function*() {
   return yield* Effect.succeed(42)
 })
-12:36 - 14:2 | 2 | This Effect.gen contains a single return statement.
+12:36 - 14:2 | 2 | This Effect.gen contains a single return statement.    effect(unnecessaryEffectGen)

--- a/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.output
+++ b/test/__snapshots__/diagnostics/unnecessaryEffectGen_noReturn.ts.output
@@ -1,9 +1,9 @@
 Effect.gen(function*() {
   yield* Effect.succeed(42)
 })
-12:36 - 14:2 | 2 | This Effect.gen contains a single return statement.
+12:36 - 14:2 | 2 | This Effect.gen contains a single return statement.    effect(unnecessaryEffectGen)
 
 Effect.gen(function*() {
   yield* Effect.void
 })
-16:46 - 18:2 | 2 | This Effect.gen contains a single return statement.
+16:46 - 18:2 | 2 | This Effect.gen contains a single return statement.    effect(unnecessaryEffectGen)

--- a/test/__snapshots__/diagnostics/unnecessaryPipe.ts.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe.ts.output
@@ -1,5 +1,5 @@
 pipe(32)
-13:28 - 13:36 | 2 | This pipe call contains no arguments.
+13:28 - 13:36 | 2 | This pipe call contains no arguments.    effect(unnecessaryPipe)
 
 Effect.succeed(32).pipe()
-15:34 - 15:59 | 2 | This pipe call contains no arguments.
+15:34 - 15:59 | 2 | This pipe call contains no arguments.    effect(unnecessaryPipe)

--- a/test/__snapshots__/diagnostics/unnecessaryPipeChain.ts.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipeChain.ts.output
@@ -1,5 +1,5 @@
 Effect.succeed(1).pipe(Effect.map((x) => x + 2)).pipe(Effect.map((x) => x + 3))
-4:26 - 4:105 | 2 | Chained pipe calls can be simplified to a single pipe call
+4:26 - 4:105 | 2 | Chained pipe calls can be simplified to a single pipe call    effect(unnecessaryPipeChain)
 
 pipe(pipe(Effect.succeed(1), Effect.map((x) => x + 2)), Effect.map((x) => x + 3))
-6:22 - 6:103 | 2 | Chained pipe calls can be simplified to a single pipe call
+6:22 - 6:103 | 2 | Chained pipe calls can be simplified to a single pipe call    effect(unnecessaryPipeChain)

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors.ts.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors.ts.output
@@ -1,5 +1,5 @@
 ShouldWarnMethodWithGenerics
-42:13 - 42:41 | 0 | Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.
+42:13 - 42:41 | 0 | Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.    effect(unsupportedServiceAccessors)
 
 ShouldWarnMethodWithMultipleSignatures
-56:13 - 56:51 | 0 | Even if accessors are enabled, accessors for 'methodWithMultipleSignaturesNoGenerics' won't be available because the signature have generic type parameters or multiple call signatures.
+56:13 - 56:51 | 0 | Even if accessors are enabled, accessors for 'methodWithMultipleSignaturesNoGenerics' won't be available because the signature have generic type parameters or multiple call signatures.    effect(unsupportedServiceAccessors)

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.output
@@ -1,5 +1,5 @@
 ShouldWarnMethodWithGenerics
-20:13 - 20:41 | 0 | Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.
+20:13 - 20:41 | 0 | Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.    effect(unsupportedServiceAccessors)
 
 ShouldWarnMethodWithMultipleSignatures
-29:13 - 29:51 | 0 | Even if accessors are enabled, accessors for 'methodWithMultipleSignaturesNoGenerics' won't be available because the signature have generic type parameters or multiple call signatures.
+29:13 - 29:51 | 0 | Even if accessors are enabled, accessors for 'methodWithMultipleSignaturesNoGenerics' won't be available because the signature have generic type parameters or multiple call signatures.    effect(unsupportedServiceAccessors)


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option `diagnosticsName` (default: `true`) that appends the rule name to diagnostic messages. This makes it easier for users to:
- Identify which rule triggered a specific diagnostic
- Configure rule severity using `diagnosticSeverity` option
- Quickly search for related documentation

## Example

**Before:**
```
Effect must be yielded or assigned to a variable.
```

**After (with diagnosticsName: true):**
```
Effect must be yielded or assigned to a variable.    effect(floatingEffect)
```

## Changes

- Added `diagnosticsName` boolean option to `LanguageServicePluginOptions` (default: `true`)
- Updated diagnostic message formatting to include rule name when enabled
- Updated all test snapshots to reflect the new format
- Added documentation for the new option in README.md

## Configuration

Users can disable this feature by setting it to `false` in their tsconfig.json:

```jsonc
{
  "compilerOptions": {
    "plugins": [{
      "name": "@effect/language-service",
      "diagnosticsName": false
    }]
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)