### PR TITLE
refactor: simplify unnecessaryFailYieldableError diagnostic implementation

### DIFF
--- a/.changeset/fix-unnecessary-fail-yieldable-error-style.md
+++ b/.changeset/fix-unnecessary-fail-yieldable-error-style.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+refactor: simplify `unnecessaryFailYieldableError` diagnostic implementation
+
+Changed the implementation to check if a type extends `Cause.YieldableError` on-demand rather than fetching all yieldable error types upfront.


### PR DESCRIPTION
## Summary
- Refactored `TypeParser.effectCauseYieldableErrorTypes` to `TypeParser.extendsCauseYieldableError`
- Changed the implementation to check if a type extends `Cause.YieldableError` on-demand rather than fetching all yieldable error types upfront
- Simplified caching key to use the specific type being checked

## Test plan
- [x] All existing tests pass (378 tests)
- [x] Type checking passes
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)