### PR TITLE
Fix @effect-diagnostics-next-line for property assignments in objects

### DIFF
--- a/.changeset/diagnostic-disable-property-assignment.md
+++ b/.changeset/diagnostic-disable-property-assignment.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fixed `@effect-diagnostics-next-line` comment directive to properly work with diagnostics on property assignments within object literals. Previously, the directive would not suppress diagnostics for properties in the middle of an object literal.

--- a/examples/diagnostics/unnecessaryPipe_disableMidObject.ts
+++ b/examples/diagnostics/unnecessaryPipe_disableMidObject.ts
@@ -1,0 +1,9 @@
+import { pipe } from "effect"
+import * as Effect from "effect/Effect"
+
+export const test = {
+  a: pipe(Effect.succeed(42)),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  b: pipe(Effect.succeed(43)),
+  c: pipe(Effect.succeed(44))
+}

--- a/src/core/LSP.ts
+++ b/src/core/LSP.ts
@@ -248,6 +248,14 @@ const createDiagnosticExecutor = Nano.fn("LSP.createCommentDirectivesProcessor")
           result = node
           return
         }
+        if (ts.isPropertyAssignment(node)) {
+          const realStart = ts.getTokenPosOfNode(node, sourceFile)
+          const starts = sourceFile.getLineStarts().filter((start) => start >= node.pos && start <= realStart)
+          if (starts.length > 0) {
+            result = node
+            return
+          }
+        }
         if (result) return
         if (node.parent) find(node.parent)
       }

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1266to1272.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1266to1272.output
@@ -27,9 +27,9 @@ export class UsesStringValueLazyEffect
 {}
 
 // should warn on "scoped" key because it returns an effect that resolves to a primitive
-// @effect-diagnostics-next-line nonObjectEffectServiceType:off
 export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>()("UsesStringValueScoped", {
   // @ts-expect-error
+  // @effect-diagnostics-next-line nonObjectEffectServiceType:off
   scoped: Effect.succeed("test" as const)
 }) {}
 

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1578to1584.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1578to1584.output
@@ -33,10 +33,10 @@ export class UsesStringValueScoped extends Effect.Service<UsesStringValueScoped>
 }) {}
 
 // should warn on "scoped" key because it returns a function that returns an effect that resolves to a primitive
-// @effect-diagnostics-next-line nonObjectEffectServiceType:off
 export class UsesStringValueLazyScoped
   extends Effect.Service<UsesStringValueLazyScoped>()("UsesStringValueLazyScoped", {
     // @ts-expect-error
+    // @effect-diagnostics-next-line nonObjectEffectServiceType:off
     scoped: (_: string) => Effect.succeed("test" as const)
   })
 {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1840to1847.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from1840to1847.output
@@ -41,9 +41,9 @@ export class UsesStringValueLazyScoped
 {}
 
 // should warn on "succeed" key because it is a primitive
-// @effect-diagnostics-next-line nonObjectEffectServiceType:off
 export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucceeds>()("UsesStringValueSucceeds", {
   // @ts-expect-error
+  // @effect-diagnostics-next-line nonObjectEffectServiceType:off
   succeed: "test" as const
 }) {}
 

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from2077to2081.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from2077to2081.output
@@ -47,8 +47,8 @@ export class UsesStringValueSucceeds extends Effect.Service<UsesStringValueSucce
 }) {}
 
 // should warn on "sync" key because it is function that returns a primitive
-// @effect-diagnostics-next-line nonObjectEffectServiceType:off
 export class UsesStringValueSync extends Effect.Service<UsesStringValueSync>()("UsesStringValueSync", {
   // @ts-expect-error
+  // @effect-diagnostics-next-line nonObjectEffectServiceType:off
   sync: () => "test" as const
 }) {}

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from402to408.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from402to408.output
@@ -7,9 +7,9 @@ export class ObjectService extends Effect.Service<ObjectService>()("ObjectServic
 }) {}
 
 // should warn on "effect" key because it returns an effect that resolves to a primitive
-// @effect-diagnostics-next-line nonObjectEffectServiceType:off
 export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()("UsesStringValueUnion", {
   // @ts-expect-error
+  // @effect-diagnostics-next-line nonObjectEffectServiceType:off
   effect: Effect.succeed("test" as ("test" | "other"))
 }) {}
 

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from667to673.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from667to673.output
@@ -13,9 +13,9 @@ export class UsesStringValueUnion extends Effect.Service<UsesStringValueUnion>()
 }) {}
 
 // should warn on "effect" key because it returns an effect that resolves to a primitive
-// @effect-diagnostics-next-line nonObjectEffectServiceType:off
 export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStringValue", {
   // @ts-expect-error
+  // @effect-diagnostics-next-line nonObjectEffectServiceType:off
   effect: Effect.succeed("test" as const)
 }) {}
 

--- a/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from979to985.output
+++ b/test/__snapshots__/diagnostics/nonObjectEffectServiceType.ts.nonObjectEffectServiceType_skipNextLine.from979to985.output
@@ -19,10 +19,10 @@ export class UsesStringValue extends Effect.Service<UsesStringValue>()("UsesStri
 }) {}
 
 // should warn on "effect" key because it returns a function that returns an effect that resolves to a primitive
-// @effect-diagnostics-next-line nonObjectEffectServiceType:off
 export class UsesStringValueLazyEffect
   extends Effect.Service<UsesStringValueLazyEffect>()("UsesStringValueLazyEffect", {
     // @ts-expect-error
+    // @effect-diagnostics-next-line nonObjectEffectServiceType:off
     effect: (_: string) => Effect.succeed("test" as const)
   })
 {}

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.codefixes
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.codefixes
@@ -1,0 +1,6 @@
+unnecessaryPipe_fix from 98 to 122
+unnecessaryPipe_skipNextLine from 98 to 122
+unnecessaryPipe_skipFile from 98 to 122
+unnecessaryPipe_fix from 215 to 239
+unnecessaryPipe_skipNextLine from 215 to 239
+unnecessaryPipe_skipFile from 215 to 239

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.output
@@ -1,0 +1,5 @@
+pipe(Effect.succeed(42))
+5:5 - 5:29 | 2 | This pipe call contains no arguments.    effect(unnecessaryPipe)
+
+pipe(Effect.succeed(44))
+8:5 - 8:29 | 2 | This pipe call contains no arguments.    effect(unnecessaryPipe)

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_fix.from215to239.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_fix.from215to239.output
@@ -1,0 +1,10 @@
+// code fix unnecessaryPipe_fix  output for range 215 - 239
+import { pipe } from "effect"
+import * as Effect from "effect/Effect"
+
+export const test = {
+  a: pipe(Effect.succeed(42)),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  b: pipe(Effect.succeed(43)),
+  c: Effect.succeed(44)
+}

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_fix.from98to122.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_fix.from98to122.output
@@ -1,0 +1,10 @@
+// code fix unnecessaryPipe_fix  output for range 98 - 122
+import { pipe } from "effect"
+import * as Effect from "effect/Effect"
+
+export const test = {
+  a: Effect.succeed(42),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  b: pipe(Effect.succeed(43)),
+  c: pipe(Effect.succeed(44))
+}

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipFile.from215to239.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipFile.from215to239.output
@@ -1,0 +1,11 @@
+// code fix unnecessaryPipe_skipFile  output for range 215 - 239
+/** @effect-diagnostics unnecessaryPipe:skip-file */
+import { pipe } from "effect"
+import * as Effect from "effect/Effect"
+
+export const test = {
+  a: pipe(Effect.succeed(42)),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  b: pipe(Effect.succeed(43)),
+  c: pipe(Effect.succeed(44))
+}

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipFile.from98to122.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipFile.from98to122.output
@@ -1,0 +1,11 @@
+// code fix unnecessaryPipe_skipFile  output for range 98 - 122
+/** @effect-diagnostics unnecessaryPipe:skip-file */
+import { pipe } from "effect"
+import * as Effect from "effect/Effect"
+
+export const test = {
+  a: pipe(Effect.succeed(42)),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  b: pipe(Effect.succeed(43)),
+  c: pipe(Effect.succeed(44))
+}

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipNextLine.from215to239.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipNextLine.from215to239.output
@@ -1,0 +1,11 @@
+// code fix unnecessaryPipe_skipNextLine  output for range 215 - 239
+import { pipe } from "effect"
+import * as Effect from "effect/Effect"
+
+export const test = {
+  a: pipe(Effect.succeed(42)),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  b: pipe(Effect.succeed(43)),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  c: pipe(Effect.succeed(44))
+}

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipNextLine.from98to122.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_disableMidObject.ts.unnecessaryPipe_skipNextLine.from98to122.output
@@ -1,0 +1,11 @@
+// code fix unnecessaryPipe_skipNextLine  output for range 98 - 122
+import { pipe } from "effect"
+import * as Effect from "effect/Effect"
+
+export const test = {
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  a: pipe(Effect.succeed(42)),
+  // @effect-diagnostics-next-line unnecessaryPipe:off
+  b: pipe(Effect.succeed(43)),
+  c: pipe(Effect.succeed(44))
+}


### PR DESCRIPTION
## Summary
- Fixed `@effect-diagnostics-next-line` comment directive to properly suppress diagnostics for property assignments within object literals
- Previously, the directive would not work for properties in the middle of an object literal

## Example

Before this fix, the following code would still show diagnostics on line 7 even with the disable comment:

```typescript
export const test = {
  a: pipe(Effect.succeed(42)),
  // @effect-diagnostics-next-line unnecessaryPipe:off
  b: pipe(Effect.succeed(43)),  // ❌ diagnostic was NOT suppressed
  c: pipe(Effect.succeed(44))
}
```

After this fix, the diagnostic is properly suppressed on line 7.

## Test plan
- ✅ Added new test case `unnecessaryPipe_disableMidObject.ts` demonstrating the fix
- ✅ All existing tests pass
- ✅ Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)