### PR TITLE
Fix duplicate edges in layer outline graph

### DIFF
--- a/.changeset/fix-layer-graph-double-edges.md
+++ b/.changeset/fix-layer-graph-double-edges.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fixed duplicate edges in layer outline graph that could occur when multiple type assignments matched between layer nodes

--- a/src/core/LayerGraph.ts
+++ b/src/core/LayerGraph.ts
@@ -472,7 +472,9 @@ export const extractOutlineGraph = Nano.fn("extractOutlineGraph")(function*(laye
       for (const [providedType, providerNodeIndexes] of providers.entries()) {
         if (requiredType === providedType || typeChecker.isTypeAssignableTo(requiredType, providedType)) {
           for (const providerNodeIndex of providerNodeIndexes) {
-            Graph.addEdge(mutableGraph, nodeIndex, providerNodeIndex, {})
+            if (!Graph.hasEdge(mutableGraph, nodeIndex, providerNodeIndex)) {
+              Graph.addEdge(mutableGraph, nodeIndex, providerNodeIndex, {})
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixed duplicate edges in the layer outline graph that could occur when multiple type assignments matched between layer nodes.

## Changes

- Added a check in `src/core/LayerGraph.ts:475` to verify if an edge already exists before adding it to the graph
- This prevents the same dependency relationship from being added multiple times to the graph visualization

## Example

Before this fix, when multiple type assignments matched between layer nodes, the graph could contain duplicate edges for the same dependency relationship. Now, each edge is added only once using `Graph.hasEdge()` to check for existing edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)