### PR TITLE
Fix memory leak in CLI diagnostics by disposing language services

### DIFF
--- a/.changeset/fix-cli-diagnostics-memory-leak.md
+++ b/.changeset/fix-cli-diagnostics-memory-leak.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Fix memory leak in CLI diagnostics by properly disposing language services when they change between batches.
+
+The CLI diagnostics command now tracks the language service instance and disposes of it when a new instance is created, preventing memory accumulation during batch processing of large codebases.


### PR DESCRIPTION
## Summary

This PR fixes a memory leak in the CLI diagnostics command by properly tracking and disposing language service instances when they change between batches.

## Problem

Previously, when processing files in batches, the CLI would create new language service instances without disposing of old ones, leading to memory accumulation when running diagnostics on large codebases.

## Solution

- Added tracking of the current language service instance
- Implemented `disposeIfLanguageServiceChanged` helper that disposes the previous instance when a new one is created
- Ensures cleanup happens at the end of batch processing

## Changes

- `src/cli/diagnostics.ts:93-98`: Added language service tracking and disposal logic
- `src/cli/diagnostics.ts:111`: Dispose language service when it changes
- `src/cli/diagnostics.ts:163`: Final cleanup after all batches complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)