### PR TITLE
Fix toggle type annotation refactors for unnamed types

### DIFF
--- a/.changeset/fix-toggle-annotations-unnamed-types.md
+++ b/.changeset/fix-toggle-annotations-unnamed-types.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Fix toggle type annotation and toggle return type annotation refactors to handle unnamed/unresolved types
+
+The refactors now use `ts.NodeBuilderFlags.IgnoreErrors` flag when generating type annotations, allowing them to work correctly with types that have errors or are unnamed (e.g., `Schema.Struct({ ... }).make`). This prevents the refactors from failing when the type contains unresolved references or complex type expressions.

--- a/examples/refactors/toggleTypeAnnotation_unnamed.ts
+++ b/examples/refactors/toggleTypeAnnotation_unnamed.ts
@@ -1,0 +1,6 @@
+// 4:15
+import * as Schema from "effect/Schema"
+
+export const debug = Schema.Struct({
+  id: Schema.Option(Schema.Number)
+}).make

--- a/src/codegens/annotate.ts
+++ b/src/codegens/annotate.ts
@@ -43,7 +43,7 @@ export const annotate = LSP.createCodegen({
           const initializerTypeNode = Option.fromNullable(typeCheckerUtils.typeToSimplifiedTypeNode(
             initializerType,
             enclosingNode,
-            ts.NodeBuilderFlags.NoTruncation
+            ts.NodeBuilderFlags.NoTruncation | ts.NodeBuilderFlags.IgnoreErrors
           )).pipe(
             Option.getOrUndefined
           )

--- a/src/refactors/toggleReturnTypeAnnotation.ts
+++ b/src/refactors/toggleReturnTypeAnnotation.ts
@@ -93,7 +93,7 @@ export const toggleReturnTypeAnnotation = LSP.createRefactor({
     const returnTypeNode = typeCheckerUtils.typeToSimplifiedTypeNode(
       returnType,
       enclosingNode,
-      ts.NodeBuilderFlags.NoTruncation
+      ts.NodeBuilderFlags.NoTruncation | ts.NodeBuilderFlags.IgnoreErrors
     )
 
     if (!returnTypeNode) return yield* Nano.fail(new LSP.RefactorNotApplicableError())

--- a/src/refactors/toggleTypeAnnotation.ts
+++ b/src/refactors/toggleTypeAnnotation.ts
@@ -46,7 +46,7 @@ export const toggleTypeAnnotation = LSP.createRefactor({
           const initializerTypeNode = Option.fromNullable(typeCheckerUtils.typeToSimplifiedTypeNode(
             initializerType,
             enclosingNode,
-            ts.NodeBuilderFlags.NoTruncation
+            ts.NodeBuilderFlags.NoTruncation | ts.NodeBuilderFlags.IgnoreErrors
           )).pipe(
             Option.getOrUndefined
           )

--- a/test/__snapshots__/refactors/toggleTypeAnnotation_unnamed.ts.ln4col15.output
+++ b/test/__snapshots__/refactors/toggleTypeAnnotation_unnamed.ts.ln4col15.output
@@ -1,0 +1,6 @@
+// Result of running refactor toggleTypeAnnotation at position 4:15
+import * as Schema from "effect/Schema"
+
+export const debug: (props: { readonly id: import("node_modules/effect/dist/dts/Option").Option<number> }, options?: Schema.MakeOptions) => { readonly id: import("node_modules/effect/dist/dts/Option").Option<number> } = Schema.Struct({
+  id: Schema.Option(Schema.Number)
+}).make


### PR DESCRIPTION
## Summary
- Fixed toggle type annotation refactor to handle unnamed/unresolved types
- Fixed toggle return type annotation refactor to handle unnamed/unresolved types
- Added `ts.NodeBuilderFlags.IgnoreErrors` flag to allow type node generation even when types contain errors

## Problem
Previously, the toggle type annotation refactors would fail when trying to add type annotations to expressions where TypeScript couldn't fully resolve all types in the signature. A common example was:

```typescript
export const debug = Schema.Struct({
  id: Schema.Option(Schema.Number)
}).make
```

When attempting to toggle the type annotation, the refactor would fail because the `.make` accessor has complex unresolved types in its signature.

## Solution
By adding the `ts.NodeBuilderFlags.IgnoreErrors` flag when calling `typeToSimplifiedTypeNode`, the TypeScript compiler now generates type nodes even when they contain errors or unresolved references. This allows the refactor to work correctly and produce valid type annotations:

```typescript
export const debug: (props: { readonly id: import("node_modules/effect/dist/dts/Option").Option<number> }, options?: Schema.MakeOptions) => { readonly id: import("node_modules/effect/dist/dts/Option").Option<number> } = Schema.Struct({
  id: Schema.Option(Schema.Number)
}).make
```

## Test Plan
- ✅ Added new test case `toggleTypeAnnotation_unnamed.ts` that verifies the refactor works with unnamed types
- ✅ All existing tests pass
- ✅ TypeScript compilation succeeds
- ✅ Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)