### PR TITLE
Optimize getTypeAtLocation usage on non-expression nodes

### DIFF
--- a/.changeset/optimize-type-at-location-usage.md
+++ b/.changeset/optimize-type-at-location-usage.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Optimize `getTypeAtLocation` usage to reduce unnecessary calls on non-expression nodes. This improves performance by ensuring type checking is only performed on expression nodes and adds additional null safety checks for symbol resolution.

--- a/src/core/LayerGraph.ts
+++ b/src/core/LayerGraph.ts
@@ -118,7 +118,7 @@ export const extractLayerGraph = Nano.fn("extractLayerGraph")(function*(node: ts
           }
         }
       }
-    } else {
+    } else if (ts.isExpression(node)) {
       layerType = typeChecker.getTypeAtLocation(node)
     }
     if (layerType) {
@@ -265,7 +265,7 @@ export const extractLayerGraph = Nano.fn("extractLayerGraph")(function*(node: ts
       let symbol = typeChecker.getSymbolAtLocation(node)
       if (symbol) {
         if (symbol.flags & ts.SymbolFlags.Alias) {
-          symbol = typeChecker.getAliasedSymbol(symbol)
+          symbol = typeChecker.getAliasedSymbol(symbol) || symbol
         }
         if (symbol.declarations && symbol.declarations.length === 1) {
           const declarationNode = getAdjustedNode(symbol.declarations[0])

--- a/src/core/TypeParser.ts
+++ b/src/core/TypeParser.ts
@@ -247,6 +247,7 @@ export function make(
     Nano.cachedBy(
       Nano.fn("TypeParser.getSourceFilesDeclaringSymbolModule")(function*(symbol: ts.Symbol) {
         const result: Array<ts.SourceFile> = []
+        if (!symbol) return result
         if (!symbol.declarations) return yield* typeParserIssue("Symbol has no declarations", undefined, undefined)
         for (const sourceFile of symbol.declarations) {
           if (!ts.isSourceFile(sourceFile)) continue
@@ -301,6 +302,7 @@ export function make(
     Nano.cachedBy(
       Nano.fn("TypeParser.getSourceFilesDeclaringSymbolUnderPackageExportedMember")(function*(symbol: ts.Symbol) {
         const result: Array<{ memberSymbol: ts.Symbol; moduleSymbol: ts.Symbol; sourceFile: ts.SourceFile }> = []
+        if (!symbol) return result
         if (!symbol.declarations) return yield* typeParserIssue("Symbol has no declarations", undefined, undefined)
         for (const declaration of symbol.declarations) {
           const sourceFile = tsUtils.getSourceFileOfNode(declaration)
@@ -636,15 +638,15 @@ export function make(
     Nano.fn("TypeParser.importedContextModule")(function*(
       node: ts.Node
     ) {
+      // should be an expression
+      if (!ts.isIdentifier(node)) {
+        return yield* typeParserIssue("Node is not an identifier", undefined, node)
+      }
       const type = typeChecker.getTypeAtLocation(node)
       // if the type has a property "Tag" that is a function
       const propertySymbol = typeChecker.getPropertyOfType(type, "Tag")
       if (!propertySymbol) {
         return yield* typeParserIssue("Type has no 'Tag' property", type, node)
-      }
-      // should be an expression
-      if (!ts.isIdentifier(node)) {
-        return yield* typeParserIssue("Node is not an identifier", type, node)
       }
       const sourceFile = tsUtils.getSourceFileOfNode(node)
       if (!sourceFile) {
@@ -678,15 +680,15 @@ export function make(
     Nano.fn("TypeParser.importedDataModule")(function*(
       node: ts.Node
     ) {
+      // should be an expression
+      if (!ts.isIdentifier(node)) {
+        return yield* typeParserIssue("Node is not an expression", undefined, node)
+      }
       const type = typeChecker.getTypeAtLocation(node)
       // if the type has a property "TaggedError" that is a function
       const propertySymbol = typeChecker.getPropertyOfType(type, "TaggedError")
       if (!propertySymbol) {
         return yield* typeParserIssue("Type has no 'TaggedError' property", type, node)
-      }
-      // should be an expression
-      if (!ts.isIdentifier(node)) {
-        return yield* typeParserIssue("Node is not an expression", type, node)
       }
       const sourceFile = tsUtils.getSourceFileOfNode(node)
       if (!sourceFile) {

--- a/src/diagnostics/leakingRequirements.ts
+++ b/src/diagnostics/leakingRequirements.ts
@@ -88,9 +88,10 @@ export const leakingRequirements = LSP.createDiagnostic({
               (type) => {
                 let symbol = type.symbol
                 if (symbol && symbol.flags & ts.SymbolFlags.Alias) {
-                  symbol = typeChecker.getAliasedSymbol(symbol)!
+                  symbol = typeChecker.getAliasedSymbol(symbol) || symbol
                 }
-                return !(symbol.declarations || []).some((declaration) => {
+                if (!symbol) return false
+                return !(symbol?.declarations || []).some((declaration) => {
                   const declarationSource = tsUtils.getSourceFileOfNode(declaration)
                   if (!declarationSource) return false
                   return (declarationSource.text.substring(declaration.pos, declaration.end).toLowerCase().indexOf(

--- a/src/diagnostics/strictBooleanExpressions.ts
+++ b/src/diagnostics/strictBooleanExpressions.ts
@@ -53,6 +53,7 @@ export const strictBooleanExpressions = LSP.createDiagnostic({
         if (!nodeToCheck) continue
         if (!conditionChecks.has(nodeToCheck.parent)) continue
 
+        if (!ts.isExpression(nodeToCheck)) continue
         const nodeType = typeChecker.getTypeAtLocation(nodeToCheck)
         const constrainedType = typeChecker.getBaseConstraintOfType(nodeType)
         let typesToCheck = [constrainedType || nodeType]


### PR DESCRIPTION
## Summary
This patch optimizes the language service by reducing unnecessary `getTypeAtLocation` calls and improving null safety in symbol resolution.

## Changes
- **LayerGraph.ts**: Only call `getTypeAtLocation` when node is an expression (added `ts.isExpression` check)
- **TypeParser.ts**: Validate node type before calling `getTypeAtLocation` in `importedContextModule` and `importedDataModule` functions
- **leakingRequirements.ts**: Add null safety check for aliased symbols
- **strictBooleanExpressions.ts**: Only perform type checking on expression nodes

## Performance Impact
By ensuring `getTypeAtLocation` is only called on expression nodes, this reduces unnecessary type checker calls that could potentially be expensive or produce incorrect results.

## Test Plan
- [x] All existing tests pass
- [x] `pnpm lint-fix` completes without issues
- [x] `pnpm check` passes TypeScript validation
- [x] `pnpm test` - all 316 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)