### PR TITLE
Add CLI diagnostics command for checking Effect-specific diagnostics

### DIFF
--- a/.changeset/cli-diagnostics-command.md
+++ b/.changeset/cli-diagnostics-command.md
@@ -1,0 +1,11 @@
+---
+"@effect/language-service": minor
+---
+
+Add new `diagnostics` CLI command to check Effect-specific diagnostics for files or projects
+
+The new `effect-language-service diagnostics` command provides a way to get Effect-specific diagnostics through the CLI without patching your TypeScript installation. It supports:
+- `--file` option to get diagnostics for a specific file
+- `--project` option with a tsconfig file to check an entire project
+
+The command outputs diagnostics in the same format as the TypeScript compiler, showing errors, warnings, and messages with their locations and descriptions.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If everything goes smoothly, something along these lines should be printed out:
 /node_modules/typescript/lib/_tsc.js patched successfully.
 ```
 
-Now the CLI has patched the tsc binary and the typescript library to raise effect diagnostics even at build time if the plugin is configured in your tsconfig!
+Now the CLI has patched the tsc binary and the typescript library to raise Effect diagnostics even at build time if the plugin is configured in your tsconfig!
 
 As the command output suggests, you may need to delete your tsbuildinfo files or perform a full rebuild in order to re-check previously existing files.
 
@@ -204,13 +204,29 @@ index.ts:3:1 - error TS3: Effect must be yielded or assigned to a variable.
 Found 1 error in index.ts:3 
 ```
 
+## Effect-Language-Service CLI
+
+The effect language service plugin comes with a builtin CLI tool that can be used to perform various utilities, checks and setups. Since it relies on typescript, we recommend to install it locally and run it locally to ensure it loads the same typescript version of your project rather than a global installation that may resolve to use a different TS version from the one of your project.
+
+### `effect-language-service diagnostics`
+Provides a way to get through a CLI the list of Effect specific diagnostics; without patching your typescript installation. A --file option may be used to get diagnostics for a specific file, or --project with a tsconfig file to get an entire project.
+
+### `effect-language-service check`
+This command runs a check of the setup of the patching mechanism of the LSP, to understand if typescript has been patched or not.
+
+### `effect-language-service patch`
+Patches (or re-patches) your local TypeScript installation to provide Effect diagnostics at build time.
+
+### `effect-language-service unpatch`
+Revery any previously applied patch to the local TypeScript installation.
+
 ## Configuring diagnostics
 
 You can either disable or change the severity of specific diagnostics by using comments in your code.
 
 ```ts
 // @effect-diagnostics effect/floatingEffect:off
-Effect.succeed(1); // This will not be reported as a floating effect
+Effect.succeed(1); // This will not be reported as a floating Effect
 
 // @effect-diagnostics effect/floatingEffect:error
 Effect.succeed(1); // This will be reported as a floating effect
@@ -304,6 +320,7 @@ and will be used as follows:
 ```ts
 export class UserRepo extends Repository("Hello")<UserRepo, { /** ... */ }>() {}
 ```
+
 
 ## Known gotchas
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
 import * as Console from "effect/Console"
 import * as Effect from "effect/Effect"
 import { check } from "./cli/check"
+import { diagnostics } from "./cli/diagnostics"
 import { patch } from "./cli/patch"
 import { unpatch } from "./cli/unpatch"
 
@@ -13,7 +14,7 @@ const cliCommand = Command.make(
   "effect-language-service",
   {},
   () => Console.log("Please select a command or run --help.")
-).pipe(Command.withSubcommands([patch, unpatch, check]))
+).pipe(Command.withSubcommands([patch, unpatch, check, diagnostics]))
 
 const main = Command.run(cliCommand, {
   name: "effect-language-service",

--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -1,0 +1,139 @@
+import * as Command from "@effect/cli/Command"
+import * as Options from "@effect/cli/Options"
+import * as Path from "@effect/platform/Path"
+import { createProjectService } from "@typescript-eslint/project-service"
+import * as Array from "effect/Array"
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
+import type * as ts from "typescript"
+import * as LanguageServicePluginOptions from "../core/LanguageServicePluginOptions"
+import * as LSP from "../core/LSP"
+import * as Nano from "../core/Nano"
+import * as TypeCheckerApi from "../core/TypeCheckerApi"
+import * as TypeCheckerUtils from "../core/TypeCheckerUtils"
+import * as TypeParser from "../core/TypeParser"
+import * as TypeScriptApi from "../core/TypeScriptApi"
+import * as TypeScriptUtils from "../core/TypeScriptUtils"
+import { diagnostics as diagnosticsDefinitions } from "../diagnostics"
+import { getTypeScript } from "./utils"
+
+export class NoFilesToCheckError extends Data.TaggedError("NoFilesToCheckError")<{}> {
+  get message(): string {
+    return "No files to check. Please provide an existing .ts file or a project tsconfig.json"
+  }
+}
+
+const file = Options.file("file").pipe(
+  Options.optional,
+  Options.withDescription("The full path of the file to check for diagnostics.")
+)
+
+const project = Options.file("project").pipe(
+  Options.optional,
+  Options.withDescription("The full path of the project tsconfig.json file to check for diagnostics.")
+)
+
+const extractEffectLspOptions = (compilerOptions: ts.CompilerOptions) => {
+  return (Predicate.hasProperty(compilerOptions, "plugins") && Array.isArray(compilerOptions.plugins)
+    ? compilerOptions.plugins
+    : []).find((_) => Predicate.hasProperty(_, "name") && _.name === "@effect/language-service")
+}
+
+export const diagnostics = Command.make(
+  "diagnostics",
+  { file, project },
+  Effect.fn("diagnostics")(function*({ file, project }) {
+    const path = yield* Path.Path
+    const tsInstance = yield* getTypeScript
+    let filesToCheck: Array<string> = []
+    let checkedFilesCount = 0
+    let errorsCount = 0
+    let warningsCount = 0
+    let messagesCount = 0
+
+    const { service } = createProjectService()
+
+    if (Option.isSome(file)) {
+      filesToCheck = [...filesToCheck, ...path.resolve(file.value ?? "")]
+    }
+
+    if (Option.isSome(project)) {
+      let tsconfigToHandle = [project.value ?? ""]
+      while (tsconfigToHandle.length > 0) {
+        const tsconfigPath = tsconfigToHandle.shift()!
+        const configFile = tsInstance.readConfigFile(tsconfigPath, tsInstance.sys.readFile)
+        if (configFile.error) continue
+        const parsedConfig = tsInstance.parseJsonConfigFileContent(
+          configFile.config,
+          tsInstance.sys,
+          tsInstance.sys.getCurrentDirectory()
+        )
+        tsconfigToHandle = [...tsconfigToHandle, ...parsedConfig.projectReferences?.map((_) => _.path) ?? []]
+        filesToCheck = [...filesToCheck, ...parsedConfig.fileNames]
+      }
+    }
+
+    if (filesToCheck.length === 0) {
+      return yield* new NoFilesToCheckError()
+    }
+
+    for (const filePath of filesToCheck) {
+      service.openClientFile(filePath)
+      const scriptInfo = service.getScriptInfo(filePath)
+      if (!scriptInfo) continue
+
+      const project = scriptInfo.getDefaultProject()
+      const languageService = project.getLanguageService(true)
+      const program = languageService.getProgram()
+      if (!program) continue
+      const sourceFile = program.getSourceFile(filePath)
+      if (!sourceFile) continue
+      const pluginConfig = extractEffectLspOptions(program.getCompilerOptions())
+      if (!pluginConfig) continue
+
+      // run the diagnostics and pipe them into addDiagnostic
+      const results = pipe(
+        LSP.getSemanticDiagnosticsWithCodeFixes(diagnosticsDefinitions, sourceFile),
+        TypeParser.nanoLayer,
+        TypeCheckerUtils.nanoLayer,
+        TypeScriptUtils.nanoLayer,
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
+        Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
+        Nano.provideService(
+          LanguageServicePluginOptions.LanguageServicePluginOptions,
+          LanguageServicePluginOptions.parse(pluginConfig)
+        ),
+        Nano.run,
+        Either.map((_) => _.diagnostics),
+        Either.map(
+          Array.map((_) =>
+            _.category === tsInstance.DiagnosticCategory.Suggestion
+              ? { ..._, category: tsInstance.DiagnosticCategory.Message }
+              : _
+          )
+        ),
+        Either.getOrElse(() => [])
+      )
+      checkedFilesCount++
+      errorsCount += results.filter((_) => _.category === tsInstance.DiagnosticCategory.Error).length
+      warningsCount += results.filter((_) => _.category === tsInstance.DiagnosticCategory.Warning).length
+      messagesCount += results.filter((_) => _.category === tsInstance.DiagnosticCategory.Message).length
+      if (results.length === 0) continue
+      // pretty print the results
+      const formattedResults = tsInstance.formatDiagnosticsWithColorAndContext(results, {
+        getCanonicalFileName: (fileName) => path.resolve(fileName),
+        getCurrentDirectory: () => path.resolve("."),
+        getNewLine: () => "\n"
+      })
+      console.log(formattedResults)
+    }
+    console.log(
+      `Checked ${checkedFilesCount} files out of ${filesToCheck.length} files. \n${errorsCount} errors, ${warningsCount} warnings and ${messagesCount} messages.`
+    )
+  })
+)


### PR DESCRIPTION
## Summary

This PR adds a new `effect-language-service diagnostics` CLI command that provides a way to check Effect-specific diagnostics through the CLI without patching the TypeScript installation.

### Features Added

- **New CLI command**: `effect-language-service diagnostics`
  - `--file` option: Check diagnostics for a specific TypeScript file
  - `--project` option: Check diagnostics for an entire project using a tsconfig.json
  - Supports TypeScript project references (monorepos)
  - Outputs diagnostics in the same color-coded format as the TypeScript compiler
  - Provides a summary showing the count of errors, warnings, and messages

- **Updated Documentation**: The README now includes comprehensive documentation for all CLI commands:
  - `diagnostics`: Check Effect-specific diagnostics
  - `check`: Verify TypeScript patching status
  - `patch`: Apply patches to TypeScript
  - `unpatch`: Remove patches from TypeScript

### Example Usage

```bash
# Check a specific file
effect-language-service diagnostics --file src/index.ts

# Check an entire project
effect-language-service diagnostics --project tsconfig.json
```

### Example Output

When diagnostics are found, the output follows the same format as TypeScript:

```
src/example.ts:5:1 - error TS3: Effect must be yielded or assigned to a variable.

5 Effect.succeed(1)
  ~~~~~~~~~~~~~~~~~~

Checked 1 files out of 1 files. 
1 errors, 0 warnings and 0 messages.
```

## Test plan

- [x] All existing tests pass
- [x] Test snapshots regenerated and verified
- [x] TypeScript type checking passes
- [x] Linting passes
- [x] Changeset created with minor version bump
- [x] README documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)