### PR TITLE
refactor: use piping flows parser in catchUnfailableEffect diagnostic

### DIFF
--- a/.changeset/refactor-catchunfailable-piping-flows.md
+++ b/.changeset/refactor-catchunfailable-piping-flows.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+refactor: use piping flows parser in catchUnfailableEffect diagnostic


### PR DESCRIPTION
## Summary
- Refactored `catchUnfailableEffect` diagnostic to use the new piping flows parser
- Simplified the implementation from 107 lines to 79 lines by leveraging `typeParser.pipingFlows()`
- Instead of manually traversing AST and parsing pipe calls, we now iterate through pre-parsed piping flows and their transformations

## Example

The diagnostic warns when using error handling on Effects that never fail:

```ts
// warns: "Looks like the previous effect never fails, so probably this error handling will never be triggered."
export const shouldReport = Effect.succeed(42).pipe(
  Effect.catchAll(() => Effect.void)
)
```

## Test plan
- [x] Deleted and regenerated snapshots - identical output
- [x] All tests pass (`pnpm test`)
- [x] Lint and type check pass (`pnpm lint-fix && pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)