### PR TITLE
Fix type annotation context resolution in toggle refactors

### DIFF
--- a/.changeset/fix-toggle-type-annotation-context.md
+++ b/.changeset/fix-toggle-type-annotation-context.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix type annotation context resolution in toggle refactors. When toggling type annotations or return type annotations, the refactors now correctly use the enclosing declaration node as context instead of the local node, which improves type resolution and prevents issues with type parameter scope.

--- a/src/codegens/annotate.ts
+++ b/src/codegens/annotate.ts
@@ -38,18 +38,13 @@ export const annotate = LSP.createCodegen({
         for (const variableDeclaration of variableDeclarations) {
           if (!variableDeclaration.initializer) continue
           const initializerType = typeChecker.getTypeAtLocation(variableDeclaration.initializer)
+          const enclosingNode = ts.findAncestor(variableDeclaration, (_) => tsUtils.isDeclarationKind(_.kind)) ||
+            sourceFile
           const initializerTypeNode = Option.fromNullable(typeCheckerUtils.typeToSimplifiedTypeNode(
             initializerType,
-            node,
+            enclosingNode,
             ts.NodeBuilderFlags.NoTruncation
           )).pipe(
-            Option.orElse(() =>
-              Option.fromNullable(typeCheckerUtils.typeToSimplifiedTypeNode(
-                initializerType,
-                undefined,
-                ts.NodeBuilderFlags.NoTruncation
-              ))
-            ),
             Option.getOrUndefined
           )
           if (!initializerTypeNode) continue

--- a/src/core/TypeScriptUtils.ts
+++ b/src/core/TypeScriptUtils.ts
@@ -99,6 +99,9 @@ export interface TypeScriptUtils {
   skipOuterExpressions<T extends ts.Expression>(node: WrappedExpression<T>): T
   skipOuterExpressions(node: ts.Expression, kinds?: ts.OuterExpressionKinds): ts.Expression
   skipOuterExpressions(node: ts.Node, kinds?: ts.OuterExpressionKinds): ts.Node
+  isDeclarationKind(
+    kind: ts.SyntaxKind
+  ): boolean
 }
 export const TypeScriptUtils = Nano.Tag<TypeScriptUtils>("TypeScriptUtils")
 
@@ -816,6 +819,47 @@ export function makeTypeScriptUtils(ts: TypeScriptApi.TypeScriptApi): TypeScript
     return node
   }
 
+  function isDeclarationKind(
+    kind: ts.SyntaxKind
+  ) {
+    return kind === ts.SyntaxKind.ArrowFunction
+      || kind === ts.SyntaxKind.BindingElement
+      || kind === ts.SyntaxKind.ClassDeclaration
+      || kind === ts.SyntaxKind.ClassExpression
+      || kind === ts.SyntaxKind.ClassStaticBlockDeclaration
+      || kind === ts.SyntaxKind.Constructor
+      || kind === ts.SyntaxKind.EnumDeclaration
+      || kind === ts.SyntaxKind.EnumMember
+      || kind === ts.SyntaxKind.ExportSpecifier
+      || kind === ts.SyntaxKind.FunctionDeclaration
+      || kind === ts.SyntaxKind.FunctionExpression
+      || kind === ts.SyntaxKind.GetAccessor
+      || kind === ts.SyntaxKind.ImportClause
+      || kind === ts.SyntaxKind.ImportEqualsDeclaration
+      || kind === ts.SyntaxKind.ImportSpecifier
+      || kind === ts.SyntaxKind.InterfaceDeclaration
+      || kind === ts.SyntaxKind.JsxAttribute
+      || kind === ts.SyntaxKind.MethodDeclaration
+      || kind === ts.SyntaxKind.MethodSignature
+      || kind === ts.SyntaxKind.ModuleDeclaration
+      || kind === ts.SyntaxKind.NamespaceExportDeclaration
+      || kind === ts.SyntaxKind.NamespaceImport
+      || kind === ts.SyntaxKind.NamespaceExport
+      || kind === ts.SyntaxKind.Parameter
+      || kind === ts.SyntaxKind.PropertyAssignment
+      || kind === ts.SyntaxKind.PropertyDeclaration
+      || kind === ts.SyntaxKind.PropertySignature
+      || kind === ts.SyntaxKind.SetAccessor
+      || kind === ts.SyntaxKind.ShorthandPropertyAssignment
+      || kind === ts.SyntaxKind.TypeAliasDeclaration
+      || kind === ts.SyntaxKind.TypeParameter
+      || kind === ts.SyntaxKind.VariableDeclaration
+      || kind === ts.SyntaxKind.JSDocTypedefTag
+      || kind === ts.SyntaxKind.JSDocCallbackTag
+      || kind === ts.SyntaxKind.JSDocPropertyTag
+      || kind === ts.SyntaxKind.NamedTupleMember
+  }
+
   return {
     findNodeAtPositionIncludingTrivia,
     parsePackageContentNameAndVersionFromScope,
@@ -838,6 +882,7 @@ export function makeTypeScriptUtils(ts: TypeScriptApi.TypeScriptApi): TypeScript
     parseAccessedExpressionForCompletion,
     getSourceFileOfNode,
     isOuterExpression,
-    skipOuterExpressions
+    skipOuterExpressions,
+    isDeclarationKind
   }
 }

--- a/src/refactors/toggleReturnTypeAnnotation.ts
+++ b/src/refactors/toggleReturnTypeAnnotation.ts
@@ -89,9 +89,10 @@ export const toggleReturnTypeAnnotation = LSP.createRefactor({
     const returnType = typeCheckerUtils.getInferredReturnType(node)
     if (!returnType) return yield* Nano.fail(new LSP.RefactorNotApplicableError())
 
+    const enclosingNode = ts.findAncestor(node, (_) => tsUtils.isDeclarationKind(_.kind)) || sourceFile
     const returnTypeNode = typeCheckerUtils.typeToSimplifiedTypeNode(
       returnType,
-      node,
+      enclosingNode,
       ts.NodeBuilderFlags.NoTruncation
     )
 

--- a/src/refactors/toggleTypeAnnotation.ts
+++ b/src/refactors/toggleTypeAnnotation.ts
@@ -42,18 +42,12 @@ export const toggleTypeAnnotation = LSP.createRefactor({
 
           const initializer = node.initializer!
           const initializerType = typeChecker.getTypeAtLocation(initializer)
+          const enclosingNode = ts.findAncestor(node, (_) => tsUtils.isDeclarationKind(_.kind)) || sourceFile
           const initializerTypeNode = Option.fromNullable(typeCheckerUtils.typeToSimplifiedTypeNode(
             initializerType,
-            node,
+            enclosingNode,
             ts.NodeBuilderFlags.NoTruncation
           )).pipe(
-            Option.orElse(() =>
-              Option.fromNullable(typeCheckerUtils.typeToSimplifiedTypeNode(
-                initializerType,
-                undefined,
-                ts.NodeBuilderFlags.NoTruncation
-              ))
-            ),
             Option.getOrUndefined
           )
           if (initializerTypeNode) {


### PR DESCRIPTION
## Summary

Fixes the type annotation context resolution in toggle type annotation and toggle return type annotation refactors.

### Changes

- Improved context node selection when converting types to type nodes
- Now uses the enclosing declaration node as context instead of the local node
- Added `isDeclarationKind` helper function to `TypeScriptUtils` for proper declaration node identification
- Updated `toggleTypeAnnotation`, `toggleReturnTypeAnnotation`, and `annotate` codegen to use the improved context resolution

### Technical Details

Previously, these refactors used the immediate node as context when calling `typeToSimplifiedTypeNode`, which could cause issues with type parameter scope resolution. Now, the refactors find the nearest enclosing declaration node (function, class, method, etc.) or fall back to the source file, which provides the correct lexical scope for type resolution.

### Test Plan

- ✅ All existing tests pass
- ✅ Type checking passes
- ✅ Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)