### PR TITLE
Dependency graph viz

### DIFF
--- a/docs/layer-graph.md
+++ b/docs/layer-graph.md
@@ -1,0 +1,178 @@
+# Layer Graph Internals
+
+This document summarizes every moving part involved in parsing `Layer`s, keeping
+track of their dependencies, and rendering the Mermaid graph that shows up in
+QuickInfo. Start in `src/quickinfo/layerInfo.ts` – everything else is a helper
+used by that entrypoint.
+
+## Main entrypoint (`layerInfo`)
+
+- `quickinfo.ts` wires the QuickInfo pipeline together and always calls
+  `layerInfo(...)` last so any new documentation is appended.
+- `layerInfo(...)` (`src/quickinfo/layerInfo.ts`) looks for a hovered variable
+  or property declaration, resolves the initializer (or the declaration itself
+  if it has no initializer), and asks the type checker for its type.
+- The type is validated with `TypeParser.layerType(...)`. If it fails,
+  QuickInfo is returned untouched. Otherwise a `LayerGraphContext` is created
+  and `processLayerGraphNode(...)` is invoked on the expression tree.
+- The function ultimately produces:
+  - A Markdown block listing every provided (`ROut`) and required (`RIn`)
+    service along with the innermost expression that produced it.
+  - Optionally, a Mermaid link built by `generateMermaidUri(...)`.
+
+## Parsing layers (`TypeParser.layerType`)
+
+Located in `src/core/TypeParser.ts`.
+
+1. `layerType(...)` ensures the type is "pipeable" (compatible with the helper’s
+   expectations – see `pipeableType(...)` in the same file).
+2. It enumerates the type’s property symbols (non-optional properties only),
+   preferring ones named `LayerTypeId` so the hot path hits sooner.
+3. Each property is inspected for a *layer variance struct*. That struct exposes
+   `_ROut`, `_E`, `_RIn` accessors. `layerVarianceStruct(...)` extracts those
+   three types via `varianceStructContravariantType` / `varianceStructCovariantType`.
+4. The extracted `{ ROut, E, RIn }` tuple is cached per `ts.Type` so repeat
+   checks are fast. `processLayerGraphNode(...)` consumes only `ROut` / `RIn`.
+
+Other helpers from `TypeParser` that participate:
+
+- `pipeCall(...)`: recognizes both `expr.pipe(...)` and `pipe(expr, ...)`
+  shapes and returns `{ subject, args }`, so `processLayerGraphNode` can treat
+  them uniformly.
+
+## Building the layer graph (`processLayerGraphNode`)
+
+Defined near the top of `src/quickinfo/layerInfo.ts`. It walks the AST and
+builds a tree of `LayerGraphNode`s (either `GraphNodeLeaf` or
+`GraphNodeCompoundTransform`).
+
+Key behaviors:
+
+1. **Pipe detection:** If the current node is a pipe call (detected via
+   `TypeParser.pipeCall`), the subject is parsed first to obtain the left-most
+   graph node, then every argument is parsed sequentially. Each call reuses
+   the graph context so services remain deduplicated.
+2. **Direct `Layer` calls:** When a call expression directly returns a Layer
+   (`typeParser.layerType(typeOfCall)` succeeds), its arguments are parsed and
+   attached as `args` to a new `GraphNodeCompoundTransform`.
+3. **Pipe callbacks:** For expressions *inside* a pipe (`pipedInGraphNode` is
+   defined) the code looks at the contextual type to see if it is a function
+   from `Layer` to `Layer`. If so, it parses any arguments and wraps the
+   previously piped node as the first argument of the transform.
+4. **Leaf fallback:** Any expression whose *value* type is a `Layer` ends up as
+   a `GraphNodeLeaf`.
+5. **Failure mode:** If none of the above match, an
+   `UnableToProduceLayerGraphError` is raised and QuickInfo will show
+   `layer graph not created: ...`.
+
+### Service bookkeeping
+
+While building each node, the function calls
+`TypeCheckerApi.appendToUniqueTypesMap(...)` for both `ROut` and `RIn`.
+
+- The helper lives in `src/core/TypeCheckerApi.ts`.
+- It keeps a `Map<string, ts.Type>` where each unique structural type gets a
+  deterministic id (`t1`, `t2`, ...).
+- When a union is encountered it is flattened so each concrete type is stored
+  separately.
+- Equivalence is checked by requiring mutual assignability
+  (`isTypeAssignableTo(a, b)` and `isTypeAssignableTo(b, a)`).
+- It returns `allIndexes`, which is exactly what every graph node stores in its
+  `rout`/`rin` arrays. Those ids are the glue used by the Mermaid generator and
+  the textual summary.
+
+## Dependency summarization (`findInnermostGraphEdge`)
+
+Before rendering docs, `layerInfo(...)` calls
+`findInnermostGraphEdge(...)` for every `ROut`/`RIn` id hanging off the root.
+This performs a depth-first search and returns the deepest graph nodes
+contributing that requirement. The result is used to:
+
+- Produce human-readable bullet lines such as
+  `MyService provided at ln 12 col 4 by `Layer.succeed(...)``.
+- Provide enough metadata (line/column + snippet) so users can jump straight to
+  the relevant node.
+
+## Mermaid rendering
+
+All logic lives in `src/quickinfo/layerInfo.ts`.
+
+1. `generateLayerMermaidUri(...)`
+   seeds a `MermaidGraphContext` (`seenIds` ensures each node’s definition is
+   emitted once) and delegates to `processNodeMermaid(...)`.
+2. `processNodeMermaid(...)` recursively collects Mermaid snippets:
+   - Each graph node becomes a `subgraph id ["`<node text>`"]` block annotated
+     with source line/column.
+   - Two nested subgraphs, `Requires` and `Provides`, are emitted and filled
+     with one subgraph per service id. Service labels use
+     `typeChecker.typeToString` with `NoTruncation` to keep the textual type.
+   - For compound nodes, it renders edges:
+     - `graph.id_rin_X -.-> child.id_rin_X` for shared requirements.
+     - `graph.id_rout_X -.-> child.id_rout_X` for shared provisions.
+     - `graph.id -.-x child.id` for children that do not share either, keeping
+       the node visible in the flow.
+3. The collected lines are joined with `flowchart TB\n`. The whole script is
+   JSON-stringified, base64-encoded via `btoa`, and appended to
+   `https://www.mermaidchart.com/play#`.
+
+Because the output is only a URI, there is no local Mermaid runtime dependency.
+
+## QuickInfo output
+
+After graph construction succeeds:
+
+1. The Markdown block is wrapped in triple backticks so VS Code renders it as a
+   doc comment. Each line is prefixed with `*` to mimic JSDoc.
+2. If a Mermaid URI exists, the code adds a QuickInfo link
+   `{@link <uri> Show full Layer graph}`. VS Code turns this into a clickable
+   entry.
+3. When no prior QuickInfo existed, `layerInfo` synthesizes a minimal one so the
+   documentation still shows up.
+
+## Touchpoints & future work
+
+- Editing how `Layer`s are parsed / grouped should happen in
+  `processLayerGraphNode(...)`. The rest of the system (summaries, Mermaid,
+  QuickInfo) operates on the abstract `LayerGraphNode` tree.
+- To tweak the Mermaid output, `processNodeMermaid(...)` is the single place to
+  adjust subgraph labels, edge styles, or the encoder.
+- If different equivalence rules for services are needed, update
+  `TypeCheckerApi.appendToUniqueTypesMap(...)` so that every consumer benefits.
+- Additional tooling (diagnostics, quick fixes) can reuse the same service ids –
+  the context is intentionally stored on `LayerGraphContext.services`.
+
+## Playground & alternate views
+
+- `buildLayerGraph(...)` is exported from `src/quickinfo/layerInfo.ts`, so any new
+  renderer (Mermaid, tree view, etc.) can work off the shared `LayerGraphNode`
+  tree without duplicating parser logic.
+- `src/quickinfo/layerOutline.ts` exports `buildNamedLayerOutline(...)` and
+  `renderNamedLayerOutline(...)`, which turn any `LayerGraphNode` tree into the
+  high-level outline that ignores `Layer.merge/provide` scaffolding. The same
+  module also exposes `generateNamedLayerOutlineMermaidUri(...)`, which renders
+  that outline as a Mermaid flowchart and returns the `https://www.mermaidchart.com`
+  link.
+- Run `pnpm tsx scripts/layer-graph-playground.ts` to inspect a concrete example.
+  The script loads `examples/quickinfo/layerGraphHierarchy.ts`, builds the graph
+  for `AppLive`, prints the current node tree, lists the leaf nodes (named layers),
+  and now also emits the *generated* outline that hides the provide/merge plumbing.
+  Sample output:
+
+  ```
+  Generated Named Layer Outline:
+  - AppService.Default
+    - UserService.Default
+      - UserRepository.Default
+        - DatabaseLive
+      - Analytics.Default
+    - EventService.Default
+      - EventsRepository.Default
+        - DatabaseLive
+      - Analytics.Default
+  ```
+
+  The script also prints the outline Mermaid link; QuickInfo now shows both the
+  original “full” graph link and the outline link, so you can jump between the
+  two visualizations quickly.
+
+  Use that outline as the living spec while iterating on new renderers.

--- a/examples/quickinfo/layerGraphHierarchy.ts
+++ b/examples/quickinfo/layerGraphHierarchy.ts
@@ -1,0 +1,41 @@
+import { Effect, Layer, pipe } from "effect"
+
+class Database extends Effect.Service<Database>()("Database", {
+  succeed: {}
+}) {}
+
+class UserRepository extends Effect.Service<UserRepository>()("UserRepository", {
+  effect: Effect.as(Database, {})
+}) {}
+
+class EventsRepository extends Effect.Service<EventsRepository>()("EventsRepository", {
+  effect: Effect.as(Database, {})
+}) {}
+
+class Analytics extends Effect.Service<Analytics>()("Analytics", {
+  succeed: {}
+}) {}
+
+class UserService extends Effect.Service<UserService>()("UserService", {
+  effect: Effect.as(Effect.zipRight(UserRepository, Analytics), {})
+}) {}
+
+class EventService extends Effect.Service<EventService>()("EventService", {
+  effect: Effect.as(Effect.zipRight(EventsRepository, Analytics), {})
+}) {}
+
+class AppService extends Effect.Service<AppService>()("AppService", {
+  effect: Effect.as(Effect.all([UserService, EventService]), {})
+}) {}
+
+const DatabaseLive = Database.Default
+
+export const AppLive = pipe(
+  DatabaseLive,
+  Layer.provideMerge(UserRepository.Default),
+  Layer.provideMerge(EventsRepository.Default),
+  Layer.merge(Analytics.Default),
+  Layer.provideMerge(UserService.Default),
+  Layer.provideMerge(EventService.Default),
+  Layer.provideMerge(AppService.Default)
+)

--- a/scripts/layer-graph-playground.ts
+++ b/scripts/layer-graph-playground.ts
@@ -1,0 +1,133 @@
+import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import ts from "typescript"
+import * as Nano from "../src/core/Nano.js"
+import * as TypeCheckerApi from "../src/core/TypeCheckerApi.js"
+import * as TypeParser from "../src/core/TypeParser.js"
+import * as TypeScriptApi from "../src/core/TypeScriptApi.js"
+import {
+  buildLayerGraph,
+  generateLayerMermaidUri,
+  type LayerGraphNode
+} from "../src/quickinfo/layerInfo.js"
+import {
+  buildNamedLayerOutline,
+  generateNamedLayerOutlineMermaidUri,
+  renderNamedLayerOutline
+} from "../src/quickinfo/layerOutline.js"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(__dirname, "..")
+const exampleFile = resolve(projectRoot, "examples/quickinfo/layerGraphHierarchy.ts")
+
+const program = ts.createProgram([exampleFile], {
+  strict: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  esModuleInterop: true,
+  skipLibCheck: true
+})
+
+const sourceFile = program.getSourceFile(exampleFile)
+if (!sourceFile) {
+  throw new Error("Unable to load example source file")
+}
+
+const typeChecker = program.getTypeChecker()
+
+function findLayerInitializer(name: string): ts.Expression {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name && declaration.initializer) {
+        return declaration.initializer
+      }
+    }
+  }
+  throw new Error("Unable to find declaration for " + name)
+}
+
+const layerNode = findLayerInitializer("AppLive")
+
+const graphResult = pipe(
+  buildLayerGraph(layerNode),
+  Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, typeChecker)),
+  Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
+  Nano.provideService(TypeCheckerApi.TypeCheckerApiCache, TypeCheckerApi.makeTypeCheckerApiCache()),
+  Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
+  Nano.run
+)
+
+if (Either.isLeft(graphResult)) {
+  throw new Error("Unable to build layer graph: " + graphResult.left.message)
+}
+
+const { rootNode, context: graphCtx } = graphResult.right
+
+function formatNodeLabel(node: LayerGraphNode): string {
+  const text = node.node.getText().replace(/\s+/g, " ").trim()
+  return text.length > 80 ? text.slice(0, 77) + "..." : text
+}
+
+function renderGraphTree(node: LayerGraphNode, depth = 0, lines: Array<string> = []): Array<string> {
+  const prefix = "  ".repeat(depth)
+  lines.push(`${prefix}- ${formatNodeLabel(node)} (${node._tag === "GraphNodeLeaf" ? "leaf" : "compound"})`)
+  if (node._tag === "GraphNodeCompoundTransform") {
+    for (const child of node.args) {
+      renderGraphTree(child, depth + 1, lines)
+    }
+  }
+  return lines
+}
+
+type LeafPath = {
+  path: Array<string>
+  leaf: string
+}
+
+function collectLeafPaths(
+  node: LayerGraphNode,
+  ancestors: Array<string> = []
+): Array<LeafPath> {
+  const current = [...ancestors, formatNodeLabel(node)]
+  if (node._tag === "GraphNodeLeaf") {
+    return [{ path: ancestors, leaf: formatNodeLabel(node) }]
+  }
+  return node.args.flatMap((child) => collectLeafPaths(child, current))
+}
+
+function renderLeafPaths(paths: Array<LeafPath>): Array<string> {
+  return paths.map((entry) => {
+    if (entry.path.length === 0) return `- ${entry.leaf}`
+    return `- ${entry.leaf} (via ${entry.path.join(" -> ")})`
+  })
+}
+
+console.log("Current Graph Tree:")
+console.log(renderGraphTree(rootNode).join("\n"))
+console.log("\nNamed Layer Leaves:")
+console.log(renderLeafPaths(collectLeafPaths(rootNode)).join("\n"))
+
+const outline = buildNamedLayerOutline(rootNode, graphCtx)
+console.log("\nGenerated Named Layer Outline:")
+console.log(renderNamedLayerOutline(outline))
+const outlineMermaidLink = generateNamedLayerOutlineMermaidUri(outline)
+if (outlineMermaidLink) {
+  console.log("\nOutline Mermaid Link:")
+  console.log(outlineMermaidLink)
+}
+
+const fullMermaidLink = pipe(
+  generateLayerMermaidUri(rootNode, graphCtx),
+  Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
+  Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
+  Nano.run
+)
+
+if (Either.isRight(fullMermaidLink)) {
+  console.log("\nFull Layer Mermaid Link:")
+  console.log(fullMermaidLink.right)
+}

--- a/src/quickinfo/layerOutline.ts
+++ b/src/quickinfo/layerOutline.ts
@@ -1,0 +1,208 @@
+import type { LayerGraphContext, LayerGraphNode } from "./layerInfo"
+
+export interface NamedLayerOutlineNode {
+  name: string
+  children: Array<NamedLayerOutlineNode>
+}
+
+function findProviders(
+  graph: LayerGraphNode,
+  serviceId: string
+): Array<LayerGraphNode> {
+  if (graph.rout.includes(serviceId)) {
+    if (graph._tag === "GraphNodeCompoundTransform") {
+      let result: Array<LayerGraphNode> = []
+      for (const child of graph.args) {
+        result = result.concat(findProviders(child, serviceId))
+      }
+      if (result.length > 0) return result
+    }
+    return [graph]
+  }
+  if (graph._tag === "GraphNodeCompoundTransform") {
+    return graph.args.flatMap((child) => findProviders(child, serviceId))
+  }
+  return []
+}
+
+function deriveLabel(providers: Array<LayerGraphNode>, fallback: string): string {
+  for (const provider of providers) {
+    const text = provider.node.getText().trim()
+    const defaultMatch = text.match(/([A-Za-z0-9_$\.]+\.Default)/)
+    if (defaultMatch) return defaultMatch[1]!
+    const liveMatch = text.match(/([A-Z][A-Za-z0-9_$]*)/)
+    if (liveMatch) return liveMatch[1]!
+  }
+  if (providers.length > 0) {
+    const text = providers[0]!.node.getText().trim()
+    return text.length > 80 ? text.slice(0, 77) + "..." : text
+  }
+  return fallback
+}
+
+interface ServiceInfo {
+  label: string
+  dependencies: Array<string>
+}
+
+function ensureServiceInfo(
+  root: LayerGraphNode,
+  memo: Map<string, ServiceInfo>,
+  serviceId: string
+) {
+  if (memo.has(serviceId)) return
+  const providers = findProviders(root, serviceId)
+  const dependencies = new Set<string>()
+  for (const provider of providers) {
+    for (const dep of provider.rin) {
+      dependencies.add(dep)
+    }
+  }
+  const info: ServiceInfo = {
+    label: deriveLabel(providers, serviceId),
+    dependencies: Array.from(dependencies)
+  }
+  memo.set(serviceId, info)
+  for (const dep of info.dependencies) {
+    ensureServiceInfo(root, memo, dep)
+  }
+}
+
+function buildServiceGraph(root: LayerGraphNode): Map<string, ServiceInfo> {
+  const memo = new Map<string, ServiceInfo>()
+  const visit = (serviceId: string) => ensureServiceInfo(root, memo, serviceId)
+  for (const serviceId of root.rout) {
+    visit(serviceId)
+  }
+  return memo
+}
+
+function mergeNodes(nodes: Array<NamedLayerOutlineNode>): Array<NamedLayerOutlineNode> {
+  const map = new Map<string, NamedLayerOutlineNode>()
+  for (const node of nodes) {
+    const existing = map.get(node.name)
+    if (existing) {
+      existing.children = mergeNodes(existing.children.concat(node.children))
+    } else {
+      map.set(node.name, {
+        name: node.name,
+        children: mergeNodes(node.children)
+      })
+    }
+  }
+  return Array.from(map.values())
+}
+
+function buildNode(
+  serviceId: string,
+  infoMap: Map<string, ServiceInfo>,
+  visited: Set<string>
+): NamedLayerOutlineNode | undefined {
+  if (visited.has(serviceId)) {
+    return undefined
+  }
+  const info = infoMap.get(serviceId)
+  if (!info) return undefined
+  const nextVisited = new Set(visited)
+  nextVisited.add(serviceId)
+  const children = info.dependencies
+    .map((dep) => buildNode(dep, infoMap, nextVisited))
+    .filter((node): node is NamedLayerOutlineNode => Boolean(node))
+  return {
+    name: info.label,
+    children: mergeNodes(children)
+  }
+}
+
+function findTopLevelServices(
+  root: LayerGraphNode,
+  infoMap: Map<string, ServiceInfo>
+): Array<string> {
+  const topLevel = new Set(root.rout)
+  const visit = (serviceId: string, ancestors: Set<string>) => {
+    if (ancestors.has(serviceId)) return
+    const nextAncestors = new Set(ancestors)
+    nextAncestors.add(serviceId)
+    const info = infoMap.get(serviceId)
+    if (!info) return
+    for (const dep of info.dependencies) {
+      topLevel.delete(dep)
+      visit(dep, nextAncestors)
+    }
+  }
+  for (const serviceId of root.rout) {
+    visit(serviceId, new Set())
+  }
+  return Array.from(topLevel)
+}
+
+export function buildNamedLayerOutline(
+  root: LayerGraphNode,
+  _ctx: LayerGraphContext
+): Array<NamedLayerOutlineNode> {
+  const infoMap = buildServiceGraph(root)
+  const topLevel = findTopLevelServices(root, infoMap)
+  const nodes = topLevel
+    .map((serviceId) => buildNode(serviceId, infoMap, new Set()))
+    .filter((node): node is NamedLayerOutlineNode => Boolean(node))
+  return mergeNodes(nodes)
+}
+
+function renderOutlineLines(
+  nodes: Array<NamedLayerOutlineNode>,
+  depth = 0,
+  lines: Array<string> = []
+): Array<string> {
+  const prefix = "  ".repeat(depth)
+  for (const node of nodes) {
+    lines.push(`${prefix}- ${node.name}`)
+    renderOutlineLines(node.children, depth + 1, lines)
+  }
+  return lines
+}
+
+export function renderNamedLayerOutline(
+  nodes: Array<NamedLayerOutlineNode>
+): string {
+  return renderOutlineLines(nodes).join("\n")
+}
+
+function escapeMermaid(text: string) {
+  return text.replace(/"/g, "#quot;")
+}
+
+export function generateNamedLayerOutlineMermaidUri(
+  nodes: Array<NamedLayerOutlineNode>
+): string | undefined {
+  if (nodes.length === 0) return undefined
+  let counter = 0
+  const nodeIds = new Map<string, string>()
+  const lines: Array<string> = []
+
+  const getId = (name: string) => {
+    let id = nodeIds.get(name)
+    if (!id) {
+      id = "n" + counter++
+      nodeIds.set(name, id)
+      lines.push(`${id}["${escapeMermaid(name)}"]`)
+    }
+    return id
+  }
+
+  function visit(node: NamedLayerOutlineNode) {
+    const parentId = getId(node.name)
+    for (const child of node.children) {
+      const childId = getId(child.name)
+      lines.push(`${parentId} --> ${childId}`)
+      visit(child)
+    }
+  }
+
+  for (const node of nodes) {
+    visit(node)
+  }
+
+  const code = "flowchart TB\n" + lines.join("\n")
+  const state = btoa(JSON.stringify({ code }))
+  return "https://www.mermaidchart.com/play#" + state
+}

--- a/test/layerOutline.test.ts
+++ b/test/layerOutline.test.ts
@@ -1,0 +1,71 @@
+import { buildLayerGraph } from "@effect/language-service/quickinfo/layerInfo"
+import {
+  buildNamedLayerOutline,
+  renderNamedLayerOutline
+} from "@effect/language-service/quickinfo/layerOutline"
+import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
+import * as path from "path"
+import * as ts from "typescript"
+import { describe, expect, it } from "vitest"
+import * as Nano from "@effect/language-service/core/Nano"
+import * as TypeCheckerApi from "@effect/language-service/core/TypeCheckerApi"
+import * as TypeParser from "@effect/language-service/core/TypeParser"
+import * as TypeScriptApi from "@effect/language-service/core/TypeScriptApi"
+
+const exampleFile = path.join(__dirname, "..", "examples", "quickinfo", "layerGraphHierarchy.ts")
+
+function findLayerInitializer(sourceFile: ts.SourceFile, name: string): ts.Expression {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name && declaration.initializer) {
+        return declaration.initializer
+      }
+    }
+  }
+  throw new Error("Unable to find declaration for " + name)
+}
+
+describe("layer outline", () => {
+  it("renders named outline for AppLive", () => {
+    const program = ts.createProgram([exampleFile], {
+      strict: true,
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      esModuleInterop: true,
+      skipLibCheck: true
+    })
+    const sourceFile = program.getSourceFile(exampleFile)
+    expect(sourceFile).toBeDefined()
+    const typeChecker = program.getTypeChecker()
+    const layerNode = findLayerInitializer(sourceFile!, "AppLive")
+
+    const graphResult = pipe(
+      buildLayerGraph(layerNode),
+      Nano.provideService(TypeParser.TypeParser, TypeParser.make(ts, typeChecker)),
+      Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
+      Nano.provideService(TypeCheckerApi.TypeCheckerApiCache, TypeCheckerApi.makeTypeCheckerApiCache()),
+      Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
+      Nano.run
+    )
+
+    if (Either.isLeft(graphResult)) {
+      throw new Error("Unable to build layer graph: " + graphResult.left.message)
+    }
+
+    const outlineNodes = buildNamedLayerOutline(graphResult.right.rootNode, graphResult.right.context)
+    expect(renderNamedLayerOutline(outlineNodes)).toMatchInlineSnapshot(`
+- AppService.Default
+  - UserService.Default
+    - UserRepository.Default
+      - DatabaseLive
+    - Analytics.Default
+  - EventService.Default
+    - EventsRepository.Default
+      - DatabaseLive
+    - Analytics.Default
+`)
+  })
+})


### PR DESCRIPTION
Layer quick-info now exports the existing Mermaid generator and a new outline builder that reasons about services, not pipe shape. We walk the layer graph’s `ROut` / `RIn` sets to recover “service → dependency” edges, pick stable labels (`*.Default` or uppercase constants such as `DatabaseLive`), and memoize each service so we never duplicate nodes or follow cycles.

`QuickInfo`, the playground script, and docs all use the shared helper. Hovering over a layer now shows two links: the original detailed graph plus the simplified outline graph.

Added a `Vitest` that spins up the example program and asserts the outline tree, so future edits to layer composition can’t regress the hierarchy.

Example (from `examples/quickinfo/layerGraphHierarchy.ts`):

Generated Named Layer Outline:
```
-   AppService.Default
  - EventService.Default
    - Analytics.Default
    - EventsRepository.Default
      - DatabaseLive
  - UserService.Default
    - Analytics.Default
    - UserRepository.Default
      - DatabaseLive
```

Mermaid:

```
flowchart TB
    app["AppService.Default"]
    eventSvc["EventService.Default"]
    userSvc["UserService.Default"]
    analytics["Analytics.Default"]
    eventsRepo["EventsRepository.Default"]
    userRepo["UserRepository.Default"]
    db["DatabaseLive"]

    app --> eventSvc
    app --> userSvc
    eventSvc --> analytics
    eventSvc --> eventsRepo
    userSvc --> analytics
    userSvc --> userRepo
    eventsRepo --> db
    userRepo --> db
```

Rendered outline:

<img width="775" height="555" alt="image" src="https://github.com/user-attachments/assets/07ea2843-3917-49aa-8f40-9b9b60d6baf5" />

This view stays identical even if the source code rewrites the pipe graph, because we’re deriving the structure from the types themselves instead of the syntactic order of `Layer.provide*`/`merge`.