### PR TITLE
Fix auto-completion for directly imported Effect APIs

### DIFF
--- a/.changeset/fix-direct-import-completions.md
+++ b/.changeset/fix-direct-import-completions.md
@@ -1,0 +1,24 @@
+---
+"@effect/language-service": patch
+---
+
+Fix auto-completion for directly imported Effect APIs. Completions now work when using direct imports like `import { Service } from "effect/Effect"` instead of only working with fully qualified names like `Effect.Service`.
+
+This fix applies to:
+- `Effect.Service` and `Effect.Tag` from `effect/Effect`
+- `Schema.Class`, `Schema.TaggedError`, `Schema.TaggedClass`, and `Schema.TaggedRequest` from `effect/Schema`
+- `Data.TaggedError` and `Data.TaggedClass` from `effect/Data`
+- `Context.Tag` from `effect/Context`
+
+Example:
+```typescript
+// Now works with direct imports
+import { Service } from "effect/Effect"
+export class MyService extends Service // ✓ Completion available
+
+// Still works with fully qualified names
+import * as Effect from "effect/Effect"
+export class MyService extends Effect.Service // ✓ Completion available
+```
+
+Fixes #394

--- a/examples/completions/contextSelfInClasses_directImportTag.ts
+++ b/examples/completions/contextSelfInClasses_directImportTag.ts
@@ -1,0 +1,4 @@
+// 4:35
+import { Tag } from "effect/Context"
+
+export class MyService extends Tag

--- a/examples/completions/effectDataClasses_directImportTaggedClass.ts
+++ b/examples/completions/effectDataClasses_directImportTaggedClass.ts
@@ -1,0 +1,4 @@
+// 4:40
+import { TaggedClass } from "effect/Data"
+
+export class MyClass extends TaggedClass

--- a/examples/completions/effectDataClasses_directImportTaggedError.ts
+++ b/examples/completions/effectDataClasses_directImportTaggedError.ts
@@ -1,0 +1,4 @@
+// 4:40
+import { TaggedError } from "effect/Data"
+
+export class MyError extends TaggedError

--- a/examples/completions/effectSchemaSelfInClasses_directImportClass.ts
+++ b/examples/completions/effectSchemaSelfInClasses_directImportClass.ts
@@ -1,0 +1,4 @@
+// 4:35
+import { Class } from "effect/Schema"
+
+export class MyClass extends Class

--- a/examples/completions/effectSchemaSelfInClasses_directImportTaggedClass.ts
+++ b/examples/completions/effectSchemaSelfInClasses_directImportTaggedClass.ts
@@ -1,0 +1,4 @@
+// 4:40
+import { TaggedClass } from "effect/Schema"
+
+export class MyClass extends TaggedClass

--- a/examples/completions/effectSchemaSelfInClasses_directImportTaggedError.ts
+++ b/examples/completions/effectSchemaSelfInClasses_directImportTaggedError.ts
@@ -1,0 +1,4 @@
+// 4:40
+import { TaggedError } from "effect/Schema"
+
+export class MyError extends TaggedError

--- a/examples/completions/effectSchemaSelfInClasses_directImportTaggedRequest.ts
+++ b/examples/completions/effectSchemaSelfInClasses_directImportTaggedRequest.ts
@@ -1,0 +1,4 @@
+// 4:44
+import { TaggedRequest } from "effect/Schema"
+
+export class MyRequest extends TaggedRequest

--- a/examples/completions/effectSelfInClasses_directImportService.ts
+++ b/examples/completions/effectSelfInClasses_directImportService.ts
@@ -1,0 +1,4 @@
+// 4:39
+import { Service } from "effect/Effect"
+
+export class MyService extends Service

--- a/examples/completions/effectSelfInClasses_directImportTag.ts
+++ b/examples/completions/effectSelfInClasses_directImportTag.ts
@@ -1,0 +1,4 @@
+// 4:35
+import { Tag } from "effect/Effect"
+
+export class MyService extends Tag

--- a/src/completions/contextSelfInClasses.ts
+++ b/src/completions/contextSelfInClasses.ts
@@ -1,6 +1,9 @@
+import { pipe } from "effect"
+import * as Option from "effect/Option"
 import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
+import * as TypeParser from "../core/TypeParser.js"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
 
@@ -9,6 +12,7 @@ export const contextSelfInClasses = LSP.createCompletion({
   apply: Nano.fn("contextSelfInClasses")(function*(sourceFile, position) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
     const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
 
     const maybeInfos = tsUtils.parseDataForExtendsClassCompletion(sourceFile, position)
     if (!maybeInfos) return []
@@ -21,19 +25,36 @@ export const contextSelfInClasses = LSP.createCompletion({
       "Context"
     ) || "Context"
 
-    // ensure accessed is an identifier
-    if (contextIdentifier !== ts.idText(accessedObject)) return []
+    // Check if this is a fully qualified name (e.g., Context.Tag)
+    const isFullyQualified = contextIdentifier === ts.idText(accessedObject)
+
     const name = ts.idText(className)
 
     // create the expected identifier
     const tagKey = (yield* KeyBuilder.createString(sourceFile, name, "service")) || name
 
-    return [{
-      name: `Tag("${name}")`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${contextIdentifier}.Tag("${tagKey}")<${name}, ${"${0}"}>(){}`,
-      replacementSpan,
-      isSnippet: true
-    }] satisfies Array<LSP.CompletionEntryDefinition>
+    // Build completions based on what the user is extending
+    const completions: Array<LSP.CompletionEntryDefinition> = []
+
+    // Check for Context.Tag or direct import Tag
+    const hasTagCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectContextModuleApi("Tag")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTagCompletion) {
+      completions.push({
+        name: `Tag("${name}")`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${contextIdentifier}.Tag("${tagKey}")<${name}, ${"${0}"}>(){}`
+          : `Tag("${tagKey}")<${name}, ${"${0}"}>(){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    return completions
   })
 })

--- a/src/completions/effectDataClasses.ts
+++ b/src/completions/effectDataClasses.ts
@@ -1,6 +1,9 @@
+import { pipe } from "effect"
+import * as Option from "effect/Option"
 import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
+import * as TypeParser from "../core/TypeParser.js"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
 
@@ -9,6 +12,7 @@ export const effectDataClasses = LSP.createCompletion({
   apply: Nano.fn("effectDataClasses")(function*(sourceFile, position) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
     const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
 
     const maybeInfos = tsUtils.parseDataForExtendsClassCompletion(sourceFile, position)
     if (!maybeInfos) return []
@@ -21,25 +25,55 @@ export const effectDataClasses = LSP.createCompletion({
       "Data"
     ) || "Data"
 
-    // ensure accessed is an identifier
-    if (effectDataIdentifier !== ts.idText(accessedObject)) return []
+    // Check if this is a fully qualified name (e.g., Data.TaggedError)
+    const isFullyQualified = effectDataIdentifier === ts.idText(accessedObject)
+
     const name = ts.idText(className)
 
     // create the expected identifier
     const errorTagKey = (yield* KeyBuilder.createString(sourceFile, name, "error")) || name
 
-    return [{
-      name: `TaggedError("${name}")`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${effectDataIdentifier}.TaggedError("${errorTagKey}")<{${"${0}"}}>{}`,
-      replacementSpan,
-      isSnippet: true
-    }, {
-      name: `TaggedClass("${name}")`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${effectDataIdentifier}.TaggedClass("${name}")<{${"${0}"}}>{}`,
-      replacementSpan,
-      isSnippet: true
-    }] satisfies Array<LSP.CompletionEntryDefinition>
+    // Build completions based on what the user is extending
+    const completions: Array<LSP.CompletionEntryDefinition> = []
+
+    // Check for Data.TaggedError or direct import TaggedError
+    const hasTaggedErrorCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectDataModuleApi("TaggedError")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTaggedErrorCompletion) {
+      completions.push({
+        name: `TaggedError("${name}")`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${effectDataIdentifier}.TaggedError("${errorTagKey}")<{${"${0}"}}>{}`
+          : `TaggedError("${errorTagKey}")<{${"${0}"}}>{}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    // Check for Data.TaggedClass or direct import TaggedClass
+    const hasTaggedClassCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectDataModuleApi("TaggedClass")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTaggedClassCompletion) {
+      completions.push({
+        name: `TaggedClass("${name}")`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${effectDataIdentifier}.TaggedClass("${name}")<{${"${0}"}}>{}`
+          : `TaggedClass("${name}")<{${"${0}"}}>{}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    return completions
   })
 })

--- a/src/completions/effectSchemaSelfInClasses.ts
+++ b/src/completions/effectSchemaSelfInClasses.ts
@@ -1,6 +1,9 @@
+import { pipe } from "effect"
+import * as Option from "effect/Option"
 import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
+import * as TypeParser from "../core/TypeParser.js"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
 
@@ -9,6 +12,7 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
   apply: Nano.fn("effectSchemaSelfInClasses")(function*(sourceFile, position) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
     const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
 
     const maybeInfos = tsUtils.parseDataForExtendsClassCompletion(sourceFile, position)
     if (!maybeInfos) return []
@@ -21,37 +25,93 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
       "Schema"
     ) || "Schema"
 
-    // ensure accessed is an identifier
-    if (schemaIdentifier !== ts.idText(accessedObject)) return []
+    // Check if this is a fully qualified name (e.g., Schema.Class)
+    const isFullyQualified = schemaIdentifier === ts.idText(accessedObject)
+
     const name = ts.idText(className)
 
     // create the expected identifier
     const errorTagKey = (yield* KeyBuilder.createString(sourceFile, name, "error")) || name
 
-    return [{
-      name: `Class<${name}>`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${schemaIdentifier}.Class<${name}>("${name}")({${"${0}"}}){}`,
-      replacementSpan,
-      isSnippet: true
-    }, {
-      name: `TaggedError<${name}>`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${schemaIdentifier}.TaggedError<${name}>("${errorTagKey}")("${errorTagKey}", {${"${0}"}}){}`,
-      replacementSpan,
-      isSnippet: true
-    }, {
-      name: `TaggedClass<${name}>`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${schemaIdentifier}.TaggedClass<${name}>("${name}")("${name}", {${"${0}"}}){}`,
-      replacementSpan,
-      isSnippet: true
-    }, {
-      name: `TaggedRequest<${name}>`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${schemaIdentifier}.TaggedRequest<${name}>("${name}")("${name}", {${"${0}"}}){}`,
-      replacementSpan,
-      isSnippet: true
-    }] satisfies Array<LSP.CompletionEntryDefinition>
+    // Build completions based on what the user is extending
+    const completions: Array<LSP.CompletionEntryDefinition> = []
+
+    // Check for Schema.Class or direct import Class
+    const hasClassCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectSchemaModuleApi("Class")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasClassCompletion) {
+      completions.push({
+        name: `Class<${name}>`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${schemaIdentifier}.Class<${name}>("${name}")({${"${0}"}}){}`
+          : `Class<${name}>("${name}")({${"${0}"}}){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    // Check for Schema.TaggedError or direct import TaggedError
+    const hasTaggedErrorCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectSchemaModuleApi("TaggedError")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTaggedErrorCompletion) {
+      completions.push({
+        name: `TaggedError<${name}>`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${schemaIdentifier}.TaggedError<${name}>("${errorTagKey}")("${errorTagKey}", {${"${0}"}}){}`
+          : `TaggedError<${name}>("${errorTagKey}")("${errorTagKey}", {${"${0}"}}){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    // Check for Schema.TaggedClass or direct import TaggedClass
+    const hasTaggedClassCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectSchemaModuleApi("TaggedClass")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTaggedClassCompletion) {
+      completions.push({
+        name: `TaggedClass<${name}>`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${schemaIdentifier}.TaggedClass<${name}>("${name}")("${name}", {${"${0}"}}){}`
+          : `TaggedClass<${name}>("${name}")("${name}", {${"${0}"}}){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    // Check for Schema.TaggedRequest or direct import TaggedRequest
+    const hasTaggedRequestCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectSchemaModuleApi("TaggedRequest")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTaggedRequestCompletion) {
+      completions.push({
+        name: `TaggedRequest<${name}>`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${schemaIdentifier}.TaggedRequest<${name}>("${name}")("${name}", {${"${0}"}}){}`
+          : `TaggedRequest<${name}>("${name}")("${name}", {${"${0}"}}){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    return completions
   })
 })

--- a/src/completions/effectSelfInClasses.ts
+++ b/src/completions/effectSelfInClasses.ts
@@ -1,6 +1,9 @@
+import { pipe } from "effect"
+import * as Option from "effect/Option"
 import * as KeyBuilder from "../core/KeyBuilder.js"
 import * as LSP from "../core/LSP"
 import * as Nano from "../core/Nano"
+import * as TypeParser from "../core/TypeParser.js"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
 
@@ -9,6 +12,7 @@ export const effectSelfInClasses = LSP.createCompletion({
   apply: Nano.fn("effectSelfInClasses")(function*(sourceFile, position) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
     const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
 
     const maybeInfos = tsUtils.parseDataForExtendsClassCompletion(sourceFile, position)
     if (!maybeInfos) return []
@@ -21,25 +25,55 @@ export const effectSelfInClasses = LSP.createCompletion({
       "Effect"
     ) || "Effect"
 
-    // ensure accessed is an identifier
-    if (effectIdentifier !== ts.idText(accessedObject)) return []
+    // Check if this is a fully qualified name (e.g., Effect.Service)
+    const isFullyQualified = effectIdentifier === ts.idText(accessedObject)
+
     const name = ts.idText(className)
 
     // create the expected identifier
     const tagKey = (yield* KeyBuilder.createString(sourceFile, name, "service")) || name
 
-    return [{
-      name: `Service<${name}>`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${effectIdentifier}.Service<${name}>()("${tagKey}", {${"${0}"}}){}`,
-      replacementSpan,
-      isSnippet: true
-    }, {
-      name: `Tag("${name}")`,
-      kind: ts.ScriptElementKind.constElement,
-      insertText: `${effectIdentifier}.Tag("${tagKey}")<${name}, {${"${0}"}}>(){}`,
-      replacementSpan,
-      isSnippet: true
-    }] satisfies Array<LSP.CompletionEntryDefinition>
+    // Build completions based on what the user is extending
+    const completions: Array<LSP.CompletionEntryDefinition> = []
+
+    // If extending Service (either Effect.Service or direct import Service)
+    const hasServiceCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectModuleApi("Service")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasServiceCompletion) {
+      completions.push({
+        name: `Service<${name}>`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${effectIdentifier}.Service<${name}>()("${tagKey}", {${"${0}"}}){}`
+          : `Service<${name}>()("${tagKey}", {${"${0}"}}){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    // If extending Tag (either Effect.Tag or direct import Tag)
+    const hasTagCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectModuleApi("Tag")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTagCompletion) {
+      completions.push({
+        name: `Tag("${name}")`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${effectIdentifier}.Tag("${tagKey}")<${name}, {${"${0}"}}>(){}`
+          : `Tag("${tagKey}")<${name}, {${"${0}"}}>(){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    return completions
   })
 })

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -16,6 +16,22 @@ exports[`Completion contextSelfInClasses > contextSelfInClasses.ts at 4:40 1`] =
 ]
 `;
 
+exports[`Completion contextSelfInClasses > contextSelfInClasses_directImportTag.ts at 4:35 1`] = `
+[
+  {
+    "insertText": "Tag("@effect/language-service/MyService")<MyService, \${0}>(){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "Tag("MyService")",
+    "replacementSpan": {
+      "length": 3,
+      "start": 139,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
 exports[`Completion contextSelfInClasses > contextSelfInClasses_identifierKey.ts at 5:40 1`] = `
 [
   {
@@ -197,6 +213,38 @@ exports[`Completion effectDataClasses > effectDataClasses.ts at 4:35 1`] = `
 ]
 `;
 
+exports[`Completion effectDataClasses > effectDataClasses_directImportTaggedClass.ts at 4:40 1`] = `
+[
+  {
+    "insertText": "TaggedClass("MyClass")<{\${0}}>{}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "TaggedClass("MyClass")",
+    "replacementSpan": {
+      "length": 11,
+      "start": 139,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion effectDataClasses > effectDataClasses_directImportTaggedError.ts at 4:40 1`] = `
+[
+  {
+    "insertText": "TaggedError("MyError")<{\${0}}>{}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "TaggedError("MyError")",
+    "replacementSpan": {
+      "length": 11,
+      "start": 139,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
@@ -234,6 +282,70 @@ exports[`Completion effectJsdocComment > effectJsdocComment.ts at 2:6 1`] = `
     "replacementSpan": {
       "length": 1,
       "start": 71,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_directImportClass.ts at 4:35 1`] = `
+[
+  {
+    "insertText": "Class<MyClass>("MyClass")({\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "Class<MyClass>",
+    "replacementSpan": {
+      "length": 5,
+      "start": 143,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_directImportTaggedClass.ts at 4:40 1`] = `
+[
+  {
+    "insertText": "TaggedClass<MyClass>("MyClass")("MyClass", {\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "TaggedClass<MyClass>",
+    "replacementSpan": {
+      "length": 11,
+      "start": 149,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_directImportTaggedError.ts at 4:40 1`] = `
+[
+  {
+    "insertText": "TaggedError<MyError>("MyError")("MyError", {\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "TaggedError<MyError>",
+    "replacementSpan": {
+      "length": 11,
+      "start": 149,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_directImportTaggedRequest.ts at 4:44 1`] = `
+[
+  {
+    "insertText": "TaggedRequest<MyRequest>("MyRequest")("MyRequest", {\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "TaggedRequest<MyRequest>",
+    "replacementSpan": {
+      "length": 13,
+      "start": 153,
     },
     "sortText": "11",
   },
@@ -359,6 +471,38 @@ exports[`Completion effectSelfInClasses > effectSelfInClasses.ts at 4:39 1`] = `
     "replacementSpan": {
       "length": 7,
       "start": 141,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion effectSelfInClasses > effectSelfInClasses_directImportService.ts at 4:39 1`] = `
+[
+  {
+    "insertText": "Service<MyService>()("@effect/language-service/MyService", {\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "Service<MyService>",
+    "replacementSpan": {
+      "length": 7,
+      "start": 141,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
+exports[`Completion effectSelfInClasses > effectSelfInClasses_directImportTag.ts at 4:35 1`] = `
+[
+  {
+    "insertText": "Tag("@effect/language-service/MyService")<MyService, {\${0}}>(){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "Tag("MyService")",
+    "replacementSpan": {
+      "length": 3,
+      "start": 137,
     },
     "sortText": "11",
   },


### PR DESCRIPTION
## Summary

Fixes #394 - Auto-completion now works for directly imported Effect APIs in addition to fully qualified names.

## Changes

This PR adds support for auto-completion when using direct imports like `import { Service } from "effect/Effect"` instead of only working with fully qualified names like `Effect.Service`.

**Modified Files:**
- `src/completions/effectSelfInClasses.ts` - Support for `Service` and `Tag` from `effect/Effect`
- `src/completions/effectSchemaSelfInClasses.ts` - Support for `Class`, `TaggedError`, `TaggedClass`, `TaggedRequest` from `effect/Schema`
- `src/completions/effectDataClasses.ts` - Support for `TaggedError` and `TaggedClass` from `effect/Data`
- `src/completions/contextSelfInClasses.ts` - Support for `Tag` from `effect/Context`

**Implementation:**
- Uses `TypeParser.isNodeReferenceToEffectModuleApi` to detect direct imports
- Maintains full backward compatibility with fully qualified names
- Performance optimized with short-circuit evaluation

## Examples

**Effect Module:**
```typescript
// Now works with direct imports
import { Service } from "effect/Effect"
export class MyService extends Service // ✓ Completion available

// Still works with fully qualified names
import * as Effect from "effect/Effect"
export class MyService extends Effect.Service // ✓ Completion available
```

**Schema Module:**
```typescript
import { TaggedError } from "effect/Schema"
export class MyError extends TaggedError // ✓ Completion available
```

**Data Module:**
```typescript
import { TaggedClass } from "effect/Data"
export class MyClass extends TaggedClass // ✓ Completion available
```

**Context Module:**
```typescript
import { Tag } from "effect/Context"
export class MyService extends Tag // ✓ Completion available
```

## Test Results

- ✅ All 352 tests passing (+9 new tests for direct imports)
- ✅ Type checking passed
- ✅ Lint passed
- ✅ Full backward compatibility maintained