### PR TITLE
Fix edge cases in missedPipeableOpportunity diagnostic

### DIFF
--- a/.changeset/fix-missed-pipeable-edge-cases.md
+++ b/.changeset/fix-missed-pipeable-edge-cases.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Fix edge cases in missedPipeableOpportunity diagnostic where it incorrectly flagged valid code patterns. The diagnostic now properly:
+- Excludes `pipe` function calls from chain detection
+- Ignores chains where the function returns a callable type (avoiding false positives for higher-order functions like `Schedule.whileOutput`)

--- a/examples/diagnostics/missedPipeableOpportunity_error.ts
+++ b/examples/diagnostics/missedPipeableOpportunity_error.ts
@@ -1,6 +1,7 @@
 // @effect-diagnostics missedPipeableOpportunity:warning
 // @test-config {"pipeableMinArgCount": 2}
-import { identity, Schema } from "effect"
+import { Duration, identity, pipe, Schedule, Schema } from "effect"
+import * as Effect from "effect/Effect"
 
 const MyStruct = Schema.Struct({
   x: Schema.Number,
@@ -8,3 +9,12 @@ const MyStruct = Schema.Struct({
 })
 
 export const shouldNotTrigger = identity(Schema.decodeUnknown(MyStruct)({ x: 42, y: 42 }))
+
+export const shouldNotTriggerFunctionReturned = pipe(
+  Schedule.exponential(Duration.millis(10), 4),
+  Schedule.whileOutput(Duration.lessThanOrEqualTo(Duration.seconds(10))) // should not report
+)
+
+export const shouldNotTriggerInnerPipe = Effect.log("Hello").pipe(
+  Effect.ensuring(Effect.log("World"))
+)


### PR DESCRIPTION
## Summary
Fixes edge cases in the `missedPipeableOpportunity` diagnostic that were causing false positives with certain valid code patterns.

## Changes
- **Exclude pipe calls**: The diagnostic now properly detects and excludes `pipe()` function calls from chain detection
- **Handle higher-order functions**: Functions that return callable types are no longer flagged, preventing false positives for patterns like `Schedule.whileOutput()`

## Examples

### Before (false positive)
```typescript
// This was incorrectly flagged as needing pipe conversion
export const shouldNotTrigger = pipe(
  Schedule.exponential(Duration.millis(10), 4),
  Schedule.whileOutput(Duration.lessThanOrEqualTo(Duration.seconds(10)))
)
```

### After (correctly ignored)
The diagnostic now correctly recognizes that:
1. This code is already using `pipe()`
2. `Schedule.whileOutput()` returns a function (callable type), so it's not a missed pipeable opportunity

## Test Coverage
Added test cases in `examples/diagnostics/missedPipeableOpportunity_error.ts`:
- `shouldNotTriggerFunctionReturned`: Tests the Schedule.whileOutput pattern
- `shouldNotTriggerInnerPipe`: Tests nested pipe detection

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)