### PR TITLE
Add default-hashed pattern for deterministic keys

### DIFF
--- a/.changeset/default-hashed-pattern.md
+++ b/.changeset/default-hashed-pattern.md
@@ -1,0 +1,17 @@
+---
+"@effect/language-service": minor
+---
+
+Add `default-hashed` pattern for deterministic keys
+
+A new `default-hashed` pattern option is now available for service and error key patterns. This pattern works like the `default` pattern but hashes the resulting string, which is useful when you want deterministic keys but are concerned about potentially exposing service names in builds.
+
+Example configuration:
+```json
+{
+  "keyPatterns": [
+    { "target": "service", "pattern": "default-hashed" },
+    { "target": "error", "pattern": "default-hashed" }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ If the filename and the class identifier are the same, they won't be repeated, b
 
 The skipLeadingPath array can contain a set of prefixes to remove from the subpath part of the path. By default "src/" is removed for example.
 
+### Pattern: default-hashed
+
+If you are concerned potentially showing service names in builds, this pattern is the same as default; but the string will be then hashed.
+
 ### Pattern: package-identifier
 
 This pattern uses the package name + identifier. This usually works great if you have a flat structure, with one file per service/error.

--- a/examples/diagnostics/deterministicKeys_defaultHashed.ts
+++ b/examples/diagnostics/deterministicKeys_defaultHashed.ts
@@ -1,0 +1,10 @@
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default-hashed" }, { "target": "error", "pattern": "default-hashed" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/src/core/KeyBuilder.ts
+++ b/src/core/KeyBuilder.ts
@@ -1,5 +1,6 @@
 import type ts from "typescript"
 import * as LanguageServicePluginOptions from "./LanguageServicePluginOptions.js"
+import * as LSP from "./LSP.js"
 import * as Nano from "./Nano.js"
 import * as TypeScriptApi from "./TypeScriptApi.js"
 import * as TypeScriptUtils from "./TypeScriptUtils.js"
@@ -65,7 +66,10 @@ export const makeKeyBuilder = Nano.fn("KeyBuilder")(
         )
 
         // return them joined
-        return parts.filter((_) => String(_).trim().length > 0).join("/")
+        const fullKey = parts.filter((_) => String(_).trim().length > 0).join("/")
+
+        // if requested so, hash it
+        return keyPattern.pattern === "default-hashed" ? LSP.cyrb53(fullKey) : fullKey
       }
     }
 

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -11,7 +11,7 @@ export type KeyBuilderKind = "service" | "error" | "custom"
 
 export interface LanguageServicePluginOptionsKeyPattern {
   target: KeyBuilderKind
-  pattern: "package-identifier" | "default"
+  pattern: "package-identifier" | "default" | "default-hashed"
   skipLeadingPath: Array<string>
 }
 
@@ -94,11 +94,11 @@ function parseKeyPatterns(patterns: Array<unknown>): Array<LanguageServicePlugin
     result.push({
       target: hasProperty(entry, "target") && isString(entry.target) &&
           ["service", "error", "custom"].includes(entry.target.toLowerCase())
-        ? entry.target.toLowerCase() as "service" | "error"
+        ? entry.target.toLowerCase() as LanguageServicePluginOptionsKeyPattern["target"]
         : "service",
       pattern: hasProperty(entry, "pattern") && isString(entry.pattern) &&
-          ["package-identifier", "default"].includes(entry.pattern.toLowerCase())
-        ? entry.pattern.toLowerCase() as "package-identifier" | "default"
+          ["package-identifier", "default", "default-hashed"].includes(entry.pattern.toLowerCase())
+        ? entry.pattern.toLowerCase() as LanguageServicePluginOptionsKeyPattern["pattern"]
         : "default",
       skipLeadingPath:
         hasProperty(entry, "skipLeadingPath") && isArray(entry.skipLeadingPath) && entry.skipLeadingPath.every(isString)

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.codefixes
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.codefixes
@@ -1,0 +1,6 @@
+deterministicKeys_fix from 331 to 358
+deterministicKeys_skipNextLine from 331 to 358
+deterministicKeys_skipFile from 331 to 358
+deterministicKeys_fix from 442 to 450
+deterministicKeys_skipNextLine from 442 to 450
+deterministicKeys_skipFile from 442 to 450

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_fix.from331to358.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_fix.from331to358.output
@@ -1,0 +1,11 @@
+// code fix deterministicKeys_fix  output for range 331 - 358
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default-hashed" }, { "target": "error", "pattern": "default-hashed" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("4e484a493c98073d")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_fix.from442to450.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_fix.from442to450.output
@@ -1,0 +1,11 @@
+// code fix deterministicKeys_fix  output for range 442 - 450
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default-hashed" }, { "target": "error", "pattern": "default-hashed" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("34c252132a18b23d")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipFile.from331to358.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipFile.from331to358.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipFile  output for range 331 - 358
+/** @effect-diagnostics deterministicKeys:skip-file */
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default-hashed" }, { "target": "error", "pattern": "default-hashed" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipFile.from442to450.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipFile.from442to450.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipFile  output for range 442 - 450
+/** @effect-diagnostics deterministicKeys:skip-file */
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default-hashed" }, { "target": "error", "pattern": "default-hashed" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipNextLine.from331to358.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipNextLine.from331to358.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipNextLine  output for range 331 - 358
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default-hashed" }, { "target": "error", "pattern": "default-hashed" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+// @effect-diagnostics-next-line deterministicKeys:off
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipNextLine.from442to450.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.deterministicKeys_skipNextLine.from442to450.output
@@ -1,0 +1,12 @@
+// code fix deterministicKeys_skipNextLine  output for range 442 - 450
+// @effect-diagnostics deterministicKeys:error
+// @test-config { "keyPatterns": [ { "target": "service", "pattern": "default-hashed" }, { "target": "error", "pattern": "default-hashed" } ] }
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+
+export class ExpectedServiceIdentifier
+  extends Context.Tag("ExpectedServiceIdentifier")<ExpectedServiceIdentifier, {}>()
+{}
+
+// @effect-diagnostics-next-line deterministicKeys:off
+export class ErrorA extends Data.TaggedError("ErrorA")<{}> {}

--- a/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.output
+++ b/test/__snapshots__/diagnostics/deterministicKeys_defaultHashed.ts.output
@@ -1,0 +1,5 @@
+"ExpectedServiceIdentifier"
+7:22 - 7:49 | 1 | Key should be '4e484a493c98073d'    effect(deterministicKeys)
+
+"ErrorA"
+10:45 - 10:53 | 1 | Key should be '34c252132a18b23d'    effect(deterministicKeys)


### PR DESCRIPTION
## Summary

This PR adds a new `default-hashed` pattern option for deterministic keys in the `deterministicKeys` diagnostic. This pattern works like the existing `default` pattern but hashes the resulting string using the cyrb53 hash function, producing a hexadecimal hash.

## Motivation

Some users may be concerned about potentially exposing service or error names in production builds. The `default-hashed` pattern provides a way to maintain deterministic keys while obfuscating the actual names through hashing.

## Changes

- Added `default-hashed` as a new pattern option in `LanguageServicePluginOptions`
- Updated `KeyBuilder` to hash keys when the `default-hashed` pattern is used
- Added documentation in README.md explaining the new pattern
- Added test case and snapshots for the new pattern

## Example

Configuration:
\`\`\`json
{
  "keyPatterns": [
    { "target": "service", "pattern": "default-hashed" },
    { "target": "error", "pattern": "default-hashed" }
  ]
}
\`\`\`

Result:
- Instead of: `"ExpectedServiceIdentifier"`
- You get: `"4e484a493c98073d"`

## Test Plan

- ✅ All existing tests pass
- ✅ New test case added for `deterministicKeys_defaultHashed.ts`
- ✅ Snapshots generated and verified
- ✅ README documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)