### PR TITLE
Fix anyUnknownInErrorContext diagnostic for JSX elements

### DIFF
--- a/.changeset/fix-jsx-any-unknown-diagnostic.md
+++ b/.changeset/fix-jsx-any-unknown-diagnostic.md
@@ -1,0 +1,14 @@
+---
+"@effect/language-service": patch
+---
+
+Fix `anyUnknownInErrorContext` diagnostic to exclude JSX elements from reporting false positives. The diagnostic will no longer incorrectly flag JSX tag names, self-closing elements, opening/closing elements, and attribute names.
+
+Example:
+```tsx
+// Before: Would incorrectly report diagnostic on <MyComponent />
+const element = <MyComponent />
+
+// After: No diagnostic, JSX elements are properly excluded
+const element = <MyComponent />
+```

--- a/src/diagnostics/anyUnknownInErrorContext.ts
+++ b/src/diagnostics/anyUnknownInErrorContext.ts
@@ -54,6 +54,10 @@ export const anyUnknownInErrorContext = LSP.createDiagnostic({
 
       // Get type at location
       if (!ts.isExpression(node)) continue
+      if (node.parent && ts.isJsxSelfClosingElement(node.parent) && node.parent.tagName === node) continue
+      if (node.parent && ts.isJsxOpeningElement(node.parent) && node.parent.tagName === node) continue
+      if (node.parent && ts.isJsxClosingElement(node.parent) && node.parent.tagName === node) continue
+      if (node.parent && ts.isJsxAttribute(node.parent) && node.parent.name === node) continue
       let type = typeChecker.getTypeAtLocation(node)
       if (ts.isCallExpression(node)) {
         const resolvedSignature = typeChecker.getResolvedSignature(node)


### PR DESCRIPTION
## Summary
- Fixed the `anyUnknownInErrorContext` diagnostic to exclude JSX elements from type checking
- Previously, JSX tag names, self-closing elements, opening/closing elements, and attribute names would trigger false positive diagnostics
- The fix adds checks to skip JSX-specific AST nodes before performing type analysis

## Changes
- Added guards in `src/diagnostics/anyUnknownInErrorContext.ts` to skip:
  - JSX self-closing element tag names
  - JSX opening element tag names
  - JSX closing element tag names
  - JSX attribute names

## Example
```tsx
// Before: Would incorrectly report diagnostic on <MyComponent />
const element = <MyComponent />

// After: No diagnostic, JSX elements are properly excluded
const element = <MyComponent />
```

## Test Plan
- All existing tests pass
- The diagnostic now properly ignores JSX syntax elements while still catching legitimate any/unknown types in Effect error/requirement channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)