### PR TITLE
Add descriptions to CLI commands

### DIFF
--- a/.changeset/cli-command-descriptions.md
+++ b/.changeset/cli-command-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add descriptions to CLI commands using `Command.withDescription` for improved help output when using `--help` flag.

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -51,4 +51,6 @@ export const check = Command.make(
       }
     }
   })
+).pipe(
+  Command.withDescription("Check if the typescript package is patched with the effect-language-service.")
 )

--- a/src/cli/codegen.ts
+++ b/src/cli/codegen.ts
@@ -191,4 +191,6 @@ export const codegen = Command.make(
       `${filesToCodegen.size} involved files, of which ${filesWithCodegenDirective.size} with codegens.\n${checkedFilesCount} checked and ${updatedFilesCount} updated.`
     )
   })
+).pipe(
+  Command.withDescription("Regenarate the outdated effect-codegens provided by the effect-language-service.")
 )

--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -440,4 +440,6 @@ export const diagnostics = Command.make(
     const hasFailures = state.errorsCount > 0 || (strict && state.warningsCount > 0)
     if (hasFailures) return yield* Effect.sync(() => process.exit(1))
   })
+).pipe(
+  Command.withDescription("Gets the effect-language-service diagnostics on the given files or project.")
 )

--- a/src/cli/patch.ts
+++ b/src/cli/patch.ts
@@ -349,4 +349,8 @@ export const patch = Command.make(
     yield* printRememberDeleteTsbuildinfo()
     yield* printRememberPrepareScript()
   })
+).pipe(
+  Command.withDescription(
+    "Patches the typescript package with the effect-language-service, so that effect diagnostics are available at build time with tsc."
+  )
 )

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -187,4 +187,6 @@ export const setup = Command.make(
         yield* Console.log(message)
       }
     })
+).pipe(
+  Command.withDescription("Setup the effect-language-service for the given project using an interactive cli.")
 )

--- a/src/cli/unpatch.ts
+++ b/src/cli/unpatch.ts
@@ -42,4 +42,6 @@ export const unpatch = Command.make(
       yield* Effect.logInfo(`${filePath} unpatched successfully.`)
     }
   })
+).pipe(
+  Command.withDescription("Unpatches the typescript package from the effect-language-service.")
 )


### PR DESCRIPTION
## Summary

- Added `Command.withDescription()` to all CLI commands for improved help output when using `--help` flag
- Commands now display meaningful descriptions explaining their purpose

## Commands Updated

| Command | Description |
|---------|-------------|
| `check` | Check if the typescript package is patched with the effect-language-service |
| `codegen` | Regenerate the outdated effect-codegens provided by the effect-language-service |
| `diagnostics` | Gets the effect-language-service diagnostics on the given files or project |
| `patch` | Patches the typescript package with the effect-language-service |
| `setup` | Setup the effect-language-service for the given project using an interactive cli |
| `unpatch` | Unpatches the typescript package from the effect-language-service |

## Example

```bash
npx @effect/language-service --help
```

Will now show descriptions for each subcommand.