### PR TITLE
Add strictEffectProvide diagnostic

### DIFF
--- a/.changeset/add-strict-effect-provide.md
+++ b/.changeset/add-strict-effect-provide.md
@@ -1,0 +1,38 @@
+---
+"@effect/language-service": minor
+---
+
+Add `strictEffectProvide` diagnostic to warn when using Effect.provide with Layer outside of application entry points
+
+This new diagnostic helps developers identify potential scope lifetime issues by detecting when `Effect.provide` is called with a Layer argument in locations that are not application entry points.
+
+**Example:**
+
+```typescript
+// Will trigger diagnostic
+export const program = Effect.void.pipe(
+  Effect.provide(MyService.Default)
+)
+```
+
+**Message:**
+> Effect.provide with a Layer should only be used at application entry points. If this is an entry point, you can safely disable this diagnostic. Otherwise, using Effect.provide may break scope lifetimes. Compose all layers at your entry point and provide them at once.
+
+**Configuration:**
+- **Default severity**: `"off"` (opt-in)
+- **Diagnostic name**: `strictEffectProvide`
+
+This diagnostic is disabled by default and can be enabled via tsconfig.json:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [{
+      "name": "@effect/language-service",
+      "diagnosticSeverity": {
+        "strictEffectProvide": "warning"
+      }
+    }]
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Warn on leaking requirements in Effect services
 - Warn on Scope as requirement of a Layer
 - Warn on subsequent `Effect.provide` anti-pattern
+- Warn when using `Effect.provide` with Layer outside of application entry points
 - Detect wrong `Self` type parameter for APIs like `Effect.Service` or `Schema.TaggedError` and similar 
 - Unnecessary usages of `Effect.gen` or `pipe()`
 - Warn when using `Effect.gen` with the old generator adapter pattern

--- a/examples/diagnostics/strictEffectProvide.ts
+++ b/examples/diagnostics/strictEffectProvide.ts
@@ -1,0 +1,48 @@
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -20,6 +20,7 @@ import { overriddenSchemaConstructor } from "./diagnostics/overriddenSchemaConst
 import { returnEffectInGen } from "./diagnostics/returnEffectInGen.js"
 import { scopeInLayerEffect } from "./diagnostics/scopeInLayerEffect.js"
 import { strictBooleanExpressions } from "./diagnostics/strictBooleanExpressions.js"
+import { strictEffectProvide } from "./diagnostics/strictEffectProvide.js"
 import { tryCatchInEffectGen } from "./diagnostics/tryCatchInEffectGen.js"
 import { unnecessaryEffectGen } from "./diagnostics/unnecessaryEffectGen.js"
 import { unnecessaryPipe } from "./diagnostics/unnecessaryPipe.js"
@@ -53,5 +54,6 @@ export const diagnostics = [
   unsupportedServiceAccessors,
   nonObjectEffectServiceType,
   deterministicKeys,
-  missedPipeableOpportunity
+  missedPipeableOpportunity,
+  strictEffectProvide
 ]

--- a/src/diagnostics/strictEffectProvide.ts
+++ b/src/diagnostics/strictEffectProvide.ts
@@ -1,0 +1,68 @@
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import type ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const strictEffectProvide = LSP.createDiagnostic({
+  name: "strictEffectProvide",
+  code: 27,
+  severity: "off",
+  apply: Nano.fn("strictEffectProvide.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const parseEffectProvideWithLayer = (node: ts.Node) =>
+      Nano.gen(function*() {
+        // Check if this is a call expression: Effect.provide(...)
+        if (
+          !ts.isCallExpression(node) ||
+          !ts.isPropertyAccessExpression(node.expression) ||
+          !ts.isIdentifier(node.expression.name) ||
+          ts.idText(node.expression.name) !== "provide" ||
+          node.arguments.length === 0
+        ) {
+          return yield* TypeParser.typeParserIssue("Not an Effect.provide call")
+        }
+
+        // Check if the expression is from the Effect module
+        yield* typeParser.importedEffectModule(node.expression.expression)
+
+        // Check if any argument is a Layer using firstSuccessOf
+        return yield* Nano.firstSuccessOf(
+          node.arguments.map((arg) => {
+            const argType = typeChecker.getTypeAtLocation(arg)
+            return typeParser.layerType(argType, arg)
+          })
+        )
+      })
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+      ts.forEachChild(node, appendNodeToVisit)
+
+      if (ts.isCallExpression(node)) {
+        const layerCheck = yield* pipe(parseEffectProvideWithLayer(node), Nano.option)
+        if (Option.isSome(layerCheck)) {
+          report({
+            location: node,
+            messageText:
+              "Effect.provide with a Layer should only be used at application entry points. If this is an entry point, you can safely disable this diagnostic. Otherwise, using Effect.provide may break scope lifetimes. Compose all layers at your entry point and provide them at once.",
+            fixes: []
+          })
+        }
+      }
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -200,7 +200,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -211,7 +211,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.codefixes
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.codefixes
@@ -1,0 +1,8 @@
+strictEffectProvide_skipNextLine from 569 to 616
+strictEffectProvide_skipFile from 569 to 616
+strictEffectProvide_skipNextLine from 427 to 461
+strictEffectProvide_skipFile from 427 to 461
+strictEffectProvide_skipNextLine from 735 to 769
+strictEffectProvide_skipFile from 735 to 769
+strictEffectProvide_skipNextLine from 893 to 963
+strictEffectProvide_skipFile from 893 to 963

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.output
@@ -1,0 +1,11 @@
+Effect.provide(MyService1.Default)
+15:2 - 15:36 | 0 | Effect.provide with a Layer should only be used at application entry points. If this is an entry point, you can safely disable this diagnostic. Otherwise, using Effect.provide may break scope lifetimes. Compose all layers at your entry point and provide them at once.    effect(strictEffectProvide)
+
+Effect.provide(Effect.void, MyService1.Default)
+19:29 - 19:76 | 0 | Effect.provide with a Layer should only be used at application entry points. If this is an entry point, you can safely disable this diagnostic. Otherwise, using Effect.provide may break scope lifetimes. Compose all layers at your entry point and provide them at once.    effect(strictEffectProvide)
+
+Effect.provide(MyService1.Default)
+24:2 - 24:36 | 0 | Effect.provide with a Layer should only be used at application entry points. If this is an entry point, you can safely disable this diagnostic. Otherwise, using Effect.provide may break scope lifetimes. Compose all layers at your entry point and provide them at once.    effect(strictEffectProvide)
+
+Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+30:2 - 30:72 | 0 | Effect.provide with a Layer should only be used at application entry points. If this is an entry point, you can safely disable this diagnostic. Otherwise, using Effect.provide may break scope lifetimes. Compose all layers at your entry point and provide them at once.    effect(strictEffectProvide)

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from427to461.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from427to461.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipFile  output for range 427 - 461
+/** @effect-diagnostics strictEffectProvide:skip-file */
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from569to616.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from569to616.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipFile  output for range 569 - 616
+/** @effect-diagnostics strictEffectProvide:skip-file */
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from735to769.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from735to769.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipFile  output for range 735 - 769
+/** @effect-diagnostics strictEffectProvide:skip-file */
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from893to963.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipFile.from893to963.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipFile  output for range 893 - 963
+/** @effect-diagnostics strictEffectProvide:skip-file */
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from427to461.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from427to461.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipNextLine  output for range 427 - 461
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+// @effect-diagnostics-next-line strictEffectProvide:off
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from569to616.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from569to616.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipNextLine  output for range 569 - 616
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+// @effect-diagnostics-next-line strictEffectProvide:off
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from735to769.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from735to769.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipNextLine  output for range 735 - 769
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+// @effect-diagnostics-next-line strictEffectProvide:off
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})

--- a/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from893to963.output
+++ b/test/__snapshots__/diagnostics/strictEffectProvide.ts.strictEffectProvide_skipNextLine.from893to963.output
@@ -1,0 +1,50 @@
+// code fix strictEffectProvide_skipNextLine  output for range 893 - 963
+// @effect-diagnostics strictEffectProvide:warning
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+// Should report: Effect.provide with a Layer
+export const shouldReport1 = Effect.void.pipe(
+  Effect.provide(MyService1.Default)
+)
+
+// Should report: Effect.provide with multiple arguments including a Layer
+export const shouldReport2 = Effect.provide(Effect.void, MyService1.Default)
+
+// Should report: Effect.provide in a chain
+export const shouldReport3 = Effect.void.pipe(
+  Effect.map(() => 42),
+  Effect.provide(MyService1.Default),
+  Effect.map((n) => n + 1)
+)
+
+// Should report: Multiple layers provided
+// @effect-diagnostics-next-line strictEffectProvide:off
+export const shouldReport4 = Effect.void.pipe(
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+// Should NOT report: providing a plain service (not a layer)
+export const shouldNotReport1 = Effect.void.pipe(
+  Effect.provideService(MyService1, new MyService1({ value: 1 }))
+)
+
+// Should NOT report: Layer.provide (not Effect.provide)
+export const shouldNotReport2 = Layer.provide(
+  MyService1.Default,
+  MyService2.Default
+)
+
+// Should NOT report: Effect.provide without layer arguments
+export const shouldNotReport3 = Effect.gen(function*() {
+  const ctx = yield* Effect.context<MyService1>()
+  return yield* Effect.provide(Effect.void, ctx)
+})


### PR DESCRIPTION
## Summary

Implements a new diagnostic `strictEffectProvide` to detect when `Effect.provide` is called with a Layer argument outside of application entry points. This helps prevent scope lifetime issues by encouraging developers to compose all layers at entry points and provide them at once.

Closes #446

## Features

- **Diagnostic name**: `strictEffectProvide`
- **Default severity**: `"off"` (opt-in)
- **Diagnostic code**: 27

## Example

The diagnostic will warn when `Effect.provide` is used with a Layer:

```typescript
// Will trigger diagnostic
export const program = Effect.void.pipe(
  Effect.provide(MyService.Default)
)
```

**Diagnostic message:**
> Effect.provide with a Layer should only be used at application entry points. If this is an entry point, you can safely disable this diagnostic. Otherwise, using Effect.provide may break scope lifetimes. Compose all layers at your entry point and provide them at once.

## Configuration

Users can enable this diagnostic in their `tsconfig.json`:

```json
{
  "compilerOptions": {
    "plugins": [{
      "name": "@effect/language-service",
      "diagnosticSeverity": {
        "strictEffectProvide": "warning"
      }
    }]
  }
}
```

## Test Coverage

- ✅ Detects `Effect.provide` with Layer in pipe chains
- ✅ Detects `Effect.provide` with Layer in direct calls
- ✅ Detects `Effect.provide` with merged layers
- ✅ Does not report `Effect.provideService`
- ✅ Does not report `Layer.provide`
- ✅ Does not report `Effect.provide` with Context (non-Layer)

Generated with [Claude Code](https://claude.com/claude-code)