### PR TITLE
fix: ensure correct path resolution in CLI setup

### DIFF
--- a/.changeset/fix-cli-path-resolution.md
+++ b/.changeset/fix-cli-path-resolution.md
@@ -1,0 +1,9 @@
+---
+"@effect/language-service": patch
+---
+
+fix: ensure correct path resolution in CLI setup
+
+- Use `process.cwd()` explicitly in `path.resolve()` for consistent behavior
+- Resolve the selected tsconfig path to an absolute path before validation
+- Simplify error handling by using direct `yield*` for `TsConfigNotFoundError`

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -35,9 +35,7 @@ const createAssessmentInput = (
     const packageJsonExists = yield* fs.exists(packageJsonPath)
 
     if (!packageJsonExists) {
-      return yield* Effect.fail(
-        new PackageJsonNotFoundError({ path: packageJsonPath })
-      )
+      return yield* new PackageJsonNotFoundError({ path: packageJsonPath })
     }
 
     const packageJsonText = yield* fs.readFileString(packageJsonPath).pipe(
@@ -83,7 +81,7 @@ export const setup = Command.make(
       // ========================================================================
       // Phase 1: Select tsconfig file
       // ========================================================================
-      const currentDir = path.resolve(".")
+      const currentDir = path.resolve(process.cwd())
       const tsconfigInput = yield* selectTsConfigFile(currentDir)
 
       // ========================================================================

--- a/src/cli/setup/tsconfig-prompt.ts
+++ b/src/cli/setup/tsconfig-prompt.ts
@@ -39,6 +39,7 @@ export const selectTsConfigFile = (
 > =>
   Effect.gen(function*() {
     const fs = yield* FileSystem.FileSystem
+    const path = yield* Path.Path
 
     const tsconfigFiles = yield* findTsConfigFiles(currentDir)
 
@@ -75,13 +76,12 @@ export const selectTsConfigFile = (
         selectedTsconfigPath = selected
       }
     }
+    selectedTsconfigPath = path.resolve(selectedTsconfigPath)
 
     // Check if the selected tsconfig file exists
     const tsconfigExists = yield* fs.exists(selectedTsconfigPath)
     if (!tsconfigExists) {
-      return yield* Effect.fail(
-        new TsConfigNotFoundError({ path: selectedTsconfigPath })
-      )
+      return yield* new TsConfigNotFoundError({ path: selectedTsconfigPath })
     }
 
     // Read the tsconfig file


### PR DESCRIPTION
## Summary

- Use `process.cwd()` explicitly in `path.resolve()` for consistent behavior across different Node.js environments
- Resolve the selected tsconfig path to an absolute path before validation to ensure file existence checks work correctly
- Simplify error handling by using direct `yield*` for `TsConfigNotFoundError`

## Changes

**`src/cli/setup.ts`:**
```diff
- const currentDir = path.resolve(".")
+ const currentDir = path.resolve(process.cwd())
```

**`src/cli/setup/tsconfig-prompt.ts`:**
```diff
+ const path = yield* Path.Path
  ...
+ selectedTsconfigPath = path.resolve(selectedTsconfigPath)
  ...
- return yield* Effect.fail(
-   new TsConfigNotFoundError({ path: selectedTsconfigPath })
- )
+ return yield* new TsConfigNotFoundError({ path: selectedTsconfigPath })
```

## Test plan

- [x] `pnpm lint-fix` passes
- [x] `pnpm check` passes  
- [x] `pnpm test` passes (383 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)