### PR TITLE
Add reportSuggestionsAsWarningsInTsc configuration option

### DIFF
--- a/.changeset/report-suggestions-as-warnings-in-tsc.md
+++ b/.changeset/report-suggestions-as-warnings-in-tsc.md
@@ -1,0 +1,21 @@
+---
+"@effect/language-service": patch
+---
+
+Add `reportSuggestionsAsWarningsInTsc` configuration option to allow suggestions and messages to be reported as warnings in TypeScript compiler.
+
+When enabled, diagnostics with "suggestion" or "message" severity will be upgraded to "warning" severity with a "[suggestion]" prefix in the message text. This is useful for CI/CD pipelines where you want to enforce suggestion-level diagnostics as warnings in the TypeScript compiler output.
+
+Example configuration:
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "reportSuggestionsAsWarningsInTsc": true
+      }
+    ]
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Few options can be provided alongside the initialization of the Language Service
         },
         "diagnosticsName": true, // controls whether to include the rule name in diagnostic messages (default: true)
         "missingDiagnosticNextLine": "warning", // controls the severity of warnings for unused @effect-diagnostics-next-line comments (default: "warning", allowed values: off,error,warning,message,suggestion)
+        "reportSuggestionsAsWarningsInTsc": false, // when enabled, diagnostics with "suggestion" or "message" severity will be reported as "warning" in TSC with "[suggestion]" prefix (default: false)
         "quickinfo": true, // controls Effect quickinfo (default: true)
         "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
         "quickinfoMaximumLength": -1, // controls how long can be the types in the quickinfo hover (helps with very long type to improve perfs, defaults to -1 for no truncation, can be any number eg. 1000 and TS will try to fit as much as possible in that budget, higher number means more info.)

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -21,6 +21,7 @@ export interface LanguageServicePluginOptions {
   diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
   diagnosticsName: boolean
   missingDiagnosticNextLine: DiagnosticSeverity | "off"
+  reportSuggestionsAsWarningsInTsc: boolean
   quickinfoEffectParameters: "always" | "never" | "whentruncated"
   quickinfo: boolean
   quickinfoMaximumLength: number
@@ -64,6 +65,7 @@ export const defaults: LanguageServicePluginOptions = {
   diagnosticSeverity: {},
   diagnosticsName: true,
   missingDiagnosticNextLine: "warning",
+  reportSuggestionsAsWarningsInTsc: false,
   quickinfo: true,
   quickinfoEffectParameters: "whentruncated",
   quickinfoMaximumLength: -1,
@@ -132,6 +134,10 @@ export function parse(config: any): LanguageServicePluginOptions {
         isString(config.missingDiagnosticNextLine) && isValidSeverityLevel(config.missingDiagnosticNextLine)
       ? config.missingDiagnosticNextLine as DiagnosticSeverity | "off"
       : defaults.missingDiagnosticNextLine,
+    reportSuggestionsAsWarningsInTsc: isObject(config) && hasProperty(config, "reportSuggestionsAsWarningsInTsc") &&
+        isBoolean(config.reportSuggestionsAsWarningsInTsc)
+      ? config.reportSuggestionsAsWarningsInTsc
+      : defaults.reportSuggestionsAsWarningsInTsc,
     quickinfo: isObject(config) && hasProperty(config, "quickinfo") && isBoolean(config.quickinfo)
       ? config.quickinfo
       : defaults.quickinfo,


### PR DESCRIPTION
## Summary

This PR adds a new LSP configuration option `reportSuggestionsAsWarningsInTsc` that allows diagnostics with "suggestion" or "message" severity to be reported as "warning" severity in the TypeScript compiler output.

When enabled, affected diagnostics are:
- Upgraded from "suggestion" or "message" to "warning" severity
- Prefixed with `[suggestion]` in the message text to indicate their original severity level

This is particularly useful for CI/CD pipelines where you want to enforce suggestion-level diagnostics as warnings in the TypeScript compiler output.

## Changes Made

1. **Added new configuration option** (`src/core/LanguageServicePluginOptions.ts`):
   - Added `reportSuggestionsAsWarningsInTsc: boolean` to the interface
   - Default value: `false`
   - Added parsing logic to read from config

2. **Modified diagnostic filtering** (`src/effect-lsp-patch-utils.ts`):
   - Updated `checkSourceFileWorker` to include suggestion/message diagnostics when flag is enabled
   - Transform suggestion/message diagnostics to warnings with `[suggestion]` prefix

3. **Updated documentation** (`README.md`):
   - Added configuration option documentation with example

4. **Added changeset** for patch release

## Example Configuration

```json
{
  "compilerOptions": {
    "plugins": [
      {
        "name": "@effect/language-service",
        "reportSuggestionsAsWarningsInTsc": true
      }
    ]
  }
}
```

## Test plan

- ✅ All existing tests pass
- ✅ TypeScript type checking passes
- ✅ Linting passes
- ✅ Configuration parsing works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)