### PR TITLE
fix: handle read-only arrays correctly in structural type to schema refactor

### DIFF
--- a/.changeset/fix-readonly-arrays.md
+++ b/.changeset/fix-readonly-arrays.md
@@ -1,0 +1,13 @@
+---
+"@effect/language-service": patch
+---
+
+Fix handling of read-only arrays in "Refactor to Schema (Recursive Structural)" code generation. 
+
+The refactor now correctly distinguishes between mutable arrays (`Array<T>`) and read-only arrays (`ReadonlyArray<T>` or `readonly T[]`):
+- `Array<T>` is now converted to `Schema.mutable(Schema.Array(...))` to preserve mutability
+- `ReadonlyArray<T>` and `readonly T[]` are converted to `Schema.Array(...)` (read-only by default)
+
+This fixes compatibility issues with external libraries (like Stripe, BetterAuth) that expect mutable arrays in their API parameters.
+
+Fixes #531

--- a/examples/refactors/structuralTypeToSchema.ts
+++ b/examples/refactors/structuralTypeToSchema.ts
@@ -14,6 +14,9 @@ export interface MyStruct {
   voidProp: void
   arrayTypeProp: Array<string>
   arrayProp: Array<string>
+  readonlyArrayProp: ReadonlyArray<string>
+  // eslint-disable-next-line @typescript-eslint/array-type
+  arrayWithReadonlyProp: readonly string[]
   dateProp: Date
   trueProp: true
   falseProp: false

--- a/src/utils/StructuralSchemaGen.ts
+++ b/src/utils/StructuralSchemaGen.ts
@@ -423,7 +423,7 @@ const processArrayType: (
     "StructuralSchemaGen.processArrayType"
   )(
     function*(type, context) {
-      const { createApiCall, typeChecker } = yield* Nano.service(StructuralSchemaGenContext)
+      const { createApiCall, typeChecker, typeCheckerUtils } = yield* Nano.service(StructuralSchemaGenContext)
 
       // Get the element type
       const typeArgs = typeChecker.getTypeArguments(type as ts.TypeReference)
@@ -432,7 +432,9 @@ const processArrayType: (
       }
 
       const elementSchema: ts.Expression = yield* processType(typeArgs[0], context)
-      return [createApiCall("Array", [elementSchema]), false]
+      const expr = createApiCall("Array", [elementSchema])
+      if (typeCheckerUtils.isReadonlyArrayType(type)) return [expr, false]
+      return [createApiCall("mutable", [expr]), false]
     }
   )
 

--- a/test/__snapshots__/refactors/structuralTypeToSchema.ts.ln4col21.output
+++ b/test/__snapshots__/refactors/structuralTypeToSchema.ts.ln4col21.output
@@ -11,8 +11,10 @@ export class MyStruct extends Schema.Class<MyStruct>("MyStruct")({
     undefinedProp: Schema.Undefined,
     unknownProp: Schema.Unknown,
     voidProp: Schema.Void,
-    arrayTypeProp: Schema.Array(Schema.String),
-    arrayProp: Schema.Array(Schema.String),
+    arrayTypeProp: Schema.mutable(Schema.Array(Schema.String)),
+    arrayProp: Schema.mutable(Schema.Array(Schema.String)),
+    readonlyArrayProp: Schema.Array(Schema.String),
+    arrayWithReadonlyProp: Schema.Array(Schema.String),
     dateProp: Schema.Date,
     trueProp: Schema.Literal(true),
     falseProp: Schema.Literal(false),
@@ -48,6 +50,9 @@ export interface MyStruct {
   voidProp: void
   arrayTypeProp: Array<string>
   arrayProp: Array<string>
+  readonlyArrayProp: ReadonlyArray<string>
+  // eslint-disable-next-line @typescript-eslint/array-type
+  arrayWithReadonlyProp: readonly string[]
   dateProp: Date
   trueProp: true
   falseProp: false

--- a/test/__snapshots__/refactors/structuralTypeToSchema_symbolNames.ts.ln14col21.output
+++ b/test/__snapshots__/refactors/structuralTypeToSchema_symbolNames.ts.ln14col21.output
@@ -22,7 +22,7 @@ class Todo extends Schema.Class<Todo>("Todo")({
 
 export class AppState extends Schema.Class<AppState>("AppState")({
     users: User,
-    tasks: Schema.Array(Schema.Tuple(Todo, User))
+    tasks: Schema.mutable(Schema.Array(Schema.Tuple(Todo, User)))
 }) { }
 
 


### PR DESCRIPTION
## Summary

Fixes #531 by correctly distinguishing between mutable and read-only arrays when generating Schema code from structural types.

## Changes

The "Refactor to Schema (Recursive Structural)" code generation now properly handles different array type declarations:

- `Array<T>` → `Schema.mutable(Schema.Array(...))` - preserves mutability
- `ReadonlyArray<T>` → `Schema.Array(...)` - read-only by default  
- `readonly T[]` → `Schema.Array(...)` - read-only by default

## Example

Before this fix, all array types were generated as read-only, causing type incompatibility with external libraries:

```typescript
// Given:
interface MyType {
  items: Array<string>  // mutable array
}

// Generated (incorrect):
Schema.Array(Schema.String)  // readonly by default
```

After this fix:

```typescript
// Generated (correct):
Schema.mutable(Schema.Array(Schema.String))  // mutable array
```

This resolves compatibility issues with libraries like Stripe and BetterAuth that expect mutable arrays in their API parameters.