### PR TITLE
Add LRU cache eviction to prevent unbounded memory growth

### DIFF
--- a/.changeset/clean-tools-move.md
+++ b/.changeset/clean-tools-move.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Improve memory by properly evicting older cached members

--- a/src/core/AutoImport.ts
+++ b/src/core/AutoImport.ts
@@ -365,6 +365,11 @@ const importProvidersCache = new Map<string, AutoImportProvider>()
 export const getOrMakeAutoImportProvider = Nano.fn("getOrMakeAutoImportProvider")(function*(
   sourceFile: ts.SourceFile
 ) {
+  // NOTE: evict the oldest entry when the cache is full to avoid unbounded memory growth
+  while (importProvidersCache.size > 5) {
+    const oldest = importProvidersCache.keys().next().value
+    if (oldest) importProvidersCache.delete(oldest)
+  }
   const autoImportProvider = importProvidersCache.get(sourceFile.fileName) ||
     (yield* makeAutoImportProvider(sourceFile))
   importProvidersCache.set(sourceFile.fileName, autoImportProvider)

--- a/src/core/KeyBuilder.ts
+++ b/src/core/KeyBuilder.ts
@@ -80,6 +80,11 @@ const keyBuilderCache = new Map<string, KeyBuilder>()
 export const getOrMakeKeyBuilder = Nano.fn("getOrMakeKeyBuilder")(function*(
   sourceFile: ts.SourceFile
 ) {
+  // NOTE: evict the oldest entry when the cache is full to avoid unbounded memory growth
+  while (keyBuilderCache.size > 5) {
+    const oldest = keyBuilderCache.keys().next().value
+    if (oldest) keyBuilderCache.delete(oldest)
+  }
   const keyBuilder = keyBuilderCache.get(sourceFile.fileName) ||
     (yield* makeKeyBuilder(sourceFile))
   keyBuilderCache.set(sourceFile.fileName, keyBuilder)

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,10 @@ const init = (
     >()
     const runDiagnosticsAndCacheCodeFixes = (fileName: string) => {
       const program = languageService.getProgram()
+      while (effectCodeFixesForFile.size > 5) {
+        const oldest = effectCodeFixesForFile.keys().next().value
+        if (oldest) effectCodeFixesForFile.delete(oldest)
+      }
       if (languageServicePluginOptions.diagnostics && program) {
         effectCodeFixesForFile.delete(fileName)
         const sourceFile = program.getSourceFile(fileName)


### PR DESCRIPTION
## Summary

This PR implements a simple LRU (Least Recently Used) cache eviction strategy to prevent unbounded memory growth in the language service. Three internal caches are affected:

- `importProvidersCache` in `src/core/AutoImport.ts`
- `keyBuilderCache` in `src/core/KeyBuilder.ts`  
- `effectCodeFixesForFile` in `src/index.ts`

Each cache now evicts the oldest entry when the cache size exceeds 5 items. This maintains good performance for recently accessed files while preventing memory leaks in long-running language service sessions.

## Changes

- Added cache size checks before inserting new entries
- Evict oldest (first) entry when cache size > 5
- Added comments explaining the eviction strategy

## Test Plan

- ✅ All existing tests pass
- ✅ Snapshots regenerated and verified - no unexpected changes
- ✅ Type checking passes
- ✅ Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)