### PR TITLE
Add codefix to runEffectInsideEffect diagnostic

### DIFF
--- a/.changeset/add-runtime-codefix.md
+++ b/.changeset/add-runtime-codefix.md
@@ -1,0 +1,24 @@
+---
+"@effect/language-service": patch
+---
+
+Add codefix to `runEffectInsideEffect` diagnostic that automatically transforms `Effect.run*` calls to use `Runtime.run*` when inside nested Effect contexts. The codefix will extract or reuse an existing Effect runtime and replace the direct Effect run call with the appropriate Runtime method.
+
+Example:
+```typescript
+// Before
+Effect.gen(function*() {
+  websocket.onmessage = (event) => {
+    Effect.runPromise(check)
+  }
+})
+
+// After applying codefix
+Effect.gen(function*() {
+  const effectRuntime = yield* Effect.runtime<never>()
+
+  websocket.onmessage = (event) => {
+    Runtime.runPromise(effectRuntime, check)
+  }
+})
+```

--- a/test/__snapshots__/diagnostics/runEffectInsideEffect.ts.codefixes
+++ b/test/__snapshots__/diagnostics/runEffectInsideEffect.ts.codefixes
@@ -1,4 +1,5 @@
 runEffectInsideEffect_skipNextLine from 404 to 418
 runEffectInsideEffect_skipFile from 404 to 418
+runEffectInsideEffect_fix from 702 to 719
 runEffectInsideEffect_skipNextLine from 702 to 719
 runEffectInsideEffect_skipFile from 702 to 719

--- a/test/__snapshots__/diagnostics/runEffectInsideEffect.ts.output
+++ b/test/__snapshots__/diagnostics/runEffectInsideEffect.ts.output
@@ -3,4 +3,4 @@ Effect.runSync
 
 Effect.runPromise
 22:4 - 22:21 | 2 | Using Effect.runPromise inside an Effect is not recommended. The same runtime should generally be used instead to run child effects.
-Consider extracting the Runtime by using for example Effect.runtime and then use Runtime.run* with the extracted runtime instead.    effect(runEffectInsideEffect)
+Consider extracting the Runtime by using for example Effect.runtime and then use Runtime.runPromise with the extracted runtime instead.    effect(runEffectInsideEffect)

--- a/test/__snapshots__/diagnostics/runEffectInsideEffect.ts.runEffectInsideEffect_fix.from702to719.output
+++ b/test/__snapshots__/diagnostics/runEffectInsideEffect.ts.runEffectInsideEffect_fix.from702to719.output
@@ -1,0 +1,28 @@
+// code fix runEffectInsideEffect_fix  output for range 702 - 719
+import { Data, Effect } from "effect"
+
+class DebuggerError extends Data.TaggedError("DebuggerError")<{
+  cause: unknown
+}> {}
+
+export const program = Effect.gen(function*() {
+const effectRuntime = yield* Effect.runtime<never>()
+
+  const response = yield* Effect.tryPromise({
+    try: () => fetch("http://localhost:9229"),
+    catch: (e) => new DebuggerError({ cause: e })
+  })
+  const data = yield* Effect.promise(() => response.json())
+
+  const websocket = Effect.runSync(Effect.sync(() => new WebSocket(data.url)))
+  //                        ^- do not runSync in here
+
+  websocket.onmessage = (event) => {
+    const check = Effect.tryPromise({
+      try: () => fetch(event.data as string),
+      catch: (e) => new DebuggerError({ cause: e })
+    })
+    Runtime.runPromise(effectRuntime, check)
+    //        ^- no runPromise, use a runtime instead
+  }
+})


### PR DESCRIPTION
## Summary

This PR adds an automatic codefix to the `runEffectInsideEffect` diagnostic that transforms `Effect.run*` calls inside nested Effect contexts to use `Runtime.run*` instead.

### Changes
- Enhanced the `runEffectInsideEffect` diagnostic to provide an automatic codefix when `Effect.runSync`, `Effect.runPromise`, `Effect.runFork`, or `Effect.runCallback` are used inside nested Effect contexts
- The codefix intelligently extracts or reuses an existing Effect runtime
- Automatically replaces the direct Effect run call with the appropriate Runtime method

### Example

**Before:**
```typescript
Effect.gen(function*() {
  websocket.onmessage = (event) => {
    Effect.runPromise(check)
  }
})
```

**After applying codefix:**
```typescript
Effect.gen(function*() {
  const effectRuntime = yield* Effect.runtime<never>()

  websocket.onmessage = (event) => {
    Runtime.runPromise(effectRuntime, check)
  }
})
```

## Test plan
- ✅ All existing tests pass
- ✅ New snapshot test added for the codefix functionality
- ✅ TypeScript checks pass
- ✅ Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)