### PR TITLE
Fix TSC patching mode diagnostics filtering

### DIFF
--- a/.changeset/fix-tsc-diagnostics-filtering.md
+++ b/.changeset/fix-tsc-diagnostics-filtering.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix TSC patching mode to properly filter diagnostics by module name. The `reportSuggestionsAsWarningsInTsc` option now only affects the TSC module and not the TypeScript module, preventing suggestions from being incorrectly reported in non-TSC contexts.

--- a/src/cli/patch.ts
+++ b/src/cli/patch.ts
@@ -193,7 +193,7 @@ const getPatchesForModule = Effect.fn("getPatchesForModule")(
         insertCheckSourceFilePosition.value.position,
         `effectLspPatchUtils().checkSourceFileWorker(${
           moduleName === "typescript" ? "module.exports" : "effectLspTypeScriptApis()"
-        }, host, node, compilerOptions, diagnostics.add)\n`,
+        }, host, node, compilerOptions, diagnostics.add, "${moduleName}")\n`,
         "\n",
         version
       )

--- a/src/effect-lsp-patch-utils.ts
+++ b/src/effect-lsp-patch-utils.ts
@@ -50,7 +50,8 @@ export function checkSourceFileWorker(
   program: ts.Program,
   sourceFile: ts.SourceFile,
   compilerOptions: ts.CompilerOptions,
-  addDiagnostic: (diagnostic: ts.Diagnostic) => void
+  addDiagnostic: (diagnostic: ts.Diagnostic) => void,
+  moduleName: string
 ) {
   // check if the plugin is enabled
   const pluginOptions = extractEffectLspOptions(compilerOptions)
@@ -80,7 +81,7 @@ export function checkSourceFileWorker(
       Array.filter((_) =>
         _.category === tsInstance.DiagnosticCategory.Error ||
         _.category === tsInstance.DiagnosticCategory.Warning ||
-        (parsedOptions.reportSuggestionsAsWarningsInTsc && (
+        (moduleName === "tsc" && parsedOptions.reportSuggestionsAsWarningsInTsc && (
           _.category === tsInstance.DiagnosticCategory.Suggestion ||
           _.category === tsInstance.DiagnosticCategory.Message
         ))
@@ -89,7 +90,8 @@ export function checkSourceFileWorker(
     Either.map(
       Array.map((_) => {
         if (
-          parsedOptions.reportSuggestionsAsWarningsInTsc && _.category === tsInstance.DiagnosticCategory.Suggestion
+          moduleName === "tsc" && parsedOptions.reportSuggestionsAsWarningsInTsc &&
+          _.category === tsInstance.DiagnosticCategory.Suggestion
         ) {
           return { ..._, category: tsInstance.DiagnosticCategory.Message }
         }


### PR DESCRIPTION
## Summary

This PR fixes an issue in the TSC patching mode where the `reportSuggestionsAsWarningsInTsc` option was incorrectly being applied to both the TSC and TypeScript modules. The option should only affect the TSC module to ensure diagnostics are properly filtered based on the patching context.

## Changes

- Added `moduleName` parameter to `checkSourceFileWorker` function in `src/effect-lsp-patch-utils.ts`
- Updated `getPatchesForModule` in `src/cli/patch.ts` to pass the `moduleName` parameter when calling `checkSourceFileWorker`
- Modified diagnostic filtering logic to only apply `reportSuggestionsAsWarningsInTsc` when `moduleName === "tsc"`

## Example

Before this fix, when patching the TypeScript module, suggestions could be incorrectly reported. Now the filtering is correctly scoped:

- When `moduleName === "tsc"`: Suggestions can be reported as warnings if `reportSuggestionsAsWarningsInTsc` is enabled
- When `moduleName === "typescript"`: Only errors and warnings are reported, suggestions are filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)