### PR TITLE
Improve CLI diagnostics output formatting

### DIFF
--- a/.changeset/improve-cli-diagnostics-display.md
+++ b/.changeset/improve-cli-diagnostics-display.md
@@ -1,0 +1,13 @@
+---
+"@effect/language-service": patch
+---
+
+Improve CLI diagnostics output formatting by displaying rule names in a more readable format.
+
+The CLI now displays diagnostic rule names using the format `effect(ruleName):` instead of `TS<code>:`, making it easier to identify which Effect diagnostic rule triggered the error. Additionally, the CLI now disables the `diagnosticsName` option internally to prevent duplicate rule name display in the message text.
+
+Example output:
+```
+Before: TS90001: Floating Effect detected...
+After:  effect(floatingEffect): Floating Effect detected...
+```

--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -118,7 +118,7 @@ export const diagnostics = Command.make(
             Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
             Nano.provideService(
               LanguageServicePluginOptions.LanguageServicePluginOptions,
-              LanguageServicePluginOptions.parse(pluginConfig)
+              { ...LanguageServicePluginOptions.parse(pluginConfig), diagnosticsName: false }
             ),
             Nano.run,
             Either.map((_) => _.diagnostics),
@@ -136,11 +136,14 @@ export const diagnostics = Command.make(
           warningsCount += results.filter((_) => _.category === tsInstance.DiagnosticCategory.Warning).length
           messagesCount += results.filter((_) => _.category === tsInstance.DiagnosticCategory.Message).length
           if (results.length > 0) {
-            const formattedResults = tsInstance.formatDiagnosticsWithColorAndContext(results, {
+            let formattedResults = tsInstance.formatDiagnosticsWithColorAndContext(results, {
               getCanonicalFileName: (fileName) => path.resolve(fileName),
               getCurrentDirectory: () => path.resolve("."),
               getNewLine: () => "\n"
             })
+            Object.values(diagnosticsDefinitions).forEach((_) =>
+              formattedResults = formattedResults.replace(new RegExp(`TS${_.code}:`, "g"), `effect(${_.name}):`)
+            )
             console.log(formattedResults)
           }
         } finally {


### PR DESCRIPTION
## Summary

This PR improves the CLI diagnostics output formatting by replacing TypeScript error codes with more readable Effect rule names.

## Changes

**Before:**
```
TS90001: Floating Effect detected...
```

**After:**
```
effect(floatingEffect): Floating Effect detected...
```

## Implementation Details

1. **Disabled `diagnosticsName` in CLI** (`src/cli/diagnostics.ts`):
   - Set `diagnosticsName: false` when providing LanguageServicePluginOptions
   - This prevents duplicate rule names in the message text

2. **Replace error codes with rule names**:
   - Added regex replacement to convert `TS<code>:` to `effect(ruleName):`
   - Uses the diagnostics definitions to map codes to rule names
   - Applied after TypeScript formats the diagnostics

## Benefits

- More readable CLI output
- Consistent with Effect diagnostic naming conventions
- Easier to identify which specific rule triggered the diagnostic
- Better developer experience when running diagnostics via CLI

## Test plan

- ✅ All existing tests pass (302 tests)
- ✅ TypeScript type checking passes
- ✅ Linting passes
- ✅ CLI diagnostics display correctly formatted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)