### PR TITLE
fix: correct auto-import order for namespace imports at file start

### DIFF
--- a/.changeset/fix-auto-import-order.md
+++ b/.changeset/fix-auto-import-order.md
@@ -1,0 +1,21 @@
+---
+"@effect/language-service": patch
+---
+
+Fix auto-import with namespace import packages generating malformed code when the identifier is at the beginning of the file.
+
+When using `namespaceImportPackages` configuration and auto-completing an export like `isAnyKeyword` from `effect/SchemaAST`, the code was incorrectly generated as:
+
+```ts
+SchemaAST.import * as SchemaAST from "effect/SchemaAST";
+```
+
+Instead of the expected:
+
+```ts
+import * as SchemaAST from "effect/SchemaAST";
+
+SchemaAST.isAnyKeyword
+```
+
+The fix ensures the import statement is added before the namespace prefix when both changes target position 0.

--- a/src/completions/middlewareAutoImports.ts
+++ b/src/completions/middlewareAutoImports.ts
@@ -80,16 +80,8 @@ const addImportCodeAction = Nano.fn("getImportFromNamespaceCodeActions")(functio
       preferences: preferences || {}
     },
     (changeTracker) => {
-      // add the introduced prefix if necessary
-      if (effectAutoImport.introducedPrefix) {
-        changeTracker.insertText(
-          sourceFile,
-          effectReplaceSpan.start,
-          effectAutoImport.introducedPrefix + "."
-        )
-      }
-
-      // add the import statement
+      // add the import statement first, so that when both changes target position 0,
+      // the import is inserted before the prefix when changes are applied sequentially
       description = AutoImport.addImport(
         ts,
         sourceFile,
@@ -97,6 +89,15 @@ const addImportCodeAction = Nano.fn("getImportFromNamespaceCodeActions")(functio
         preferences,
         effectAutoImport
       ).description
+
+      // add the introduced prefix after the import
+      if (effectAutoImport.introducedPrefix) {
+        changeTracker.insertText(
+          sourceFile,
+          effectReplaceSpan.start,
+          effectAutoImport.introducedPrefix + "."
+        )
+      }
     }
   )
 


### PR DESCRIPTION
## Summary

- Fixes auto-import with namespace import packages generating malformed code when the identifier is at the beginning of the file

Closes #414

## Problem

When using `namespaceImportPackages` configuration and auto-completing an export like `isAnyKeyword` from `effect/SchemaAST`, the code was incorrectly generated as:

```ts
SchemaAST.import * as SchemaAST from "effect/SchemaAST";
```

## Solution

The issue was in `src/completions/middlewareAutoImports.ts` where the order of text changes added to TypeScript's ChangeTracker was incorrect. The prefix (`SchemaAST.`) was being inserted before the import statement, but both targeted position 0. When the editor applies these changes sequentially with offset adjustment, the import ended up being placed after the prefix text.

The fix swaps the order of operations - the import statement is now added first, followed by the prefix. This ensures correct output:

```ts
import * as SchemaAST from "effect/SchemaAST";

SchemaAST.isAnyKeyword
```