### PR TITLE
refactor: use piping flows parser in multipleEffectProvide diagnostic

### DIFF
--- a/.changeset/refactor-multipleeffectprovide-piping-flows.md
+++ b/.changeset/refactor-multipleeffectprovide-piping-flows.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+refactor: use piping flows parser in multipleEffectProvide diagnostic

--- a/src/diagnostics/multipleEffectProvide.ts
+++ b/src/diagnostics/multipleEffectProvide.ts
@@ -1,4 +1,5 @@
 import { pipe } from "effect/Function"
+import * as Option from "effect/Option"
 import type ts from "typescript"
 import * as LSP from "../core/LSP.js"
 import * as Nano from "../core/Nano.js"
@@ -30,89 +31,91 @@ export const multipleEffectProvide = LSP.createDiagnostic({
       "Layer"
     ) || "Layer"
 
-    const parseEffectProvideLayer = (node: ts.Node) => {
-      if (
-        ts.isCallExpression(node) &&
-        node.arguments.length > 0
-      ) {
-        const layer = node.arguments[0]
-        const type = typeCheckerUtils.getTypeAtLocation(layer)
-        if (!type) return Nano.void_
-        return pipe(
-          typeParser.isNodeReferenceToEffectModuleApi("provide")(node.expression),
-          Nano.flatMap(() => typeParser.layerType(type, layer)),
-          Nano.map(() => ({ layer, node })),
-          Nano.orElse(() => Nano.void_)
-        )
-      }
-      return Nano.void_
-    }
+    // Get all piping flows for the source file
+    const flows = yield* typeParser.pipingFlows(sourceFile)
 
-    const parsePipeCall = (node: ts.Node) =>
-      Nano.gen(function*() {
-        const { args } = yield* typeParser.pipeCall(node)
-        let currentChunk = 0
-        const previousLayers: Array<Array<{ layer: ts.Expression; node: ts.CallExpression }>> = [[]]
-        for (const pipeArg of args) {
-          const parsedProvide = yield* (parseEffectProvideLayer(pipeArg))
-          if (parsedProvide) {
-            previousLayers[currentChunk].push(parsedProvide)
+    for (const flow of flows) {
+      let currentChunk = 0
+      const previousLayers: Array<Array<{ layer: ts.Expression; node: ts.CallExpression }>> = [[]]
+
+      // Look for consecutive Effect.provide transformations in the flow
+      for (const transformation of flow.transformations) {
+        // Skip if no args
+        if (!transformation.args || transformation.args.length === 0) {
+          // Non-provide transformation breaks the chain
+          currentChunk++
+          previousLayers.push([])
+          continue
+        }
+
+        // Check if the callee is Effect.provide
+        const isProvideCall = yield* pipe(
+          typeParser.isNodeReferenceToEffectModuleApi("provide")(transformation.callee),
+          Nano.option
+        )
+
+        if (Option.isSome(isProvideCall)) {
+          const layer = transformation.args[0]
+          const type = typeCheckerUtils.getTypeAtLocation(layer)
+          const node = ts.findAncestor(transformation.callee, ts.isCallExpression)
+
+          // Check if the argument is a Layer type and we found the call expression
+          const isLayerType = type
+            ? yield* pipe(
+              typeParser.layerType(type, layer),
+              Nano.option
+            )
+            : Option.none()
+
+          if (Option.isSome(isLayerType) && node) {
+            previousLayers[currentChunk].push({ layer, node })
           } else {
+            // Not a layer, breaks the chain
             currentChunk++
             previousLayers.push([])
           }
+        } else {
+          // Non-provide transformation breaks the chain
+          currentChunk++
+          previousLayers.push([])
         }
-        // report for each chunk
-        for (const chunk of previousLayers) {
-          if (chunk.length < 2) continue
-          report({
-            location: chunk[0].node,
-            messageText:
-              "Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.",
-            fixes: [{
-              fixName: "multipleEffectProvide_fix",
-              description: "Combine into a single provide",
-              apply: Nano.gen(function*() {
-                const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
-                changeTracker.deleteRange(sourceFile, {
-                  pos: ts.getTokenPosOfNode(chunk[0].node, sourceFile),
-                  end: chunk[chunk.length - 1].node.end
-                })
-                const newNode = ts.factory.createCallExpression(
+      }
+
+      // Report for each chunk with 2+ consecutive provide calls
+      for (const chunk of previousLayers) {
+        if (chunk.length < 2) continue
+        report({
+          location: chunk[0].node,
+          messageText:
+            "Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.",
+          fixes: [{
+            fixName: "multipleEffectProvide_fix",
+            description: "Combine into a single provide",
+            apply: Nano.gen(function*() {
+              const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+              changeTracker.deleteRange(sourceFile, {
+                pos: ts.getTokenPosOfNode(chunk[0].node, sourceFile),
+                end: chunk[chunk.length - 1].node.end
+              })
+              const newNode = ts.factory.createCallExpression(
+                ts.factory.createPropertyAccessExpression(
+                  ts.factory.createIdentifier(effectModuleIdentifier),
+                  ts.factory.createIdentifier("provide")
+                ),
+                undefined,
+                [ts.factory.createCallExpression(
                   ts.factory.createPropertyAccessExpression(
-                    ts.factory.createIdentifier(effectModuleIdentifier),
-                    ts.factory.createIdentifier("provide")
+                    ts.factory.createIdentifier(layerModuleIdentifier),
+                    ts.factory.createIdentifier("mergeAll")
                   ),
                   undefined,
-                  [ts.factory.createCallExpression(
-                    ts.factory.createPropertyAccessExpression(
-                      ts.factory.createIdentifier(layerModuleIdentifier),
-                      ts.factory.createIdentifier("mergeAll")
-                    ),
-                    undefined,
-                    chunk.map((c) => c.layer)
-                  )]
-                )
-                changeTracker.insertNodeAt(sourceFile, ts.getTokenPosOfNode(chunk[0].node, sourceFile), newNode)
-              })
-            }]
-          })
-        }
-      })
-
-    const nodeToVisit: Array<ts.Node> = []
-    const appendNodeToVisit = (node: ts.Node) => {
-      nodeToVisit.push(node)
-      return undefined
-    }
-    ts.forEachChild(sourceFile, appendNodeToVisit)
-
-    while (nodeToVisit.length > 0) {
-      const node = nodeToVisit.shift()!
-      ts.forEachChild(node, appendNodeToVisit)
-
-      if (ts.isCallExpression(node)) {
-        yield* pipe(parsePipeCall(node), Nano.ignore)
+                  chunk.map((c) => c.layer)
+                )]
+              )
+              changeTracker.insertNodeAt(sourceFile, ts.getTokenPosOfNode(chunk[0].node, sourceFile), newNode)
+            })
+          }]
+        })
       }
     }
   })


### PR DESCRIPTION
## Summary
- Refactored `multipleEffectProvide` diagnostic to use the new piping flows parser
- Replaced manual AST traversal with `typeParser.pipingFlows(sourceFile)`
- Replaced custom `findCallExpression` helper with `ts.findAncestor(callee, ts.isCallExpression)`
- Iterate through flow transformations to find consecutive `Effect.provide` calls

## Example

The diagnostic warns when chaining multiple `Effect.provide` calls:

```ts
// warns: "Avoid chaining Effect.provide calls..."
export const shouldReport = Effect.void.pipe(
  Effect.provide(MyService1.Default),
  Effect.provide(MyService2.Default)
)
```

## Test plan
- [x] All tests pass (`pnpm test`)
- [x] Lint and type check pass (`pnpm lint-fix && pnpm check`)
- [x] Snapshots regenerate identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)