### PR TITLE
docs: Add monorepo installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This package implements a TypeScript language service plugin that allows additio
 ## Installation
 
 1. `npm install @effect/language-service --save-dev` in your project
+   - For monorepos: We suggest installing `@effect/language-service` in the monorepo root and configuring it in the root `tsconfig.json` for consistent behavior across all packages
+   - For any other package: Install directly in the package where you want to use it
 2. Inside your tsconfig.json, you should add the plugin configuration as follows:
 ```jsonc
 {


### PR DESCRIPTION
## Summary

Adds installation guidance for monorepo setups to the README.

## Changes

Updated the installation instructions to include specific guidance for monorepo users:
- Recommends installing `@effect/language-service` in the monorepo root
- Suggests configuring it in the root `tsconfig.json` for consistent behavior across all packages
- Clarifies that for non-monorepo packages, it can be installed directly in the package

This helps users working with monorepos understand the recommended setup pattern.

## Type of Change

- [x] Documentation update
- [ ] No breaking changes
- [ ] No changeset required (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)