### PR TITLE
feat: add redundantSchemaTagIdentifier diagnostic

### DIFF
--- a/.changeset/redundant-schema-tag-identifier.md
+++ b/.changeset/redundant-schema-tag-identifier.md
@@ -1,0 +1,21 @@
+---
+"@effect/language-service": minor
+---
+
+Add `redundantSchemaTagIdentifier` diagnostic that suggests removing redundant identifier arguments when they equal the tag value in `Schema.TaggedClass`, `Schema.TaggedError`, or `Schema.TaggedRequest`.
+
+**Before:**
+```typescript
+class MyError extends Schema.TaggedError<MyError>("MyError")("MyError", {
+  message: Schema.String
+}) {}
+```
+
+**After applying the fix:**
+```typescript
+class MyError extends Schema.TaggedError<MyError>()("MyError", {
+  message: Schema.String
+}) {}
+```
+
+Also updates the completions to not include the redundant identifier when autocompleting `Schema.TaggedClass`, `Schema.TaggedError`, and `Schema.TaggedRequest`.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Warn when using `Effect.fail` with the global `Error` type, recommending tagged errors
 - Warn when `Layer.mergeAll` contains layers with interdependencies (where one layer provides a service that another layer in the same call requires)
 - Suggest using `Effect.fn` for functions that return `Effect.gen` for better tracing and concise syntax
+- Suggest removing redundant identifier argument when it equals the tag value in `Schema.TaggedClass`, `Schema.TaggedError`, or `Schema.TaggedRequest`
 
 ### Completions
 

--- a/examples/diagnostics/redundantSchemaTagIdentifier.ts
+++ b/examples/diagnostics/redundantSchemaTagIdentifier.ts
@@ -1,0 +1,34 @@
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/src/completions/effectSchemaSelfInClasses.ts
+++ b/src/completions/effectSchemaSelfInClasses.ts
@@ -67,8 +67,8 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
         name: `TaggedError<${name}>`,
         kind: ts.ScriptElementKind.constElement,
         insertText: isFullyQualified
-          ? `${schemaIdentifier}.TaggedError<${name}>("${errorTagKey}")("${errorTagKey}", {${"${0}"}}){}`
-          : `TaggedError<${name}>("${errorTagKey}")("${errorTagKey}", {${"${0}"}}){}`,
+          ? `${schemaIdentifier}.TaggedError<${name}>()("${errorTagKey}", {${"${0}"}}){}`
+          : `TaggedError<${name}>()("${errorTagKey}", {${"${0}"}}){}`,
         replacementSpan,
         isSnippet: true
       })
@@ -86,8 +86,8 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
         name: `TaggedClass<${name}>`,
         kind: ts.ScriptElementKind.constElement,
         insertText: isFullyQualified
-          ? `${schemaIdentifier}.TaggedClass<${name}>("${name}")("${name}", {${"${0}"}}){}`
-          : `TaggedClass<${name}>("${name}")("${name}", {${"${0}"}}){}`,
+          ? `${schemaIdentifier}.TaggedClass<${name}>()("${name}", {${"${0}"}}){}`
+          : `TaggedClass<${name}>()("${name}", {${"${0}"}}){}`,
         replacementSpan,
         isSnippet: true
       })
@@ -105,8 +105,8 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
         name: `TaggedRequest<${name}>`,
         kind: ts.ScriptElementKind.constElement,
         insertText: isFullyQualified
-          ? `${schemaIdentifier}.TaggedRequest<${name}>("${name}")("${name}", {${"${0}"}}){}`
-          : `TaggedRequest<${name}>("${name}")("${name}", {${"${0}"}}){}`,
+          ? `${schemaIdentifier}.TaggedRequest<${name}>()("${name}", {${"${0}"}}){}`
+          : `TaggedRequest<${name}>()("${name}", {${"${0}"}}){}`,
         replacementSpan,
         isSnippet: true
       })

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -26,6 +26,7 @@ import { multipleEffectProvide } from "./diagnostics/multipleEffectProvide.js"
 import { nonObjectEffectServiceType } from "./diagnostics/nonObjectEffectServiceType.js"
 import { outdatedEffectCodegen } from "./diagnostics/outdatedEffectCodegen.js"
 import { overriddenSchemaConstructor } from "./diagnostics/overriddenSchemaConstructor.js"
+import { redundantSchemaTagIdentifier } from "./diagnostics/redundantSchemaTagIdentifier.js"
 import { returnEffectInGen } from "./diagnostics/returnEffectInGen.js"
 import { runEffectInsideEffect } from "./diagnostics/runEffectInsideEffect.js"
 import { schemaStructWithTag } from "./diagnostics/schemaStructWithTag.js"
@@ -83,5 +84,6 @@ export const diagnostics = [
   globalErrorInEffectFailure,
   layerMergeAllWithDependencies,
   effectMapVoid,
-  effectFnOpportunity
+  effectFnOpportunity,
+  redundantSchemaTagIdentifier
 ]

--- a/src/diagnostics/redundantSchemaTagIdentifier.ts
+++ b/src/diagnostics/redundantSchemaTagIdentifier.ts
@@ -1,0 +1,66 @@
+import { pipe } from "effect"
+import type ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+
+export const redundantSchemaTagIdentifier = LSP.createDiagnostic({
+  name: "redundantSchemaTagIdentifier",
+  code: 42,
+  description:
+    "Suggests removing redundant identifier argument when it equals the tag value in Schema.TaggedClass/TaggedError/TaggedRequest",
+  severity: "suggestion",
+  apply: Nano.fn("redundantSchemaTagIdentifier.apply")(function*(sourceFile, report) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    const nodeToVisit: Array<ts.Node> = []
+    const appendNodeToVisit = (node: ts.Node) => {
+      nodeToVisit.push(node)
+      return undefined
+    }
+    ts.forEachChild(sourceFile, appendNodeToVisit)
+
+    while (nodeToVisit.length > 0) {
+      const node = nodeToVisit.shift()!
+
+      // Check if this is a class declaration that extends Schema.TaggedClass/TaggedError/TaggedRequest
+      if (ts.isClassDeclaration(node) && node.name && node.heritageClauses) {
+        const result = yield* pipe(
+          typeParser.extendsSchemaTaggedClass(node),
+          Nano.orElse(() => typeParser.extendsSchemaTaggedError(node)),
+          Nano.orElse(() => typeParser.extendsSchemaTaggedRequest(node)),
+          Nano.orElse(() => Nano.void_)
+        )
+
+        if (result && result.keyStringLiteral && result.tagStringLiteral) {
+          const { keyStringLiteral, tagStringLiteral } = result
+
+          // Check if the key (identifier) and tag have the same value
+          if (keyStringLiteral.text === tagStringLiteral.text) {
+            report({
+              location: keyStringLiteral,
+              messageText: `Identifier '${keyStringLiteral.text}' is redundant since it equals the _tag value`,
+              fixes: [{
+                fixName: "redundantSchemaTagIdentifier_removeIdentifier",
+                description: `Remove redundant identifier '${keyStringLiteral.text}'`,
+                apply: Nano.gen(function*() {
+                  const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+
+                  // Delete the string literal text range to remove the redundant identifier
+                  changeTracker.deleteRange(sourceFile, {
+                    pos: ts.getTokenPosOfNode(keyStringLiteral, sourceFile),
+                    end: keyStringLiteral.end
+                  })
+                })
+              }]
+            })
+          }
+        }
+      }
+
+      ts.forEachChild(node, appendNodeToVisit)
+    }
+  })
+})

--- a/test/__snapshots__/completions.test.ts.snap
+++ b/test/__snapshots__/completions.test.ts.snap
@@ -248,7 +248,7 @@ exports[`Completion effectDataClasses > effectDataClasses_directImportTaggedErro
 exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:5 1`] = `
 [
   {
-    "insertText": "@effect-diagnostics \${1|anyUnknownInErrorContext,catchAllToMapError,catchUnfailableEffect,classSelfMismatch,deterministicKeys,duplicatePackage,effectFnOpportunity,effectGenUsesAdapter,effectInVoidSuccess,effectMapVoid,floatingEffect,genericEffectServices,globalErrorInEffectCatch,globalErrorInEffectFailure,importFromBarrel,layerMergeAllWithDependencies,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingLayerContext,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,runEffectInsideEffect,schemaStructWithTag,schemaUnionOfLiterals,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unknownInEffectCatch,unnecessaryEffectGen,unnecessaryFailYieldableError,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics \${1|anyUnknownInErrorContext,catchAllToMapError,catchUnfailableEffect,classSelfMismatch,deterministicKeys,duplicatePackage,effectFnOpportunity,effectGenUsesAdapter,effectInVoidSuccess,effectMapVoid,floatingEffect,genericEffectServices,globalErrorInEffectCatch,globalErrorInEffectFailure,importFromBarrel,layerMergeAllWithDependencies,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingLayerContext,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,redundantSchemaTagIdentifier,returnEffectInGen,runEffectInsideEffect,schemaStructWithTag,schemaUnionOfLiterals,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unknownInEffectCatch,unnecessaryEffectGen,unnecessaryFailYieldableError,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics",
@@ -259,7 +259,7 @@ exports[`Completion effectDiagnosticsComment > effectDiagnosticsComment.ts at 2:
     "sortText": "11",
   },
   {
-    "insertText": "@effect-diagnostics-next-line \${1|anyUnknownInErrorContext,catchAllToMapError,catchUnfailableEffect,classSelfMismatch,deterministicKeys,duplicatePackage,effectFnOpportunity,effectGenUsesAdapter,effectInVoidSuccess,effectMapVoid,floatingEffect,genericEffectServices,globalErrorInEffectCatch,globalErrorInEffectFailure,importFromBarrel,layerMergeAllWithDependencies,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingLayerContext,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,returnEffectInGen,runEffectInsideEffect,schemaStructWithTag,schemaUnionOfLiterals,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unknownInEffectCatch,unnecessaryEffectGen,unnecessaryFailYieldableError,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
+    "insertText": "@effect-diagnostics-next-line \${1|anyUnknownInErrorContext,catchAllToMapError,catchUnfailableEffect,classSelfMismatch,deterministicKeys,duplicatePackage,effectFnOpportunity,effectGenUsesAdapter,effectInVoidSuccess,effectMapVoid,floatingEffect,genericEffectServices,globalErrorInEffectCatch,globalErrorInEffectFailure,importFromBarrel,layerMergeAllWithDependencies,leakingRequirements,missedPipeableOpportunity,missingEffectContext,missingEffectError,missingEffectServiceDependency,missingLayerContext,missingReturnYieldStar,missingStarInYieldEffectGen,multipleEffectProvide,nonObjectEffectServiceType,outdatedEffectCodegen,overriddenSchemaConstructor,redundantSchemaTagIdentifier,returnEffectInGen,runEffectInsideEffect,schemaStructWithTag,schemaUnionOfLiterals,scopeInLayerEffect,strictBooleanExpressions,strictEffectProvide,tryCatchInEffectGen,unknownInEffectCatch,unnecessaryEffectGen,unnecessaryFailYieldableError,unnecessaryPipe,unnecessaryPipeChain,unsupportedServiceAccessors|}:\${2|off,warning,error,message,suggestion|}$0",
     "isSnippet": true,
     "kind": "string",
     "name": "@effect-diagnostics-next-line",
@@ -307,7 +307,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_direct
 exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_directImportTaggedClass.ts at 4:40 1`] = `
 [
   {
-    "insertText": "TaggedClass<MyClass>("MyClass")("MyClass", {\${0}}){}",
+    "insertText": "TaggedClass<MyClass>()("MyClass", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedClass<MyClass>",
@@ -323,7 +323,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_direct
 exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_directImportTaggedError.ts at 4:40 1`] = `
 [
   {
-    "insertText": "TaggedError<MyError>("MyError")("MyError", {\${0}}){}",
+    "insertText": "TaggedError<MyError>()("MyError", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedError<MyError>",
@@ -339,7 +339,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_direct
 exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_directImportTaggedRequest.ts at 4:44 1`] = `
 [
   {
-    "insertText": "TaggedRequest<MyRequest>("MyRequest")("MyRequest", {\${0}}){}",
+    "insertText": "TaggedRequest<MyRequest>()("MyRequest", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedRequest<MyRequest>",
@@ -366,7 +366,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_dotTok
     "sortText": "11",
   },
   {
-    "insertText": "S.TaggedError<Test>("Test")("Test", {\${0}}){}",
+    "insertText": "S.TaggedError<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedError<Test>",
@@ -377,7 +377,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_dotTok
     "sortText": "11",
   },
   {
-    "insertText": "S.TaggedClass<Test>("Test")("Test", {\${0}}){}",
+    "insertText": "S.TaggedClass<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedClass<Test>",
@@ -388,7 +388,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_dotTok
     "sortText": "11",
   },
   {
-    "insertText": "S.TaggedRequest<Test>("Test")("Test", {\${0}}){}",
+    "insertText": "S.TaggedRequest<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedRequest<Test>",
@@ -415,7 +415,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_tagg.t
     "sortText": "11",
   },
   {
-    "insertText": "S.TaggedError<Test>("Test")("Test", {\${0}}){}",
+    "insertText": "S.TaggedError<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedError<Test>",
@@ -426,7 +426,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_tagg.t
     "sortText": "11",
   },
   {
-    "insertText": "S.TaggedClass<Test>("Test")("Test", {\${0}}){}",
+    "insertText": "S.TaggedClass<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedClass<Test>",
@@ -437,7 +437,7 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_tagg.t
     "sortText": "11",
   },
   {
-    "insertText": "S.TaggedRequest<Test>("Test")("Test", {\${0}}){}",
+    "insertText": "S.TaggedRequest<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
     "name": "TaggedRequest<Test>",

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.codefixes
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.codefixes
@@ -1,0 +1,9 @@
+redundantSchemaTagIdentifier_removeIdentifier from 543 to 565
+redundantSchemaTagIdentifier_skipNextLine from 543 to 565
+redundantSchemaTagIdentifier_skipFile from 543 to 565
+redundantSchemaTagIdentifier_removeIdentifier from 778 to 800
+redundantSchemaTagIdentifier_skipNextLine from 778 to 800
+redundantSchemaTagIdentifier_skipFile from 778 to 800
+redundantSchemaTagIdentifier_removeIdentifier from 1024 to 1048
+redundantSchemaTagIdentifier_skipNextLine from 1024 to 1048
+redundantSchemaTagIdentifier_skipFile from 1024 to 1048

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.output
@@ -1,0 +1,8 @@
+"RedundantTaggedClass"
+15:51 - 15:73 | 2 | Identifier 'RedundantTaggedClass' is redundant since it equals the _tag value    effect(redundantSchemaTagIdentifier)
+
+"RedundantTaggedError"
+22:51 - 22:73 | 2 | Identifier 'RedundantTaggedError' is redundant since it equals the _tag value    effect(redundantSchemaTagIdentifier)
+
+"RedundantTaggedRequest"
+29:55 - 29:79 | 2 | Identifier 'RedundantTaggedRequest' is redundant since it equals the _tag value    effect(redundantSchemaTagIdentifier)

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_removeIdentifier.from1024to1048.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_removeIdentifier.from1024to1048.output
@@ -1,0 +1,35 @@
+// code fix redundantSchemaTagIdentifier_removeIdentifier  output for range 1024 - 1048
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>()("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_removeIdentifier.from543to565.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_removeIdentifier.from543to565.output
@@ -1,0 +1,35 @@
+// code fix redundantSchemaTagIdentifier_removeIdentifier  output for range 543 - 565
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>()("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_removeIdentifier.from778to800.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_removeIdentifier.from778to800.output
@@ -1,0 +1,35 @@
+// code fix redundantSchemaTagIdentifier_removeIdentifier  output for range 778 - 800
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>()("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipFile.from1024to1048.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipFile.from1024to1048.output
@@ -1,0 +1,36 @@
+// code fix redundantSchemaTagIdentifier_skipFile  output for range 1024 - 1048
+/** @effect-diagnostics redundantSchemaTagIdentifier:skip-file */
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipFile.from543to565.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipFile.from543to565.output
@@ -1,0 +1,36 @@
+// code fix redundantSchemaTagIdentifier_skipFile  output for range 543 - 565
+/** @effect-diagnostics redundantSchemaTagIdentifier:skip-file */
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipFile.from778to800.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipFile.from778to800.output
@@ -1,0 +1,36 @@
+// code fix redundantSchemaTagIdentifier_skipFile  output for range 778 - 800
+/** @effect-diagnostics redundantSchemaTagIdentifier:skip-file */
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipNextLine.from1024to1048.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipNextLine.from1024to1048.output
@@ -1,0 +1,36 @@
+// code fix redundantSchemaTagIdentifier_skipNextLine  output for range 1024 - 1048
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+// @effect-diagnostics-next-line redundantSchemaTagIdentifier:off
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipNextLine.from543to565.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipNextLine.from543to565.output
@@ -1,0 +1,36 @@
+// code fix redundantSchemaTagIdentifier_skipNextLine  output for range 543 - 565
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+// @effect-diagnostics-next-line redundantSchemaTagIdentifier:off
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}

--- a/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipNextLine.from778to800.output
+++ b/test/__snapshots__/diagnostics/redundantSchemaTagIdentifier.ts.redundantSchemaTagIdentifier_skipNextLine.from778to800.output
@@ -1,0 +1,36 @@
+// code fix redundantSchemaTagIdentifier_skipNextLine  output for range 778 - 800
+import * as Schema from "effect/Schema"
+
+// Valid usage: identifier differs from tag (no redundancy)
+export class DifferentIdentifier extends Schema.TaggedClass<DifferentIdentifier>("MyIdentifier")("MyTag", {
+  prop: Schema.String
+}) {}
+
+// Valid usage: no identifier provided (short form)
+export class NoIdentifier extends Schema.TaggedClass<NoIdentifier>()("NoIdentifier", {
+  prop: Schema.String
+}) {}
+
+// Invalid usage: identifier equals tag (redundant)
+export class RedundantTaggedClass
+  extends Schema.TaggedClass<RedundantTaggedClass>("RedundantTaggedClass")("RedundantTaggedClass", {
+    prop: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedError (redundant)
+// @effect-diagnostics-next-line redundantSchemaTagIdentifier:off
+export class RedundantTaggedError
+  extends Schema.TaggedError<RedundantTaggedError>("RedundantTaggedError")("RedundantTaggedError", {
+    message: Schema.String
+  })
+{}
+
+// Invalid usage: identifier equals tag in TaggedRequest (redundant)
+export class RedundantTaggedRequest
+  extends Schema.TaggedRequest<RedundantTaggedRequest>("RedundantTaggedRequest")("RedundantTaggedRequest", {
+    payload: {},
+    success: Schema.Void,
+    failure: Schema.Never
+  })
+{}


### PR DESCRIPTION
## Summary
- Adds a new `redundantSchemaTagIdentifier` diagnostic that suggests removing redundant identifier arguments when they equal the tag value in `Schema.TaggedClass`, `Schema.TaggedError`, or `Schema.TaggedRequest`
- Updates completions for `Schema.TaggedClass`, `Schema.TaggedError`, and `Schema.TaggedRequest` to not include the redundant identifier

## Example

**Before (diagnostic reported):**
```typescript
class MyError extends Schema.TaggedError<MyError>("MyError")("MyError", {
  message: Schema.String
}) {}
```

**After applying the fix:**
```typescript
class MyError extends Schema.TaggedError<MyError>()("MyError", {
  message: Schema.String
}) {}
```

## Test plan
- [x] Run `pnpm lint-fix` - passes
- [x] Run `pnpm check` - passes
- [x] Run `pnpm test` - all 442 tests pass
- [x] New diagnostic example file added at `examples/diagnostics/redundantSchemaTagIdentifier.ts`
- [x] Test snapshots generated for the new diagnostic

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)