### PR TITLE
Add catchUnfailableEffect diagnostic

### DIFF
--- a/.changeset/catch-unfailable-effect.md
+++ b/.changeset/catch-unfailable-effect.md
@@ -1,0 +1,30 @@
+---
+"@effect/language-service": minor
+---
+
+Add new diagnostic `catchUnfailableEffect` to warn when using catch functions on effects that never fail
+
+This diagnostic detects when catch error handling functions are applied to effects that have a `never` error type (meaning they cannot fail). It supports all Effect catch variants:
+
+- `Effect.catchAll`
+- `Effect.catch`
+- `Effect.catchIf`
+- `Effect.catchSome`
+- `Effect.catchTag`
+- `Effect.catchTags`
+
+Example:
+
+```typescript
+// Will trigger diagnostic
+const example = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- Warns here
+)
+
+// Will not trigger diagnostic
+const example2 = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+```
+
+The diagnostic works in both pipeable style (`Effect.succeed(x).pipe(Effect.catchAll(...))`) and data-first style (`pipe(Effect.succeed(x), Effect.catchAll(...))`), analyzing the error type at each position in the pipe chain.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Warn when schema classes override the default constructor behavior
 - Warn when `@effect-diagnostics-next-line` comments have no effect (i.e., they don't suppress any diagnostic)
 - Detect nested function calls that can be converted to pipeable style for better readability
+- Warn when using catch functions (`catchAll`, `catch`, `catchIf`, `catchSome`, `catchTag`, `catchTags`) on effects that never fail
 
 ### Completions
 

--- a/examples/diagnostics/catchUnfailableEffect.ts
+++ b/examples/diagnostics/catchUnfailableEffect.ts
@@ -1,0 +1,37 @@
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, pipe } from "effect"
+
+export const shouldReport = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReport = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportPipe = pipe(
+  Effect.succeed(42),
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReportPipe = pipe(
+  Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArg = Effect.succeed(42).pipe(
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldNotTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.void),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should report here
+)

--- a/examples/diagnostics/catchUnfailableEffect_variants.ts
+++ b/examples/diagnostics/catchUnfailableEffect_variants.ts
@@ -1,0 +1,31 @@
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/src/core/TypeParser.ts
+++ b/src/core/TypeParser.ts
@@ -307,7 +307,7 @@ export function make(
           const moduleSymbol = typeChecker.getSymbolAtLocation(sourceFile)
           if (!moduleSymbol) continue
           const memberSymbol = typeChecker.tryGetMemberInModuleExports(memberName, moduleSymbol)
-          if (memberSymbol) result.push({ memberSymbol, moduleSymbol, sourceFile })
+          if (memberSymbol && memberSymbol === symbol) result.push({ memberSymbol, moduleSymbol, sourceFile })
         }
         if (result.length > 0) {
           return result

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,3 +1,4 @@
+import { catchUnfailableEffect } from "./diagnostics/catchUnfailableEffect.js"
 import { classSelfMismatch } from "./diagnostics/classSelfMismatch.js"
 import { deterministicKeys } from "./diagnostics/deterministicKeys.js"
 import { duplicatePackage } from "./diagnostics/duplicatePackage.js"
@@ -28,6 +29,7 @@ import { unnecessaryPipeChain } from "./diagnostics/unnecessaryPipeChain.js"
 import { unsupportedServiceAccessors } from "./diagnostics/unsupportedServiceAccessors.js"
 
 export const diagnostics = [
+  catchUnfailableEffect,
   classSelfMismatch,
   duplicatePackage,
   effectGenUsesAdapter,

--- a/src/diagnostics/catchUnfailableEffect.ts
+++ b/src/diagnostics/catchUnfailableEffect.ts
@@ -1,0 +1,103 @@
+import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
+import type ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const catchUnfailableEffect = LSP.createDiagnostic({
+  name: "catchUnfailableEffect",
+  code: 2,
+  severity: "suggestion",
+  apply: Nano.fn("catchUnfailableEffect.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+      ts.forEachChild(node, appendNodeToVisit)
+
+      // Check if this is a call expression (cold expression)
+      if (ts.isCallExpression(node)) {
+        // Check if the call expression references any of the catch functions
+        const catchFunctions = ["catchAll", "catch", "catchIf", "catchSome", "catchTag", "catchTags"]
+        const isCatchCall = yield* pipe(
+          Nano.firstSuccessOf(
+            catchFunctions.map((catchFn) => typeParser.isNodeReferenceToEffectModuleApi(catchFn)(node.expression))
+          ),
+          Nano.option
+        )
+
+        if (Option.isSome(isCatchCall)) {
+          // Check if the parent is a pipe call
+          const parent = node.parent
+          if (parent && ts.isCallExpression(parent)) {
+            const pipeCallResult = yield* pipe(
+              typeParser.pipeCall(parent),
+              Nano.option
+            )
+
+            if (Option.isSome(pipeCallResult)) {
+              const { args, node: pipeCallNode, subject } = pipeCallResult.value
+
+              // Find the index of this node in the pipe arguments
+              const argIndex = args.findIndex((arg) => arg === node)
+
+              if (argIndex !== -1) {
+                let effectTypeToCheck: ts.Type | undefined
+
+                // Get the effect type based on argument index
+                if (argIndex === 0) {
+                  // If argIndex is 0, get the type from the subject
+                  effectTypeToCheck = typeChecker.getTypeAtLocation(subject)
+                } else {
+                  // If argIndex > 0, get the type from signature type arguments at argIndex
+                  const signature = typeChecker.getResolvedSignature(pipeCallNode)
+                  if (signature) {
+                    const typeArguments = typeChecker.getTypeArgumentsForResolvedSignature(signature)
+                    if (typeArguments && typeArguments.length > argIndex) {
+                      effectTypeToCheck = typeArguments[argIndex]
+                    }
+                  }
+                }
+
+                // Check if the effect type has error type never
+                if (effectTypeToCheck) {
+                  const effectType = yield* pipe(
+                    typeParser.effectType(effectTypeToCheck, node),
+                    Nano.option
+                  )
+
+                  // Only report if we successfully parsed an effect type and E is never
+                  if (Option.isSome(effectType)) {
+                    const { E } = effectType.value
+
+                    // Only report if E is exactly never
+                    if (E.flags & ts.TypeFlags.Never) {
+                      report({
+                        location: node.expression,
+                        messageText:
+                          `Looks like the previous effect never fails, so probably this error handling will never be triggered.`,
+                        fixes: []
+                      })
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -200,7 +200,7 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|catchUnfailableEffect,classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -211,7 +211,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|catchUnfailableEffect,classSelfMismatch,deterministicKeys,duplicatePackage,effectGenUsesAdapter,effectInVoidSuccess,floatingEffect,genericEffectServices,importFromBarrel,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unnecessaryEffectGen,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipFile.from1067to1082.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipFile.from1067to1082.output
@@ -1,0 +1,39 @@
+// code fix catchUnfailableEffect_skipFile  output for range 1067 - 1082
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, pipe } from "effect"
+
+export const shouldReport = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReport = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportPipe = pipe(
+  Effect.succeed(42),
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReportPipe = pipe(
+  Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArg = Effect.succeed(42).pipe(
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldNotTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.void),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipFile.from147to162.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipFile.from147to162.output
@@ -1,0 +1,39 @@
+// code fix catchUnfailableEffect_skipFile  output for range 147 - 162
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, pipe } from "effect"
+
+export const shouldReport = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReport = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportPipe = pipe(
+  Effect.succeed(42),
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReportPipe = pipe(
+  Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArg = Effect.succeed(42).pipe(
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldNotTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.void),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipFile.from377to392.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipFile.from377to392.output
@@ -1,0 +1,39 @@
+// code fix catchUnfailableEffect_skipFile  output for range 377 - 392
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, pipe } from "effect"
+
+export const shouldReport = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReport = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportPipe = pipe(
+  Effect.succeed(42),
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReportPipe = pipe(
+  Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArg = Effect.succeed(42).pipe(
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldNotTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.void),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipNextLine.from1067to1082.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipNextLine.from1067to1082.output
@@ -1,0 +1,39 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 1067 - 1082
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, pipe } from "effect"
+
+export const shouldReport = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReport = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportPipe = pipe(
+  Effect.succeed(42),
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReportPipe = pipe(
+  Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArg = Effect.succeed(42).pipe(
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldNotTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const shouldTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.void),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipNextLine.from147to162.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipNextLine.from147to162.output
@@ -1,0 +1,39 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 147 - 162
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, pipe } from "effect"
+
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const shouldReport = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReport = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportPipe = pipe(
+  Effect.succeed(42),
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReportPipe = pipe(
+  Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArg = Effect.succeed(42).pipe(
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldNotTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.void),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipNextLine.from377to392.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.catchUnfailableEffect_skipNextLine.from377to392.output
@@ -1,0 +1,39 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 377 - 392
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, pipe } from "effect"
+
+export const shouldReport = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReport = Effect.fail("error").pipe(
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const shouldReportPipe = pipe(
+  Effect.succeed(42),
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+export const shouldNotReportPipe = pipe(
+  Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArg = Effect.succeed(42).pipe(
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldNotTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.fail("error")),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should not report here
+)
+
+export const shouldTriggerThirdArgPipe = pipe(
+  Effect.succeed(42),
+  Effect.flatMap(() => Effect.void),
+  Effect.catchAll(() => Effect.succeed(42)) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.codefixes
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.codefixes
@@ -1,0 +1,6 @@
+catchUnfailableEffect_skipNextLine from 147 to 162
+catchUnfailableEffect_skipFile from 147 to 162
+catchUnfailableEffect_skipNextLine from 377 to 392
+catchUnfailableEffect_skipFile from 377 to 392
+catchUnfailableEffect_skipNextLine from 1067 to 1082
+catchUnfailableEffect_skipFile from 1067 to 1082

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect.ts.output
@@ -1,0 +1,8 @@
+Effect.catchAll
+5:2 - 5:17 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)
+
+Effect.catchAll
+14:2 - 14:17 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)
+
+Effect.catchAll
+36:2 - 36:17 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from172to187.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from172to187.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipFile  output for range 172 - 187
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from311to325.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from311to325.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipFile  output for range 311 - 325
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from485to501.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from485to501.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipFile  output for range 485 - 501
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from662to677.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from662to677.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipFile  output for range 662 - 677
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from816to832.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipFile.from816to832.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipFile  output for range 816 - 832
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from172to187.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from172to187.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 172 - 187
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from311to325.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from311to325.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 311 - 325
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from485to501.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from485to501.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 485 - 501
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from662to677.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from662to677.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 662 - 677
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from816to832.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.catchUnfailableEffect_skipNextLine.from816to832.output
@@ -1,0 +1,33 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 816 - 832
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect, Option } from "effect"
+
+// catchAll variant
+export const catchAllExample = Effect.succeed(42).pipe(
+  Effect.catchAll(() => Effect.void) // <- should report here
+)
+
+// catchIf variant
+export const catchIfExample = Effect.succeed(42).pipe(
+  Effect.catchIf((error) => error === "MyError", () => Effect.void) // <- should report here
+)
+
+// catchSome variant
+export const catchSomeExample = Effect.succeed(42).pipe(
+  Effect.catchSome(() => Option.some(Effect.void)) // <- should report here
+)
+
+// catchTag variant
+export const catchTagExample = Effect.succeed(42).pipe(
+  // @ts-expect-error
+  Effect.catchTag("MyError", () => Effect.void) // <- should report here
+)
+
+// catchTags variant
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const catchTagsExample = Effect.succeed(42).pipe(
+  Effect.catchTags({
+    // @ts-expect-error
+    MyError: () => Effect.void
+  }) // <- should report here
+)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.codefixes
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.codefixes
@@ -1,0 +1,10 @@
+catchUnfailableEffect_skipNextLine from 172 to 187
+catchUnfailableEffect_skipFile from 172 to 187
+catchUnfailableEffect_skipNextLine from 311 to 325
+catchUnfailableEffect_skipFile from 311 to 325
+catchUnfailableEffect_skipNextLine from 485 to 501
+catchUnfailableEffect_skipFile from 485 to 501
+catchUnfailableEffect_skipNextLine from 662 to 677
+catchUnfailableEffect_skipFile from 662 to 677
+catchUnfailableEffect_skipNextLine from 816 to 832
+catchUnfailableEffect_skipFile from 816 to 832

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_variants.ts.output
@@ -1,0 +1,14 @@
+Effect.catchAll
+6:2 - 6:17 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)
+
+Effect.catchIf
+11:2 - 11:16 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)
+
+Effect.catchSome
+16:2 - 16:18 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)
+
+Effect.catchTag
+22:2 - 22:17 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)
+
+Effect.catchTags
+27:2 - 27:18 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)


### PR DESCRIPTION
## Summary

This PR adds a new diagnostic `catchUnfailableEffect` that warns when catch error handling functions are used on effects that have a `never` error type (meaning they cannot fail).

The diagnostic supports all Effect catch function variants:
- `Effect.catchAll`
- `Effect.catch`
- `Effect.catchIf`
- `Effect.catchSome`
- `Effect.catchTag`
- `Effect.catchTags`

## Example

```typescript
// Triggers diagnostic - effect never fails
const example = Effect.succeed(42).pipe(
  Effect.catchAll(() => Effect.void) // <- Warning: error handling will never be triggered
)

// Does not trigger - effect can fail
const example2 = Effect.fail("error").pipe(
  Effect.catchAll(() => Effect.succeed(42))
)
```

The diagnostic works in both pipeable style (`Effect.succeed(x).pipe(Effect.catchAll(...))`) and data-first style (`pipe(Effect.succeed(x), Effect.catchAll(...))`), analyzing the error type at each position in the pipe chain.

## Test plan

- ✅ Created comprehensive test examples in `examples/diagnostics/catchUnfailableEffect.ts` and `catchUnfailableEffect_variants.ts`
- ✅ All 300 tests pass including new diagnostic tests
- ✅ Type checking passes (`pnpm check`)
- ✅ Linting passes (`pnpm lint-fix`)
- ✅ Added documentation to README.md
- ✅ Created changeset with minor version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)