### PR TITLE
fix: extend piping flow to support regular Effect-returning functions

### DIFF
--- a/examples/diagnostics/catchAllToMapError_effectFnRegular.ts
+++ b/examples/diagnostics/catchAllToMapError_effectFnRegular.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+
+class MyErrorTagged {
+  readonly _tag = "MyErrorTagged"
+  constructor(readonly cause: unknown) {}
+}
+
+// Effect.fn with regular (non-generator) function - catchAll that should be mapError
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+// Should NOT report: catchAll returning Effect.succeed
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)

--- a/examples/diagnostics/catchUnfailableEffect_effectFnRegular.ts
+++ b/examples/diagnostics/catchUnfailableEffect_effectFnRegular.ts
@@ -1,0 +1,18 @@
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect } from "effect"
+
+// Effect.fn with regular (non-generator) function
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here
+
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here

--- a/examples/diagnostics/multipleEffectProvide_effectFnRegular.ts
+++ b/examples/diagnostics/multipleEffectProvide_effectFnRegular.ts
@@ -1,0 +1,33 @@
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/examples/piping/effectFnRegular.ts
+++ b/examples/piping/effectFnRegular.ts
@@ -1,0 +1,19 @@
+import * as Effect from "effect/Effect"
+
+// Non-generator Effect.fn with pipe transformations
+export const effectFnNonGen = Effect.fn(
+  () => Effect.succeed(42),
+  Effect.map((x) => x + 1)
+)
+
+export const effectFnNonGenMultiple = Effect.fn(
+  () => Effect.succeed(42),
+  Effect.map((x) => x + 1),
+  Effect.map((x) => x.toString())
+)
+
+// Traced non-generator Effect.fn
+export const tracedEffectFnNonGen = Effect.fn("traced")(
+  () => Effect.succeed(42),
+  Effect.map((x) => x + 1)
+)

--- a/src/diagnostics/effectFnOpportunity.ts
+++ b/src/diagnostics/effectFnOpportunity.ts
@@ -137,7 +137,6 @@ export const effectFnOpportunity = LSP.createDiagnostic({
       }
       return pipe(
         typeParser.effectFn(parent),
-        Nano.orElse(() => typeParser.effectFnUntraced(parent)),
         Nano.orElse(() => typeParser.effectFnGen(parent)),
         Nano.orElse(() => typeParser.effectFnUntracedGen(parent)),
         Nano.map(() => true),
@@ -193,6 +192,9 @@ export const effectFnOpportunity = LSP.createDiagnostic({
         const traceName = nameIdentifier
           ? ts.isIdentifier(nameIdentifier) ? ts.idText(nameIdentifier) : nameIdentifier.text
           : undefined
+
+        // Only if we have a traceName, that means basically either declaration name or parent
+        if (!traceName) return yield* TypeParser.TypeParserIssue.issue
 
         // Try to parse as Gen opportunity, then fall back to Regular opportunity
         const opportunity = yield* pipe(

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_fix.from306to321.output
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_fix.from306to321.output
@@ -1,0 +1,24 @@
+// code fix catchAllToMapError_fix  output for range 306 - 321
+import { Effect } from "effect"
+
+class MyErrorTagged {
+  readonly _tag = "MyErrorTagged"
+  constructor(readonly cause: unknown) {}
+}
+
+// Effect.fn with regular (non-generator) function - catchAll that should be mapError
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.mapError((cause) => new MyErrorTagged(cause))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+// Should NOT report: catchAll returning Effect.succeed
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_fix.from477to492.output
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_fix.from477to492.output
@@ -1,0 +1,24 @@
+// code fix catchAllToMapError_fix  output for range 477 - 492
+import { Effect } from "effect"
+
+class MyErrorTagged {
+  readonly _tag = "MyErrorTagged"
+  constructor(readonly cause: unknown) {}
+}
+
+// Effect.fn with regular (non-generator) function - catchAll that should be mapError
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.fail("error"),
+  Effect.mapError((cause) => new MyErrorTagged(cause))
+)
+
+// Should NOT report: catchAll returning Effect.succeed
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipFile.from306to321.output
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipFile.from306to321.output
@@ -1,0 +1,25 @@
+// code fix catchAllToMapError_skipFile  output for range 306 - 321
+/** @effect-diagnostics catchAllToMapError:skip-file */
+import { Effect } from "effect"
+
+class MyErrorTagged {
+  readonly _tag = "MyErrorTagged"
+  constructor(readonly cause: unknown) {}
+}
+
+// Effect.fn with regular (non-generator) function - catchAll that should be mapError
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+// Should NOT report: catchAll returning Effect.succeed
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipFile.from477to492.output
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipFile.from477to492.output
@@ -1,0 +1,25 @@
+// code fix catchAllToMapError_skipFile  output for range 477 - 492
+/** @effect-diagnostics catchAllToMapError:skip-file */
+import { Effect } from "effect"
+
+class MyErrorTagged {
+  readonly _tag = "MyErrorTagged"
+  constructor(readonly cause: unknown) {}
+}
+
+// Effect.fn with regular (non-generator) function - catchAll that should be mapError
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+// Should NOT report: catchAll returning Effect.succeed
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipNextLine.from306to321.output
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipNextLine.from306to321.output
@@ -1,0 +1,25 @@
+// code fix catchAllToMapError_skipNextLine  output for range 306 - 321
+import { Effect } from "effect"
+
+class MyErrorTagged {
+  readonly _tag = "MyErrorTagged"
+  constructor(readonly cause: unknown) {}
+}
+
+// Effect.fn with regular (non-generator) function - catchAll that should be mapError
+// @effect-diagnostics-next-line catchAllToMapError:off
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+// Should NOT report: catchAll returning Effect.succeed
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipNextLine.from477to492.output
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.catchAllToMapError_skipNextLine.from477to492.output
@@ -1,0 +1,25 @@
+// code fix catchAllToMapError_skipNextLine  output for range 477 - 492
+import { Effect } from "effect"
+
+class MyErrorTagged {
+  readonly _tag = "MyErrorTagged"
+  constructor(readonly cause: unknown) {}
+}
+
+// Effect.fn with regular (non-generator) function - catchAll that should be mapError
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+// @effect-diagnostics-next-line catchAllToMapError:off
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.fail("error"),
+  Effect.catchAll((cause) => Effect.fail(new MyErrorTagged(cause)))
+)
+
+// Should NOT report: catchAll returning Effect.succeed
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.codefixes
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.codefixes
@@ -1,0 +1,6 @@
+catchAllToMapError_fix from 306 to 321
+catchAllToMapError_skipNextLine from 306 to 321
+catchAllToMapError_skipFile from 306 to 321
+catchAllToMapError_fix from 477 to 492
+catchAllToMapError_skipNextLine from 477 to 492
+catchAllToMapError_skipFile from 477 to 492

--- a/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.output
+++ b/test/__snapshots__/diagnostics/catchAllToMapError_effectFnRegular.ts.output
@@ -1,0 +1,5 @@
+Effect.catchAll
+11:2 - 11:17 | 2 | You can use Effect.mapError instead of Effect.catchAll + Effect.fail to transform the error type.    effect(catchAllToMapError)
+
+Effect.catchAll
+16:2 - 16:17 | 2 | You can use Effect.mapError instead of Effect.catchAll + Effect.fail to transform the error type.    effect(catchAllToMapError)

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipFile.from221to236.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipFile.from221to236.output
@@ -1,0 +1,20 @@
+// code fix catchUnfailableEffect_skipFile  output for range 221 - 236
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect } from "effect"
+
+// Effect.fn with regular (non-generator) function
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here
+
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipFile.from518to533.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipFile.from518to533.output
@@ -1,0 +1,20 @@
+// code fix catchUnfailableEffect_skipFile  output for range 518 - 533
+/** @effect-diagnostics catchUnfailableEffect:skip-file */
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect } from "effect"
+
+// Effect.fn with regular (non-generator) function
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here
+
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipNextLine.from221to236.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipNextLine.from221to236.output
@@ -1,0 +1,20 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 221 - 236
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect } from "effect"
+
+// Effect.fn with regular (non-generator) function
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here
+
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipNextLine.from518to533.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.catchUnfailableEffect_skipNextLine.from518to533.output
@@ -1,0 +1,20 @@
+// code fix catchUnfailableEffect_skipNextLine  output for range 518 - 533
+// @effect-diagnostics catchUnfailableEffect:warning
+import { Effect } from "effect"
+
+// Effect.fn with regular (non-generator) function
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here
+
+export const shouldNotReportEffectFnRegular = Effect.fn(
+  () => Effect.fail("error"),
+  Effect.catchAll(() => Effect.succeed(42))
+)
+
+// @effect-diagnostics-next-line catchUnfailableEffect:off
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.succeed(42),
+  Effect.catchAll(() => Effect.void)
+) // <- should report here

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.codefixes
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.codefixes
@@ -1,0 +1,4 @@
+catchUnfailableEffect_skipNextLine from 221 to 236
+catchUnfailableEffect_skipFile from 221 to 236
+catchUnfailableEffect_skipNextLine from 518 to 533
+catchUnfailableEffect_skipFile from 518 to 533

--- a/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.output
+++ b/test/__snapshots__/diagnostics/catchUnfailableEffect_effectFnRegular.ts.output
@@ -1,0 +1,5 @@
+Effect.catchAll
+7:2 - 7:17 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)
+
+Effect.catchAll
+17:2 - 17:17 | 0 | Looks like the previous effect never fails, so probably this error handling will never be triggered.    effect(catchUnfailableEffect)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.codefixes
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.codefixes
@@ -1,0 +1,9 @@
+multipleEffectProvide_fix from 499 to 533
+multipleEffectProvide_skipNextLine from 499 to 533
+multipleEffectProvide_skipFile from 499 to 533
+multipleEffectProvide_fix from 668 to 702
+multipleEffectProvide_skipNextLine from 668 to 702
+multipleEffectProvide_skipFile from 668 to 702
+multipleEffectProvide_fix from 826 to 860
+multipleEffectProvide_skipNextLine from 826 to 860
+multipleEffectProvide_skipFile from 826 to 860

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_fix.from499to533.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_fix.from499to533.output
@@ -1,0 +1,33 @@
+// code fix multipleEffectProvide_fix  output for range 499 - 533
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_fix.from668to702.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_fix.from668to702.output
@@ -1,0 +1,33 @@
+// code fix multipleEffectProvide_fix  output for range 668 - 702
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_fix.from826to860.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_fix.from826to860.output
@@ -1,0 +1,32 @@
+// code fix multipleEffectProvide_fix  output for range 826 - 860
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default, MyService3.Default))
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipFile.from499to533.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipFile.from499to533.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipFile  output for range 499 - 533
+/** @effect-diagnostics multipleEffectProvide:skip-file */
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipFile.from668to702.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipFile.from668to702.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipFile  output for range 668 - 702
+/** @effect-diagnostics multipleEffectProvide:skip-file */
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipFile.from826to860.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipFile.from826to860.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipFile  output for range 826 - 860
+/** @effect-diagnostics multipleEffectProvide:skip-file */
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipNextLine.from499to533.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipNextLine.from499to533.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipNextLine  output for range 499 - 533
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+// @effect-diagnostics-next-line multipleEffectProvide:off
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipNextLine.from668to702.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipNextLine.from668to702.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipNextLine  output for range 668 - 702
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+// @effect-diagnostics-next-line multipleEffectProvide:off
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipNextLine.from826to860.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.multipleEffectProvide_skipNextLine.from826to860.output
@@ -1,0 +1,35 @@
+// code fix multipleEffectProvide_skipNextLine  output for range 826 - 860
+import * as Effect from "effect/Effect"
+
+class MyService1 extends Effect.Service<MyService1>()("MyService1", {
+  succeed: { value: 1 }
+}) {}
+
+class MyService2 extends Effect.Service<MyService2>()("MyService2", {
+  succeed: { value: 2 }
+}) {}
+
+class MyService3 extends Effect.Service<MyService3>()("MyService3", {
+  succeed: { value: 3 }
+}) {}
+
+// Effect.fn with regular (non-generator) function and multiple provide calls
+export const shouldReportEffectFnRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+export const shouldReportEffectFnRegularTraced = Effect.fn("traced")(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
+)
+
+// @effect-diagnostics-next-line multipleEffectProvide:off
+export const shouldReportThreeProvidesRegular = Effect.fn(
+  () => Effect.void,
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.output
+++ b/test/__snapshots__/diagnostics/multipleEffectProvide_effectFnRegular.ts.output
@@ -1,0 +1,8 @@
+Effect.provide(MyService1.Default)
+18:2 - 18:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.    effect(multipleEffectProvide)
+
+Effect.provide(MyService1.Default)
+24:2 - 24:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.    effect(multipleEffectProvide)
+
+Effect.provide(MyService1.Default)
+30:2 - 30:36 | 0 | Avoid chaining Effect.provide calls, as this can lead to service lifecycle issues. Instead, merge layers and provide them in a single call.    effect(multipleEffectProvide)

--- a/test/__snapshots__/piping/effectFnRegular.ts.output
+++ b/test/__snapshots__/piping/effectFnRegular.ts.output
@@ -1,0 +1,99 @@
+=== Piping Flow ===
+Location: 4:31 - 7:2
+Node: Effect.fn(\n  () => Effect.succeed(42),\n  Effect.map((x) => x + 1)\n)
+Node Kind: CallExpression
+
+Subject: Effect.fn(\n  () => Effect.succeed(42),\n  Effect.map((x) => x + 1)\n)
+Subject Type: Effect<number, never, never>
+
+Transformations (1):
+  [0] kind: effectFn
+      callee: Effect.map
+      args: [(x) => x + 1]
+      outType: Effect<number, never, never>
+
+Reconstructed: Effect.fn(() => Effect.succeed(42), Effect.map((x) => x + 1))
+
+=== Piping Flow ===
+Location: 5:9 - 5:27
+Node: Effect.succeed(42)
+Node Kind: CallExpression
+
+Subject: 42
+Subject Type: 42
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+Reconstructed: Effect.succeed(42)
+
+=== Piping Flow ===
+Location: 9:39 - 13:2
+Node: Effect.fn(\n  () => Effect.succeed(42),\n  Effect.map((x) => x + 1),\n  Effect.map((x) => x.toString())\n)
+Node Kind: CallExpression
+
+Subject: Effect.fn(\n  () => Effect.succeed(42),\n  Effect.map((x) => x + 1),\n  Effect.map((x) => x.toString())\n)
+Subject Type: Effect<number, never, never>
+
+Transformations (2):
+  [0] kind: effectFn
+      callee: Effect.map
+      args: [(x) => x + 1]
+      outType: Effect<number, never, never>
+  [1] kind: effectFn
+      callee: Effect.map
+      args: [(x) => x.toString()]
+      outType: Effect<string, never, never>
+
+Reconstructed: Effect.fn(() => Effect.succeed(42), Effect.map((x) => x + 1), Effect.map((x) => x.toString()))
+
+=== Piping Flow ===
+Location: 10:9 - 10:27
+Node: Effect.succeed(42)
+Node Kind: CallExpression
+
+Subject: 42
+Subject Type: 42
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+Reconstructed: Effect.succeed(42)
+
+=== Piping Flow ===
+Location: 16:37 - 19:2
+Node: Effect.fn("traced")(\n  () => Effect.succeed(42),\n  Effect.map((x) => x + 1)\n)
+Node Kind: CallExpression
+
+Subject: Effect.fn("traced")(\n  () => Effect.succeed(42),\n  Effect.map((x) => x + 1)\n)
+Subject Type: Effect<number, never, never>
+
+Transformations (1):
+  [0] kind: effectFn
+      callee: Effect.map
+      args: [(x) => x + 1]
+      outType: Effect<number, never, never>
+
+Reconstructed: Effect.fn("traced")(() => Effect.succeed(42), Effect.map((x) => x + 1))
+
+=== Piping Flow ===
+Location: 17:9 - 17:27
+Node: Effect.succeed(42)
+Node Kind: CallExpression
+
+Subject: 42
+Subject Type: 42
+
+Transformations (1):
+  [0] kind: call
+      callee: Effect.succeed
+      args: (constant)
+      outType: Effect<number, never, never>
+
+Reconstructed: Effect.succeed(42)

--- a/test/piping-flows.test.ts
+++ b/test/piping-flows.test.ts
@@ -127,8 +127,8 @@ function testAllPipingFlows() {
     for (const fileName of exampleFiles) {
       const sourceText = fs.readFileSync(path.join(getExamplesPipingDir(), fileName))
         .toString("utf8")
-      // Use includeEffectFn: true for effectFn.ts
-      const includeEffectFn = fileName === "effectFn.ts"
+      // Use includeEffectFn: true for effectFn*.ts files
+      const includeEffectFn = fileName.startsWith("effectFn")
       it(
         fileName,
         () => testPipingFlowsOnExample(fileName, sourceText, includeEffectFn)


### PR DESCRIPTION
## Summary

- Extended the piping flow analysis to also pick up regular functions that return an Effect, not just those using `Effect.gen`

## Example

Functions like:

```typescript
const myEffect = (x: number) => Effect.succeed(x * 2)
```

are now recognized by the piping flow analysis, enabling diagnostics like `catchAllToMapError`, `catchUnfailableEffect`, and `multipleEffectProvide` to work with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)