### PR TITLE
feat: rename reportSuggestionsAsWarningsInTsc to includeSuggestionsInTsc

### DIFF
--- a/.changeset/rename-include-suggestions-in-tsc.md
+++ b/.changeset/rename-include-suggestions-in-tsc.md
@@ -1,0 +1,13 @@
+---
+"@effect/language-service": minor
+---
+
+Rename `reportSuggestionsAsWarningsInTsc` option to `includeSuggestionsInTsc` and change default to `true`.
+
+This option controls whether diagnostics with "suggestion" severity are included in TSC output when using the `effect-language-service patch` feature. When enabled, suggestions are reported as messages in TSC output, which is useful for LLM-based development tools to see all suggestions.
+
+**Breaking change**: The option has been renamed and the default behavior has changed:
+- Old: `reportSuggestionsAsWarningsInTsc: false` (suggestions not included by default)
+- New: `includeSuggestionsInTsc: true` (suggestions included by default)
+
+To restore the previous behavior, set `"includeSuggestionsInTsc": false` in your tsconfig.json plugin configuration.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Few options can be provided alongside the initialization of the Language Service
         },
         "diagnosticsName": true, // controls whether to include the rule name in diagnostic messages (default: true)
         "missingDiagnosticNextLine": "warning", // controls the severity of warnings for unused @effect-diagnostics-next-line comments (default: "warning", allowed values: off,error,warning,message,suggestion)
-        "reportSuggestionsAsWarningsInTsc": false, // when enabled, diagnostics with "suggestion" or "message" severity will be reported as "warning" in TSC with "[suggestion]" prefix (default: false)
+        "includeSuggestionsInTsc": true, // when enabled with effect-language-service patch enabled, diagnostics with "suggestion" severity will be reported as "message" in TSC with "[suggestion]" prefix; useful to help steer LLM output (default: true)
         "quickinfo": true, // controls Effect quickinfo (default: true)
         "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
         "quickinfoMaximumLength": -1, // controls how long can be the types in the quickinfo hover (helps with very long type to improve perfs, defaults to -1 for no truncation, can be any number eg. 1000 and TS will try to fit as much as possible in that budget, higher number means more info.)

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -21,7 +21,7 @@ export interface LanguageServicePluginOptions {
   diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
   diagnosticsName: boolean
   missingDiagnosticNextLine: DiagnosticSeverity | "off"
-  reportSuggestionsAsWarningsInTsc: boolean
+  includeSuggestionsInTsc: boolean
   quickinfoEffectParameters: "always" | "never" | "whentruncated"
   quickinfo: boolean
   quickinfoMaximumLength: number
@@ -66,7 +66,7 @@ export const defaults: LanguageServicePluginOptions = {
   diagnosticSeverity: {},
   diagnosticsName: true,
   missingDiagnosticNextLine: "warning",
-  reportSuggestionsAsWarningsInTsc: false,
+  includeSuggestionsInTsc: true,
   quickinfo: true,
   quickinfoEffectParameters: "whentruncated",
   quickinfoMaximumLength: -1,
@@ -136,10 +136,10 @@ export function parse(config: any): LanguageServicePluginOptions {
         isString(config.missingDiagnosticNextLine) && isValidSeverityLevel(config.missingDiagnosticNextLine)
       ? config.missingDiagnosticNextLine as DiagnosticSeverity | "off"
       : defaults.missingDiagnosticNextLine,
-    reportSuggestionsAsWarningsInTsc: isObject(config) && hasProperty(config, "reportSuggestionsAsWarningsInTsc") &&
-        isBoolean(config.reportSuggestionsAsWarningsInTsc)
-      ? config.reportSuggestionsAsWarningsInTsc
-      : defaults.reportSuggestionsAsWarningsInTsc,
+    includeSuggestionsInTsc: isObject(config) && hasProperty(config, "includeSuggestionsInTsc") &&
+        isBoolean(config.includeSuggestionsInTsc)
+      ? config.includeSuggestionsInTsc
+      : defaults.includeSuggestionsInTsc,
     quickinfo: isObject(config) && hasProperty(config, "quickinfo") && isBoolean(config.quickinfo)
       ? config.quickinfo
       : defaults.quickinfo,

--- a/src/effect-lsp-patch-utils.ts
+++ b/src/effect-lsp-patch-utils.ts
@@ -81,16 +81,16 @@ export function checkSourceFileWorker(
       Array.filter((_) =>
         _.category === tsInstance.DiagnosticCategory.Error ||
         _.category === tsInstance.DiagnosticCategory.Warning ||
-        (moduleName === "tsc" && parsedOptions.reportSuggestionsAsWarningsInTsc && (
-          _.category === tsInstance.DiagnosticCategory.Suggestion ||
-          _.category === tsInstance.DiagnosticCategory.Message
+        (moduleName === "tsc" && parsedOptions.includeSuggestionsInTsc && (
+          _.category === tsInstance.DiagnosticCategory.Message ||
+          _.category === tsInstance.DiagnosticCategory.Suggestion
         ))
       )
     ),
     Either.map(
       Array.map((_) => {
         if (
-          moduleName === "tsc" && parsedOptions.reportSuggestionsAsWarningsInTsc &&
+          moduleName === "tsc" && parsedOptions.includeSuggestionsInTsc &&
           _.category === tsInstance.DiagnosticCategory.Suggestion
         ) {
           return { ..._, category: tsInstance.DiagnosticCategory.Message }


### PR DESCRIPTION
## Summary

- Renames `reportSuggestionsAsWarningsInTsc` option to `includeSuggestionsInTsc`
- Changes default from `false` to `true` 
- Updates behavior to always include "message" level diagnostics and optionally include "suggestion" level diagnostics

## Breaking Change

The option has been renamed and the default behavior has changed:
- **Old**: `reportSuggestionsAsWarningsInTsc: false` (suggestions not included by default)
- **New**: `includeSuggestionsInTsc: true` (suggestions included by default)

To restore the previous behavior, set `"includeSuggestionsInTsc": false` in your tsconfig.json plugin configuration.

## Example

```json
{
  "compilerOptions": {
    "plugins": [
      {
        "name": "@effect/language-service",
        "includeSuggestionsInTsc": true // now defaults to true
      }
    ]
  }
}
```