### PR TITLE
fix: resolve TypeScript from project working directory

### DIFF
--- a/.changeset/fix-typescript-resolution.md
+++ b/.changeset/fix-typescript-resolution.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+fix: resolve TypeScript from project's working directory
+
+The CLI now attempts to resolve TypeScript from the current working directory first before falling back to the package's bundled version. This ensures the CLI uses the same TypeScript version as the project being analyzed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ const main = Command.run(cliCommand, {
   version: "0.0.2"
 })
 
-const cliLayers = Layer.merge(NodeContext.layer, TypeScriptContext.live)
+const cliLayers = Layer.merge(NodeContext.layer, TypeScriptContext.live(process.cwd()))
 
 main(process.argv).pipe(
   Effect.provide(cliLayers),

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -70,14 +70,23 @@ export class TypeScriptContext extends Context.Tag("TypeScriptContext")<
   TypeScriptContext,
   TypeScriptApi
 >() {
-  static live = Layer.effect(
-    TypeScriptContext,
-    Effect.try({
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      try: () => require("typescript") as typeof ts,
-      catch: (cause) => new UnableToFindInstalledTypeScriptPackage({ cause })
-    })
-  )
+  static live = (cwd: string) =>
+    Layer.effect(
+      TypeScriptContext,
+      Effect.try({
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        try: () => require(require.resolve("typescript", { paths: [cwd] })) as typeof ts,
+        catch: (cause) => new UnableToFindInstalledTypeScriptPackage({ cause })
+      }).pipe(
+        Effect.orElse(() =>
+          Effect.try({
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            try: () => require("typescript") as typeof ts,
+            catch: (cause) => new UnableToFindInstalledTypeScriptPackage({ cause })
+          })
+        )
+      )
+    )
 }
 
 export const getPackageJsonData = Effect.fn("getPackageJsonData")(function*(packageDir: string) {

--- a/test/setup-cli.test.ts
+++ b/test/setup-cli.test.ts
@@ -59,12 +59,12 @@ export async function expectSetupChanges(
 ) {
   // Run assessment
   const assessmentState = await Effect.runPromise(
-    assess(assessmentInput).pipe(Effect.provide(TypeScriptContext.live))
+    assess(assessmentInput).pipe(Effect.provide(TypeScriptContext.live(".")))
   )
 
   // Compute changes (returns { codeActions, messages })
   const result = await Effect.runPromise(
-    computeChanges(assessmentState, targetState).pipe(Effect.provide(TypeScriptContext.live))
+    computeChanges(assessmentState, targetState).pipe(Effect.provide(TypeScriptContext.live(".")))
   )
 
   // 1. Snapshot of change summary (file + description)


### PR DESCRIPTION
## Summary

- The CLI now resolves TypeScript from the project's working directory first, using `require.resolve("typescript", { paths: [cwd] })`
- Falls back to the bundled TypeScript version if project-local resolution fails
- Ensures the language service uses the same TypeScript version as the project being analyzed

## Changes

- `TypeScriptContext.live` now accepts a `cwd` parameter for resolution context
- Resolution first attempts project-local TypeScript, then falls back to bundled version
- Updated tests to pass the working directory parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)