### PR TITLE
Fix TSC patching mode diagnosticsName and suggestion handling

### DIFF
--- a/.changeset/fix-tsc-patching-diagnostics-name.md
+++ b/.changeset/fix-tsc-patching-diagnostics-name.md
@@ -1,0 +1,9 @@
+---
+"@effect/language-service": patch
+---
+
+Fix TSC patching mode to properly enable diagnosticsName option and simplify suggestion handling.
+
+When using the language service in TSC patching mode, the `diagnosticsName` option is now automatically enabled to ensure diagnostic rule names are included in the output. Additionally, the handling of suggestion-level diagnostics has been simplified - when `reportSuggestionsAsWarningsInTsc` is enabled, suggestions are now converted to Message category instead of Warning category with a prefix.
+
+This change ensures consistent diagnostic formatting across both IDE and CLI usage modes.

--- a/src/effect-lsp-patch-utils.ts
+++ b/src/effect-lsp-patch-utils.ts
@@ -56,7 +56,10 @@ export function checkSourceFileWorker(
   const pluginOptions = extractEffectLspOptions(compilerOptions)
   if (!pluginOptions) return
 
-  const parsedOptions = LanguageServicePluginOptions.parse(pluginOptions)
+  const parsedOptions: LanguageServicePluginOptions.LanguageServicePluginOptions = {
+    ...LanguageServicePluginOptions.parse(pluginOptions),
+    diagnosticsName: true
+  }
 
   // run the diagnostics and pipe them into addDiagnostic
   pipe(
@@ -77,24 +80,18 @@ export function checkSourceFileWorker(
       Array.filter((_) =>
         _.category === tsInstance.DiagnosticCategory.Error ||
         _.category === tsInstance.DiagnosticCategory.Warning ||
-        (parsedOptions.reportSuggestionsAsWarningsInTsc &&
-          (_.category === tsInstance.DiagnosticCategory.Suggestion ||
-            _.category === tsInstance.DiagnosticCategory.Message))
+        (parsedOptions.reportSuggestionsAsWarningsInTsc && (
+          _.category === tsInstance.DiagnosticCategory.Suggestion ||
+          _.category === tsInstance.DiagnosticCategory.Message
+        ))
       )
     ),
     Either.map(
       Array.map((_) => {
         if (
-          parsedOptions.reportSuggestionsAsWarningsInTsc && (_.category === tsInstance.DiagnosticCategory.Suggestion ||
-            _.category === tsInstance.DiagnosticCategory.Message)
+          parsedOptions.reportSuggestionsAsWarningsInTsc && _.category === tsInstance.DiagnosticCategory.Suggestion
         ) {
-          return {
-            ..._,
-            category: tsInstance.DiagnosticCategory.Warning,
-            messageText: typeof _.messageText === "string"
-              ? `[suggestion] ${_.messageText}`
-              : _.messageText
-          }
+          return { ..._, category: tsInstance.DiagnosticCategory.Message }
         }
         return _
       })


### PR DESCRIPTION
## Summary

This PR fixes two issues in the TSC patching mode:

1. **Enables `diagnosticsName` option**: The TSC patching mode now automatically sets `diagnosticsName: true` to ensure diagnostic rule names are properly included in the output
2. **Simplifies suggestion handling**: When `reportSuggestionsAsWarningsInTsc` is enabled, suggestion-level diagnostics are now converted to `Message` category instead of `Warning` category with a `[suggestion]` prefix

## Changes

- Modified `checkSourceFileWorker` in `src/effect-lsp-patch-utils.ts` to:
  - Force enable `diagnosticsName: true` for TSC patching mode
  - Simplify suggestion category conversion logic
  - Improve code formatting consistency

## Test Plan

- [x] All existing tests pass (`pnpm test`)
- [x] TypeScript checks pass (`pnpm check`)
- [x] Linting passes (`pnpm lint-fix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)