### PR TITLE
refactor: extract symbol collection logic from overview command

### DIFF
--- a/.changeset/refactor-overview-symbols.md
+++ b/.changeset/refactor-overview-symbols.md
@@ -1,0 +1,9 @@
+---
+"@effect/language-service": patch
+---
+
+Refactor CLI overview command to extract symbol collection logic into reusable utility
+
+- Extract `collectSourceFileExportedSymbols` into `src/cli/utils/ExportedSymbols.ts` for reuse across CLI commands
+- Add `--max-symbol-depth` option to overview command (default: 3) to control how deep to traverse nested symbol properties
+- Add tests for the overview command with snapshot testing

--- a/src/cli/utils/ExportedSymbols.ts
+++ b/src/cli/utils/ExportedSymbols.ts
@@ -1,0 +1,121 @@
+import type * as ts from "typescript"
+
+/**
+ * Location information for an exported symbol
+ */
+export interface SymbolLocation {
+  readonly filePath: string
+  readonly line: number
+  readonly column: number
+}
+
+/**
+ * Information about an exported symbol
+ */
+export interface ExportedSymbolInfo {
+  readonly symbol: ts.Symbol
+  readonly name: string
+  readonly location: SymbolLocation
+  readonly type: ts.Type
+  readonly description: string | undefined
+}
+
+/**
+ * Gets the location info from a declaration
+ */
+const getLocationFromDeclaration = (
+  declaration: ts.Declaration,
+  tsInstance: typeof ts
+): SymbolLocation | undefined => {
+  const sourceFile = declaration.getSourceFile()
+  if (!sourceFile) return undefined
+  const { character, line } = tsInstance.getLineAndCharacterOfPosition(sourceFile, declaration.getStart())
+  return {
+    filePath: sourceFile.fileName,
+    line: line + 1,
+    column: character + 1
+  }
+}
+
+/**
+ * Collects all exported symbols from a source file, including nested properties.
+ * For example, if a module exports `Foo` which has a `Default` property, this will
+ * return both `Foo` and `Foo.Default` as separate entries.
+ *
+ * @param sourceFile - The source file to collect exports from
+ * @param tsInstance - The TypeScript instance
+ * @param typeChecker - The TypeScript type checker
+ * @param maxSymbolDepth - Maximum depth to traverse nested properties.
+ *                         0 = only root exports, 1 = root + one level of properties, etc.
+ *                         Default is 0 (only root exports).
+ */
+export const collectSourceFileExportedSymbols = (
+  sourceFile: ts.SourceFile,
+  tsInstance: typeof ts,
+  typeChecker: ts.TypeChecker,
+  maxSymbolDepth: number = 0
+): Array<ExportedSymbolInfo> => {
+  const result: Array<ExportedSymbolInfo> = []
+
+  // Get the module symbol for the source file
+  const moduleSymbol = typeChecker.getSymbolAtLocation(sourceFile)
+  if (!moduleSymbol) {
+    return result
+  }
+
+  // Get all exports from the module
+  const exports = typeChecker.getExportsOfModule(moduleSymbol)
+
+  // Work queue: [symbol, qualifiedName, location | undefined, depth]
+  // Initialize with exported symbols using their names and declaration locations at depth 0
+  const workQueue: Array<[ts.Symbol, string, SymbolLocation | undefined, number]> = exports.map((s) => {
+    const declarations = s.getDeclarations()
+    const location = declarations && declarations.length > 0
+      ? getLocationFromDeclaration(declarations[0], tsInstance)
+      : undefined
+    return [s, tsInstance.symbolName(s), location, 0]
+  })
+
+  // Track which symbols have been exploded (properties added to queue)
+  const exploded = new WeakSet<ts.Symbol>()
+
+  while (workQueue.length > 0) {
+    const [symbol, name, location, depth] = workQueue.shift()!
+
+    if (!location) continue
+
+    const type = typeChecker.getTypeOfSymbol(symbol)
+
+    // Explode symbol: add its properties to the queue (only once per symbol)
+    // Child symbols inherit the parent's code location
+    // Only explode if we haven't reached maxSymbolDepth
+    if (!exploded.has(symbol) && depth < maxSymbolDepth) {
+      exploded.add(symbol)
+
+      const properties = typeChecker.getPropertiesOfType(type)
+      for (const propSymbol of properties) {
+        const propName = tsInstance.symbolName(propSymbol)
+        // Skip prototype property - it contains instance type, not a real export
+        if (propName === "prototype") continue
+        const childName = `${name}.${propName}`
+        workQueue.push([propSymbol, childName, location, depth + 1])
+      }
+    }
+
+    // Get JSDoc description if available
+    const docComment = symbol.getDocumentationComment(typeChecker)
+    const description = docComment.length > 0
+      ? docComment.map((part) => part.text).join("")
+      : undefined
+
+    result.push({
+      symbol,
+      name,
+      location,
+      type,
+      description
+    })
+  }
+
+  return result
+}

--- a/test/__snapshots__/overview/documented.ts.overview
+++ b/test/__snapshots__/overview/documented.ts.overview
@@ -1,0 +1,49 @@
+
+[0;1mServices (4)[0m
+  DbConnection
+    [0;90mdocumented.ts:6:1[0m
+    [0;90mDbConnection[0m
+    [0;90mManages database connections and pooling[0m
+
+  FileSystem
+    [0;90mdocumented.ts:13:1[0m
+    [0;90mFileSystem[0m
+    [0;90mProvides file system access for reading and writing files[0m
+
+  Cache
+    [0;90mdocumented.ts:20:1[0m
+    [0;90mCache[0m
+    [0;90mIn-memory caching layer for improved performance[0m
+
+  UserRepository
+    [0;90mdocumented.ts:27:1[0m
+    [0;90mUserRepository[0m
+    [0;90mRepository for user data access and persistence[0m
+
+
+[0;1mLayers (6)[0m
+  DbConnection.Default
+    [0;90mdocumented.ts:6:1[0m
+    [0;90mLayer<DbConnection, never, never>[0m
+
+  FileSystem.Default
+    [0;90mdocumented.ts:13:1[0m
+    [0;90mLayer<FileSystem, never, never>[0m
+
+  Cache.Default
+    [0;90mdocumented.ts:20:1[0m
+    [0;90mLayer<Cache, never, FileSystem>[0m
+
+  UserRepository.Default
+    [0;90mdocumented.ts:27:1[0m
+    [0;90mLayer<UserRepository, never, DbConnection | Cache>[0m
+
+  CacheLive
+    [0;90mdocumented.ts:34:14[0m
+    [0;90mLayer<Cache, never, never>[0m
+    [0;90mProvides cache with file system backing store[0m
+
+  AppLive
+    [0;90mdocumented.ts:39:14[0m
+    [0;90mLayer<Cache | UserRepository, never, never>[0m
+    [0;90mComplete application layer with all dependencies wired[0m

--- a/test/__snapshots__/overview/duplicated.ts.overview
+++ b/test/__snapshots__/overview/duplicated.ts.overview
@@ -1,0 +1,5 @@
+
+[0;1mLayers (1)[0m
+  AppLive
+    [0;90mduplicated.ts:31:14[0m
+    [0;90mLayer<Database | UserRepository | Analytics | UserService | EventsRepository | EventService | AppService, never, Database | UserRepository | Analytics | UserService | EventsRepository | EventService>[0m

--- a/test/__snapshots__/overview/effect.ts.overview
+++ b/test/__snapshots__/overview/effect.ts.overview
@@ -1,0 +1,5 @@
+
+[0;1mLayers (1)[0m
+  AppLive
+    [0;90meffect.ts:9:14[0m
+    [0;90mLayer<never, never, never>[0m

--- a/test/__snapshots__/overview/followSymbols.ts.overview
+++ b/test/__snapshots__/overview/followSymbols.ts.overview
@@ -1,0 +1,9 @@
+
+[0;1mLayers (2)[0m
+  followSymbols
+    [0;90mfollowSymbols.ts:5:14[0m
+    [0;90mLayer<UserRepository, never, FileSystem>[0m
+
+  moreComplex
+    [0;90mfollowSymbols.ts:7:14[0m
+    [0;90mLayer<UserRepository | DbConnection, never, DbConnection>[0m

--- a/test/__snapshots__/overview/generics.ts.overview
+++ b/test/__snapshots__/overview/generics.ts.overview
@@ -1,0 +1,5 @@
+
+[0;1mLayers (1)[0m
+  NoComment
+    [0;90mgenerics.ts:19:14[0m
+    [0;90mLayer<IsGeneric<UserRepository>, never, never>[0m

--- a/test/__snapshots__/overview/incorrectInference.ts.overview
+++ b/test/__snapshots__/overview/incorrectInference.ts.overview
@@ -1,0 +1,5 @@
+
+[0;1mLayers (1)[0m
+  testInference
+    [0;90mincorrectInference.ts:11:14[0m
+    [0;90mLayer<never, never, never>[0m

--- a/test/__snapshots__/overview/multiple.ts.overview
+++ b/test/__snapshots__/overview/multiple.ts.overview
@@ -1,0 +1,5 @@
+
+[0;1mLayers (1)[0m
+  AppLive
+    [0;90mmultiple.ts:33:14[0m
+    [0;90mLayer<Database | UserRepository | EventsRepository | Analytics | UserService | EventService | AppService, never, Database | UserRepository | EventsRepository | Analytics | UserService | EventService>[0m

--- a/test/__snapshots__/overview/simple.ts.overview
+++ b/test/__snapshots__/overview/simple.ts.overview
@@ -1,0 +1,51 @@
+
+[0;1mServices (4)[0m
+  DbConnection
+    [0;90msimple.ts:3:1[0m
+    [0;90mDbConnection[0m
+
+  FileSystem
+    [0;90msimple.ts:6:1[0m
+    [0;90mFileSystem[0m
+
+  Cache
+    [0;90msimple.ts:9:1[0m
+    [0;90mCache[0m
+
+  UserRepository
+    [0;90msimple.ts:12:1[0m
+    [0;90mUserRepository[0m
+
+
+[0;1mLayers (8)[0m
+  DbConnection.Default
+    [0;90msimple.ts:3:1[0m
+    [0;90mLayer<DbConnection, never, never>[0m
+
+  FileSystem.Default
+    [0;90msimple.ts:6:1[0m
+    [0;90mLayer<FileSystem, never, never>[0m
+
+  Cache.Default
+    [0;90msimple.ts:9:1[0m
+    [0;90mLayer<Cache, never, FileSystem>[0m
+
+  UserRepository.Default
+    [0;90msimple.ts:12:1[0m
+    [0;90mLayer<UserRepository, never, DbConnection | Cache>[0m
+
+  expect
+    [0;90msimple.ts:16:14[0m
+    [0;90mLayer<UserRepository, never, DbConnection | Cache>[0m
+
+  simplePipeIn
+    [0;90msimple.ts:18:14[0m
+    [0;90mLayer<UserRepository, never, DbConnection | FileSystem>[0m
+
+  liveWithPipeable
+    [0;90msimple.ts:20:14[0m
+    [0;90mLayer<DbConnection | Cache | UserRepository, never, DbConnection | FileSystem>[0m
+
+  cacheWithFs
+    [0;90msimple.ts:25:14[0m
+    [0;90mLayer<Cache, never, never>[0m

--- a/test/__snapshots__/overview/specialChars.ts.overview
+++ b/test/__snapshots__/overview/specialChars.ts.overview
@@ -1,0 +1,5 @@
+
+[0;1mLayers (1)[0m
+  NoComment
+    [0;90mspecialChars.ts:15:14[0m
+    [0;90mLayer<IsGeneric<"With<Special>Chars#!">, never, never>[0m

--- a/test/overview.test.ts
+++ b/test/overview.test.ts
@@ -1,0 +1,77 @@
+import { collectExportedItems, renderOverview } from "@effect/language-service/cli/overview"
+import * as Nano from "@effect/language-service/core/Nano"
+import * as TypeCheckerApi from "@effect/language-service/core/TypeCheckerApi"
+import * as TypeCheckerUtils from "@effect/language-service/core/TypeCheckerUtils"
+import * as TypeParser from "@effect/language-service/core/TypeParser"
+import * as TypeScriptApi from "@effect/language-service/core/TypeScriptApi"
+import * as TypeScriptUtils from "@effect/language-service/core/TypeScriptUtils"
+import * as Doc from "@effect/printer-ansi/AnsiDoc"
+import * as Either from "effect/Either"
+import { pipe } from "effect/Function"
+import * as fs from "fs"
+import * as path from "path"
+import * as ts from "typescript"
+import { describe, expect, it } from "vitest"
+import { createServicesWithMockedVFS } from "./utils/mocks.js"
+
+const getExamplesLayerGraphDir = () => path.join(__dirname, "..", "examples", "layer-graph")
+
+async function testOverviewOnExample(fileName: string, sourceText: string) {
+  const { program, sourceFile } = createServicesWithMockedVFS(fileName, sourceText)
+
+  // create snapshot path
+  const snapshotFilePath = path.join(
+    __dirname,
+    "__snapshots__",
+    "overview",
+    fileName + ".overview"
+  )
+
+  // attempt to run collectExportedItems and get the output
+  const result = pipe(
+    collectExportedItems(sourceFile, ts, program.getTypeChecker()),
+    TypeParser.nanoLayer,
+    TypeCheckerUtils.nanoLayer,
+    TypeScriptUtils.nanoLayer,
+    Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
+    Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
+    Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
+    Nano.unsafeRun
+  )
+
+  expect(Either.isRight(result), "should run with no error " + result).toEqual(true)
+
+  if (Either.isLeft(result)) {
+    await expect("// error running collectExportedItems").toMatchFileSnapshot(snapshotFilePath)
+    return
+  }
+
+  const items = result.right
+
+  // Render the overview with the file's directory as cwd (so paths are relative)
+  const cwd = path.dirname(path.resolve(fileName))
+  const doc = renderOverview({ ...items, totalFilesCount: 1 }, cwd)
+  const rendered = Doc.render(doc, { style: "pretty" })
+
+  await expect(rendered).toMatchFileSnapshot(snapshotFilePath)
+}
+
+function testAllOverviewExamples() {
+  // read all filenames from layer-graph examples
+  const allExampleFiles = fs.readdirSync(getExamplesLayerGraphDir())
+
+  describe("Overview", () => {
+    // for each example file
+    for (const fileName of allExampleFiles) {
+      if (!fileName.endsWith(".ts")) continue
+
+      it(fileName, async () => {
+        const sourceText = fs.readFileSync(path.join(getExamplesLayerGraphDir(), fileName))
+          .toString("utf8")
+        await testOverviewOnExample(fileName, sourceText)
+      })
+    }
+  })
+}
+
+testAllOverviewExamples()


### PR DESCRIPTION
## Summary

- Extract `collectSourceFileExportedSymbols` into `src/cli/utils/ExportedSymbols.ts` for reuse across CLI commands
- Add `--max-symbol-depth` option to overview command (default: 3) to control how deep to traverse nested symbol properties
- Add tests for the overview command with snapshot testing

## Changes

### New Files
- `src/cli/utils/ExportedSymbols.ts` - Utility module with:
  - `SymbolLocation` interface - holds file path, line, column
  - `ExportedSymbolInfo` interface - holds symbol, name, location, type, description
  - `collectSourceFileExportedSymbols()` - collects exported symbols with configurable depth traversal

### Modified Files
- `src/cli/overview.ts` - Refactored to use the new utility and added `--max-symbol-depth` option

### Tests
- `test/overview.test.ts` - New test file using layer-graph examples
- `test/__snapshots__/overview/*.overview` - Snapshot files for overview output

## Usage

```bash
# Use default depth of 3
effect-lsp overview --project tsconfig.json

# Only show root exports
effect-lsp overview --project tsconfig.json --max-symbol-depth 0

# Show root + 1 level (e.g., Service.Default)
effect-lsp overview --project tsconfig.json --max-symbol-depth 1
```

## Example Output

```
Services (4)
  DbConnection
    simple.ts:3:1
    DbConnection

  FileSystem
    simple.ts:6:1
    FileSystem

Layers (8)
  DbConnection.Default
    simple.ts:3:1
    Layer<DbConnection, never, never>

  Cache.Default
    simple.ts:9:1
    Layer<Cache, never, FileSystem>
```