### PR TITLE
chore: deprecate TypeScript Signature methods in favor of property accessors

### DIFF
--- a/.changeset/deprecate-typescript-signature-methods.md
+++ b/.changeset/deprecate-typescript-signature-methods.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Mark deprecated TypeScript Signature methods and migrate to property accessors
+
+Added `@deprecated` annotations to TypeScript Signature interface methods (`getParameters`, `getTypeParameters`, `getDeclaration`, `getReturnType`, `getTypeParameterAtPosition`) with guidance to use their modern property alternatives. Updated codebase usage of `getParameters()` to use `.parameters` property instead.

--- a/src/core/TypeParser.ts
+++ b/src/core/TypeParser.ts
@@ -2215,7 +2215,7 @@ export function make(
 
                   // Get the subject type from the first transformation's input parameter
                   if (i === 0 && callSigs.length > 0) {
-                    const params = callSigs[0].getParameters()
+                    const params = callSigs[0].parameters
                     if (params.length > 0) {
                       subjectType = typeChecker.getTypeOfSymbol(params[0])
                     }

--- a/src/core/TypeScriptApi.ts
+++ b/src/core/TypeScriptApi.ts
@@ -156,6 +156,23 @@ declare module "typescript" {
     /** @deprecated Use the `ts.idText(node)` method instead */
     readonly text: string
   }
+
+  export interface Signature {
+    /** @deprecated Use the .parameters property instead */
+    getParameters(): ReadonlyArray<ts.Symbol>
+
+    /** @deprecated Use the .typeParameters property instead */
+    getTypeParameters(): Array<ts.TypeParameter> | undefined
+
+    /** @deprecated Use the .declaration property instead */
+    getDeclaration(): ts.SignatureDeclaration
+
+    /** @deprecated Use typeChecker.getReturnTypeOfSignature instead */
+    getReturnType(): ts.Type
+
+    /** @deprecated Use typeCheckerUtils.getTypeParameterAtPosition instead */
+    getTypeParameterAtPosition(pos: number): ts.Type
+  }
 }
 
 type _TypeScriptApi = typeof ts


### PR DESCRIPTION
## Summary
- Added `@deprecated` annotations to TypeScript `Signature` interface methods in `src/core/TypeScriptApi.ts`:
  - `getParameters()` → use `.parameters` property
  - `getTypeParameters()` → use `.typeParameters` property
  - `getDeclaration()` → use `.declaration` property
  - `getReturnType()` → use `typeChecker.getReturnTypeOfSignature`
  - `getTypeParameterAtPosition()` → use `typeCheckerUtils.getTypeParameterAtPosition`
- Migrated existing usage of `getParameters()` in `src/core/TypeParser.ts:2218` to use `.parameters` property

## Test plan
- [x] `pnpm lint-fix` passes
- [x] `pnpm check` passes
- [x] `pnpm test` passes (446 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)