### PR TITLE
Allow Schema constructor overrides that redirect parameters to super

### DIFF
--- a/.changeset/whole-houses-peel.md
+++ b/.changeset/whole-houses-peel.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Allow to override Schema constructor as long parameters are just redirected

--- a/examples/diagnostics/overriddenSchemaConstructor_valid.ts
+++ b/examples/diagnostics/overriddenSchemaConstructor_valid.ts
@@ -1,0 +1,9 @@
+import * as Schema from "effect/Schema"
+
+export class Valid extends Schema.Class<Valid>("Valid")({
+  a: Schema.Number
+}) {
+  protected constructor(a: Valid, options: Schema.MakeOptions) {
+    super(a, options)
+  }
+}

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_valid.ts.codefixes
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_valid.ts.codefixes
@@ -1,0 +1,1 @@
+no codefixes

--- a/test/__snapshots__/diagnostics/overriddenSchemaConstructor_valid.ts.output
+++ b/test/__snapshots__/diagnostics/overriddenSchemaConstructor_valid.ts.output
@@ -1,0 +1,1 @@
+// no diagnostics


### PR DESCRIPTION
## Summary
- Improves the `overriddenSchemaConstructor` diagnostic to allow constructor overrides that simply redirect parameters to the super constructor
- This enables customizing constructor visibility (e.g., `protected`) while maintaining default Schema behavior
- The diagnostic still correctly warns when constructors modify parameters or use custom logic

## Example

The diagnostic now allows this pattern:

```ts
class Valid extends Schema.Class<Valid>("Valid")({ a: Schema.Number }) {
  protected constructor(a: Valid, options: Schema.MakeOptions) {
    super(a, options)  // Just redirecting parameters - no custom logic
  }
}
```

But still warns about this:

```ts
class Invalid extends Schema.Class<Invalid>("Invalid")({ a: Schema.Number }) {
  constructor() {
    super({ a: 42 })  // Custom logic - diagnostic still warns
  }
}
```

## Test plan
- ✅ All existing tests pass
- ✅ New test case added: `overriddenSchemaConstructor_valid.ts`
- ✅ Verified diagnostic correctly allows parameter redirection
- ✅ Verified diagnostic still warns on custom constructor logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)