### PR TITLE
Fix symbol resolution for aliased module exports

### DIFF
--- a/.changeset/handle-aliased-exported-symbols.md
+++ b/.changeset/handle-aliased-exported-symbols.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix symbol resolution for aliased module exports. The TypeParser now correctly handles cases where symbols are exported from a module with an alias, improving the accuracy of type analysis for Effect modules.

--- a/src/core/TypeParser.ts
+++ b/src/core/TypeParser.ts
@@ -313,7 +313,16 @@ export function make(
           const moduleSymbol = typeChecker.getSymbolAtLocation(sourceFile)
           if (!moduleSymbol) continue
           const memberSymbol = typeChecker.tryGetMemberInModuleExports(memberName, moduleSymbol)
-          if (memberSymbol && memberSymbol === symbol) result.push({ memberSymbol, moduleSymbol, sourceFile })
+          if (memberSymbol) {
+            if (memberSymbol === symbol) {
+              result.push({ memberSymbol, moduleSymbol, sourceFile })
+            } else if (memberSymbol.flags & ts.SymbolFlags.Alias) {
+              const aliased = typeChecker.getAliasedSymbol(memberSymbol)
+              if (aliased === symbol) {
+                result.push({ memberSymbol, moduleSymbol, sourceFile })
+              }
+            }
+          }
         }
         if (result.length > 0) {
           return result


### PR DESCRIPTION
## Summary
- Improves the `getSourceFilesDeclaringSymbolExportedUnderPackageModule` function in TypeParser to correctly handle aliased module exports
- Previously only checked for direct symbol matches, now also resolves aliases before comparison

## Details
The change adds additional logic to check if a member symbol is an alias (`ts.SymbolFlags.Alias`) and resolves it using `typeChecker.getAliasedSymbol()` before comparing with the target symbol. This ensures that:

```typescript
// Now correctly recognized
export { Effect as Eff } from 'effect'
```

## Test plan
- ✅ All existing tests pass (340 tests)
- ✅ TypeScript compilation succeeds
- ✅ Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)