### PR TITLE
Simplify global Error diagnostic messages

### DIFF
--- a/.changeset/simplify-global-error-message.md
+++ b/.changeset/simplify-global-error-message.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Simplify diagnostic messages for global Error type usage
+
+The diagnostic messages for `globalErrorInEffectCatch` and `globalErrorInEffectFailure` now use the more generic term "tagged errors" instead of "tagged errors (Data.TaggedError)" to provide cleaner, more concise guidance.

--- a/src/diagnostics/globalErrorInEffectCatch.ts
+++ b/src/diagnostics/globalErrorInEffectCatch.ts
@@ -64,7 +64,7 @@ export const globalErrorInEffectCatch = LSP.createDiagnostic({
                   report({
                     location: node.expression,
                     messageText:
-                      `The 'catch' callback in ${nodeText} returns the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together.\nInstead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.`,
+                      `The 'catch' callback in ${nodeText} returns the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together.\nInstead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.`,
                     fixes: []
                   })
                 }

--- a/src/diagnostics/globalErrorInEffectFailure.ts
+++ b/src/diagnostics/globalErrorInEffectFailure.ts
@@ -45,7 +45,7 @@ export const globalErrorInEffectFailure = LSP.createDiagnostic({
                   report({
                     location: node,
                     messageText:
-                      `Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.`,
+                      `Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.`,
                     fixes: []
                   })
                 )

--- a/test/__snapshots__/diagnostics/globalErrorInEffectCatch.ts.output
+++ b/test/__snapshots__/diagnostics/globalErrorInEffectCatch.ts.output
@@ -1,7 +1,7 @@
 Effect.tryPromise
 13:35 - 13:52 | 0 | The 'catch' callback in Effect.tryPromise returns the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together.
-Instead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectCatch)
+Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectCatch)
 
 Effect.tryMapPromise
 23:60 - 23:80 | 0 | The 'catch' callback in Effect.tryMapPromise returns the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together.
-Instead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectCatch)
+Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectCatch)

--- a/test/__snapshots__/diagnostics/globalErrorInEffectFailure.ts.output
+++ b/test/__snapshots__/diagnostics/globalErrorInEffectFailure.ts.output
@@ -1,8 +1,8 @@
 Effect.fail(new Error("global error"))
-7:28 - 7:66 | 0 | Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+7:28 - 7:66 | 0 | Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
 
 Effect.fail(new globalThis.Error("global error"))
-8:29 - 8:78 | 0 | Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+8:29 - 8:78 | 0 | Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
 
 Effect.fail(new BaseExtendsError())
-14:29 - 14:64 | 0 | Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+14:29 - 14:64 | 0 | Effect.fail is called with the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)


### PR DESCRIPTION
## Summary

- Simplified diagnostic messages for `globalErrorInEffectCatch` and `globalErrorInEffectFailure`
- Changed from "tagged errors (Data.TaggedError)" to just "tagged errors" for cleaner messaging

## Changes

The diagnostic messages now use the more generic term "tagged errors" instead of explicitly mentioning `Data.TaggedError`. This makes the message more concise while still providing clear guidance.

### Before
```
Instead, use tagged errors (Data.TaggedError) or custom errors with a discriminator property to get properly type-checked errors.
```

### After
```
Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.
```