### PR TITLE
Improve unsupportedServiceAccessors diagnostic message for Effect.Tag

### DIFF
--- a/.changeset/improve-unsupported-accessors-message.md
+++ b/.changeset/improve-unsupported-accessors-message.md
@@ -1,0 +1,16 @@
+---
+"@effect/language-service": patch
+---
+
+Improve diagnostic message for `unsupportedServiceAccessors` when used with `Effect.Tag`
+
+When the `unsupportedServiceAccessors` diagnostic is triggered on an `Effect.Tag` class (which doesn't allow disabling accessors), the message now includes a helpful suggestion to use `Context.Tag` instead:
+
+```typescript
+export class MyService extends Effect.Tag("MyService")<MyService, {
+  method: <A>(value: A) => Effect.Effect<A>
+}>() {}
+// Diagnostic: Even if accessors are enabled, accessors for 'method' won't be available 
+// because the signature have generic type parameters or multiple call signatures.
+// Effect.Tag does not allow to disable accessors, so you may want to use Context.Tag instead.
+```

--- a/src/diagnostics/unsupportedServiceAccessors.ts
+++ b/src/diagnostics/unsupportedServiceAccessors.ts
@@ -52,11 +52,14 @@ export const unsupportedServiceAccessors = LSP.createDiagnostic({
 
           if (missingMembers.length > 0) {
             const memberNames = missingMembers.map(({ property }) => `'${ts.symbolName(property)}'`).join(", ")
+            const suggestedFix = parseResult.kind === "effectTag"
+              ? "\nEffect.Tag does not allow to disable accessors, so you may want to use Context.Tag instead."
+              : ""
 
             report({
               location: parseResult.className,
               messageText:
-                `Even if accessors are enabled, accessors for ${memberNames} won't be available because the signature have generic type parameters or multiple call signatures.`,
+                `Even if accessors are enabled, accessors for ${memberNames} won't be available because the signature have generic type parameters or multiple call signatures.${suggestedFix}`,
               fixes: [{
                 fixName: "unsupportedServiceAccessors_enableCodegen",
                 description: "Enable accessors codegen",

--- a/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.output
+++ b/test/__snapshots__/diagnostics/unsupportedServiceAccessors_effectTag.ts.output
@@ -1,5 +1,7 @@
 ShouldWarnMethodWithGenerics
-20:13 - 20:41 | 0 | Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.    effect(unsupportedServiceAccessors)
+20:13 - 20:41 | 0 | Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.
+Effect.Tag does not allow to disable accessors, so you may want to use Context.Tag instead.    effect(unsupportedServiceAccessors)
 
 ShouldWarnMethodWithMultipleSignatures
-29:13 - 29:51 | 0 | Even if accessors are enabled, accessors for 'methodWithMultipleSignaturesNoGenerics' won't be available because the signature have generic type parameters or multiple call signatures.    effect(unsupportedServiceAccessors)
+29:13 - 29:51 | 0 | Even if accessors are enabled, accessors for 'methodWithMultipleSignaturesNoGenerics' won't be available because the signature have generic type parameters or multiple call signatures.
+Effect.Tag does not allow to disable accessors, so you may want to use Context.Tag instead.    effect(unsupportedServiceAccessors)


### PR DESCRIPTION
## Summary

- Enhances the `unsupportedServiceAccessors` diagnostic to provide a more helpful message when used with `Effect.Tag`
- When accessors cannot be generated (due to generic type parameters or multiple call signatures), the diagnostic now suggests using `Context.Tag` instead since `Effect.Tag` doesn't allow disabling accessors

## Example

```typescript
export class MyService extends Effect.Tag("MyService")<MyService, {
  method: <A>(value: A) => Effect.Effect<A>
}>() {}
```

**Before:**
> Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.

**After:**
> Even if accessors are enabled, accessors for 'method' won't be available because the signature have generic type parameters or multiple call signatures.
> Effect.Tag does not allow to disable accessors, so you may want to use Context.Tag instead.