### PR TITLE
Fix try/catch diagnostic to ignore try/finally blocks

### DIFF
--- a/.changeset/salty-terms-sell.md
+++ b/.changeset/salty-terms-sell.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Tone down try/catch message to ignore try/finally blocks

--- a/examples/diagnostics/tryCatchInEffectGen_finally.ts
+++ b/examples/diagnostics/tryCatchInEffectGen_finally.ts
@@ -1,0 +1,11 @@
+import * as Effect from "effect/Effect"
+
+// we consider this fine because there is no error handling, just cleanup
+export const shouldNotTrigger = Effect.gen(function*() {
+  try {
+    const result = yield* Effect.succeed(42)
+    return result
+  } finally {
+    console.log("exit")
+  }
+})

--- a/src/diagnostics/tryCatchInEffectGen.ts
+++ b/src/diagnostics/tryCatchInEffectGen.ts
@@ -25,7 +25,7 @@ export const tryCatchInEffectGen = LSP.createDiagnostic({
       ts.forEachChild(node, appendNodeToVisit)
 
       // Check if this is a try statement
-      if (ts.isTryStatement(node)) {
+      if (ts.isTryStatement(node) && node.catchClause) {
         // Find the containing generator function
         // go up until we meet the causing generator/function
         const generatorOrRegularFunction = ts.findAncestor(

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen_finally.ts.codefixes
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen_finally.ts.codefixes
@@ -1,0 +1,1 @@
+no codefixes

--- a/test/__snapshots__/diagnostics/tryCatchInEffectGen_finally.ts.output
+++ b/test/__snapshots__/diagnostics/tryCatchInEffectGen_finally.ts.output
@@ -1,0 +1,1 @@
+// no diagnostics


### PR DESCRIPTION
## Summary

- Fixed the `tryCatchInEffectGen` diagnostic to correctly ignore try/finally blocks without catch clauses
- These patterns are commonly used for cleanup logic and don't involve error handling that needs to be converted to Effect patterns

## Example

Before this fix, the following code would incorrectly trigger the diagnostic:

```typescript
export const shouldNotTrigger = Effect.gen(function*() {
  try {
    const result = yield* Effect.succeed(42)
    return result
  } finally {
    console.log("exit")
  }
})
```

After this fix, this code no longer triggers the diagnostic, as try/finally blocks without catch clauses are valid patterns for cleanup logic.

## Test plan

- ✅ All existing tests pass
- ✅ Added new test case `tryCatchInEffectGen_finally.ts` that verifies try/finally blocks don't trigger the diagnostic
- ✅ Regenerated all snapshots to verify no unexpected side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)