### PR TITLE
fix: support namespace imports for unnecessaryPipe diagnostic

### DIFF
--- a/.changeset/fix-unnecessary-pipe-namespace.md
+++ b/.changeset/fix-unnecessary-pipe-namespace.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix `unnecessaryPipe` diagnostic and refactor not working with namespace imports from `effect/Function` (e.g., `Function.pipe()` or `Fn.pipe()`)

--- a/examples/diagnostics/unnecessaryPipe_namespace.ts
+++ b/examples/diagnostics/unnecessaryPipe_namespace.ts
@@ -1,0 +1,10 @@
+import * as Fn from "effect/Function"
+
+export const shouldNotReport = Fn.pipe(
+  "Hello",
+  (_) => _.length
+)
+
+export const shouldReport = Fn.pipe(
+  "hello"
+)

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.codefixes
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.codefixes
@@ -1,0 +1,3 @@
+unnecessaryPipe_fix from 139 to 159
+unnecessaryPipe_skipNextLine from 139 to 159
+unnecessaryPipe_skipFile from 139 to 159

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.output
@@ -1,0 +1,4 @@
+Fn.pipe(
+  "hello"
+)
+8:28 - 10:1 | 2 | This pipe call contains no arguments.    effect(unnecessaryPipe)

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.unnecessaryPipe_fix.from139to159.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.unnecessaryPipe_fix.from139to159.output
@@ -1,0 +1,9 @@
+// code fix unnecessaryPipe_fix  output for range 139 - 159
+import * as Fn from "effect/Function"
+
+export const shouldNotReport = Fn.pipe(
+  "Hello",
+  (_) => _.length
+)
+
+export const shouldReport = "hello"

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.unnecessaryPipe_skipFile.from139to159.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.unnecessaryPipe_skipFile.from139to159.output
@@ -1,0 +1,12 @@
+// code fix unnecessaryPipe_skipFile  output for range 139 - 159
+/** @effect-diagnostics unnecessaryPipe:skip-file */
+import * as Fn from "effect/Function"
+
+export const shouldNotReport = Fn.pipe(
+  "Hello",
+  (_) => _.length
+)
+
+export const shouldReport = Fn.pipe(
+  "hello"
+)

--- a/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.unnecessaryPipe_skipNextLine.from139to159.output
+++ b/test/__snapshots__/diagnostics/unnecessaryPipe_namespace.ts.unnecessaryPipe_skipNextLine.from139to159.output
@@ -1,0 +1,12 @@
+// code fix unnecessaryPipe_skipNextLine  output for range 139 - 159
+import * as Fn from "effect/Function"
+
+export const shouldNotReport = Fn.pipe(
+  "Hello",
+  (_) => _.length
+)
+
+// @effect-diagnostics-next-line unnecessaryPipe:off
+export const shouldReport = Fn.pipe(
+  "hello"
+)


### PR DESCRIPTION
## Summary

- Fixes the `unnecessaryPipe` diagnostic not triggering for namespace imports from `effect/Function` (e.g., `Function.pipe()` or `Fn.pipe()`)
- The `pipeCall` function in `TypeParser.ts` now correctly identifies `Function.pipe(A, B, ...)` patterns in addition to the existing `pipe(A, B, ...)` and `expression.pipe(...)` patterns

Closes #564

## Example

Before this fix, the following code would not trigger the `unnecessaryPipe` diagnostic:

```ts
import * as Fn from "effect/Function"

// This was NOT reported as unnecessary
const result = Fn.pipe("hello")
```

After this fix, it correctly reports:

```
Fn.pipe(
  "hello"
)
8:28 - 10:1 | 2 | This pipe call contains no arguments.    effect(unnecessaryPipe)
```