### PR TITLE
Add code fix to rewrite Schema class constructor overrides as static 'new' methods

### DIFF
--- a/.changeset/add-static-override-detection.md
+++ b/.changeset/add-static-override-detection.md
@@ -1,0 +1,29 @@
+---
+"@effect/language-service": patch
+---
+
+Add code fix to rewrite Schema class constructor overrides as static 'new' methods
+
+When detecting constructor overrides in Schema classes, the diagnostic now provides a new code fix option that automatically rewrites the constructor as a static 'new' method. This preserves the custom initialization logic while maintaining Schema's decoding behavior.
+
+Example:
+```typescript
+// Before (with constructor override)
+class MyClass extends Schema.Class<MyClass>("MyClass")({ a: Schema.Number }) {
+  b: number
+  constructor() {
+    super({ a: 42 })
+    this.b = 56
+  }
+}
+
+// After (using static 'new' method)
+class MyClass extends Schema.Class<MyClass>("MyClass")({ a: Schema.Number }) {
+  b: number
+  public static new() {
+    const _this = new this({ a: 42 })
+    _this.b = 56
+    return _this
+  }
+}
+```

--- a/examples/diagnostics/overriddenSchemaConstructor_static.ts
+++ b/examples/diagnostics/overriddenSchemaConstructor_static.ts
@@ -1,0 +1,14 @@
+import * as Schema from "effect/Schema"
+
+export class InvalidBecauseOfConstructor
+  extends Schema.Class<InvalidBecauseOfConstructor>("InvalidBecauseOfConstructor")({
+    a: Schema.Number
+  })
+{
+  b: number
+  // should be report here at constructor location
+  constructor() {
+    super({ a: 42 })
+    this.b = 56
+  }
+}

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.codefixes
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.codefixes
@@ -1,6 +1,8 @@
+overriddenSchemaConstructor_static from 660 to 700
 overriddenSchemaConstructor_fix from 660 to 700
 overriddenSchemaConstructor_skipNextLine from 660 to 700
 overriddenSchemaConstructor_skipFile from 660 to 700
+overriddenSchemaConstructor_static from 889 to 938
 overriddenSchemaConstructor_fix from 889 to 938
 overriddenSchemaConstructor_skipNextLine from 889 to 938
 overriddenSchemaConstructor_skipFile from 889 to 938

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.output
@@ -1,9 +1,9 @@
 constructor() {
     super({ a: 42 })
   }
-29:2 - 31:3 | 1 | Classes extending Schema must not override the constructor    effect(overriddenSchemaConstructor)
+29:2 - 31:3 | 1 | Classes extending Schema must not override the constructor; this is because it silently breaks the schema decoding behaviour. If that's needed, we recommend instead to use a static 'new' method that constructs the instance.    effect(overriddenSchemaConstructor)
 
 constructor() {
     super({} as any as never)
   }
-36:2 - 38:3 | 1 | Classes extending Schema must not override the constructor    effect(overriddenSchemaConstructor)
+36:2 - 38:3 | 1 | Classes extending Schema must not override the constructor; this is because it silently breaks the schema decoding behaviour. If that's needed, we recommend instead to use a static 'new' method that constructs the instance.    effect(overriddenSchemaConstructor)

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.overriddenSchemaConstructor_static.from660to700.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.overriddenSchemaConstructor_static.from660to700.output
@@ -1,0 +1,41 @@
+// code fix overriddenSchemaConstructor_static  output for range 660 - 700
+import * as Schema from "effect/Schema"
+
+export class Valid extends Schema.Class<Valid>("Valid")({
+  a: Schema.Number
+}) {}
+
+export class Valid2 extends Schema.Class<Valid2>("Valid")({
+  a: Schema.Number
+}) {
+  otherMethod() {
+    return this.a
+  }
+}
+
+export class BaseClass {}
+export class Valid3 extends BaseClass {
+  constructor() {
+    super()
+  }
+}
+
+// this is invalid because if the class extends a Schema, there should be no constructor override
+export class InvalidBecauseOfConstructor
+  extends Schema.Class<InvalidBecauseOfConstructor>("InvalidBecauseOfConstructor")({
+    a: Schema.Number
+  })
+{
+  // should be report here at constructor location
+  public static new() {
+        const _this = new this({ a: 42 })
+        return _this
+    }
+}
+
+// this is invalid because if the class extends a Schema, there should be no constructor override (even forced weirdly!)
+export class InvalidExtendsString extends Schema.Struct({}) {
+  constructor() {
+    super({} as any as never)
+  }
+}

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.overriddenSchemaConstructor_static.from889to938.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor.ts.overriddenSchemaConstructor_static.from889to938.output
@@ -1,0 +1,41 @@
+// code fix overriddenSchemaConstructor_static  output for range 889 - 938
+import * as Schema from "effect/Schema"
+
+export class Valid extends Schema.Class<Valid>("Valid")({
+  a: Schema.Number
+}) {}
+
+export class Valid2 extends Schema.Class<Valid2>("Valid")({
+  a: Schema.Number
+}) {
+  otherMethod() {
+    return this.a
+  }
+}
+
+export class BaseClass {}
+export class Valid3 extends BaseClass {
+  constructor() {
+    super()
+  }
+}
+
+// this is invalid because if the class extends a Schema, there should be no constructor override
+export class InvalidBecauseOfConstructor
+  extends Schema.Class<InvalidBecauseOfConstructor>("InvalidBecauseOfConstructor")({
+    a: Schema.Number
+  })
+{
+  // should be report here at constructor location
+  constructor() {
+    super({ a: 42 })
+  }
+}
+
+// this is invalid because if the class extends a Schema, there should be no constructor override (even forced weirdly!)
+export class InvalidExtendsString extends Schema.Struct({}) {
+  public static new() {
+        const _this = new this({} as any as never)
+        return _this
+    }
+}

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.codefixes
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.codefixes
@@ -1,0 +1,4 @@
+overriddenSchemaConstructor_static from 260 to 316
+overriddenSchemaConstructor_fix from 260 to 316
+overriddenSchemaConstructor_skipNextLine from 260 to 316
+overriddenSchemaConstructor_skipFile from 260 to 316

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.output
@@ -1,0 +1,5 @@
+constructor() {
+    super({ a: 42 })
+    this.b = 56
+  }
+10:2 - 13:3 | 1 | Classes extending Schema must not override the constructor; this is because it silently breaks the schema decoding behaviour. If that's needed, we recommend instead to use a static 'new' method that constructs the instance.    effect(overriddenSchemaConstructor)

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_fix.from260to316.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_fix.from260to316.output
@@ -1,0 +1,10 @@
+// code fix overriddenSchemaConstructor_fix  output for range 260 - 316
+import * as Schema from "effect/Schema"
+
+export class InvalidBecauseOfConstructor
+  extends Schema.Class<InvalidBecauseOfConstructor>("InvalidBecauseOfConstructor")({
+    a: Schema.Number
+  })
+{
+  b: number
+}

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_skipFile.from260to316.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_skipFile.from260to316.output
@@ -1,0 +1,16 @@
+// code fix overriddenSchemaConstructor_skipFile  output for range 260 - 316
+/** @effect-diagnostics overriddenSchemaConstructor:skip-file */
+import * as Schema from "effect/Schema"
+
+export class InvalidBecauseOfConstructor
+  extends Schema.Class<InvalidBecauseOfConstructor>("InvalidBecauseOfConstructor")({
+    a: Schema.Number
+  })
+{
+  b: number
+  // should be report here at constructor location
+  constructor() {
+    super({ a: 42 })
+    this.b = 56
+  }
+}

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_skipNextLine.from260to316.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_skipNextLine.from260to316.output
@@ -1,0 +1,16 @@
+// code fix overriddenSchemaConstructor_skipNextLine  output for range 260 - 316
+import * as Schema from "effect/Schema"
+
+// @effect-diagnostics-next-line overriddenSchemaConstructor:off
+export class InvalidBecauseOfConstructor
+  extends Schema.Class<InvalidBecauseOfConstructor>("InvalidBecauseOfConstructor")({
+    a: Schema.Number
+  })
+{
+  b: number
+  // should be report here at constructor location
+  constructor() {
+    super({ a: 42 })
+    this.b = 56
+  }
+}

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_static.from260to316.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_static.ts.overriddenSchemaConstructor_static.from260to316.output
@@ -1,0 +1,16 @@
+// code fix overriddenSchemaConstructor_static  output for range 260 - 316
+import * as Schema from "effect/Schema"
+
+export class InvalidBecauseOfConstructor
+  extends Schema.Class<InvalidBecauseOfConstructor>("InvalidBecauseOfConstructor")({
+    a: Schema.Number
+  })
+{
+  b: number
+  // should be report here at constructor location
+  public static new() {
+        const _this = new this({ a: 42 })
+        _this.b = 56
+        return _this
+    }
+}


### PR DESCRIPTION
## Summary

This PR enhances the `overriddenSchemaConstructor` diagnostic by adding a new code fix that automatically rewrites constructor overrides in Schema classes as static 'new' methods. This pattern preserves custom initialization logic while maintaining Schema's decoding behavior.

## Changes

- Added a new code fix `overriddenSchemaConstructor_static` that transforms constructor overrides into static 'new' methods
- Improved the diagnostic message to explain why constructor overrides break Schema behavior and suggest the static 'new' pattern
- The transformation handles:
  - Converting `super()` calls to `new this()` 
  - Replacing all `this` references with a local `_this` variable
  - Adding a return statement for the constructed instance
  - Preserving type parameters and method parameters

## Example

**Before (with constructor override):**
```typescript
class MyClass extends Schema.Class<MyClass>("MyClass")({ a: Schema.Number }) {
  b: number
  constructor() {
    super({ a: 42 })
    this.b = 56
  }
}
```

**After (using static 'new' method):**
```typescript
class MyClass extends Schema.Class<MyClass>("MyClass")({ a: Schema.Number }) {
  b: number
  public static new() {
    const _this = new this({ a: 42 })
    _this.b = 56
    return _this
  }
}
```

## Test Coverage

- Added new example file: `examples/diagnostics/overriddenSchemaConstructor_static.ts`
- Added comprehensive snapshot tests for the new code fix
- All existing tests pass without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)