### PR TITLE
fix: improve missedPipeableOpportunity to check callee safety

### DIFF
--- a/.changeset/missed-pipeable-callee-safety.md
+++ b/.changeset/missed-pipeable-callee-safety.md
@@ -1,0 +1,31 @@
+---
+"@effect/language-service": patch
+---
+
+Improved `missedPipeableOpportunity` diagnostic to check if callees are safe to use in pipes without losing `this` context.
+
+The diagnostic now stops accumulating transformations when it encounters an unsafe callee (like method calls on class instances) and wraps the result with any remaining outer transformations.
+
+Safe callees include:
+- Property access on modules/namespaces (e.g., `Effect.map`)
+- Standalone function identifiers
+- Call expressions (already evaluated)
+- Arrow functions and function expressions
+
+Example - before this change, the diagnostic would incorrectly suggest:
+```typescript
+// Input
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// Would produce (incorrect - loses console.log wrapper)
+Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise)
+```
+
+Now it correctly produces:
+```typescript
+// Input
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// Output (correct - preserves console.log wrapper)
+console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+```

--- a/examples/diagnostics/missedPipeableOpportunity_safer.ts
+++ b/examples/diagnostics/missedPipeableOpportunity_safer.ts
@@ -1,0 +1,23 @@
+// @effect-diagnostics missedPipeableOpportunity:warning
+// @test-config {"pipeableMinArgCount": 2}
+import * as Effect from "effect/Effect"
+
+// this should not trigger because console.log is not a pipeable operation
+// so it would be console.log(Effect.log("Hello").pipe(Effect.runPromise))
+// which has not 2 arguments
+console.log(Effect.runPromise(Effect.log("Hello")))
+
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+console.log(
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello"))))
+    )
+  )
+)

--- a/src/cli/overview.ts
+++ b/src/cli/overview.ts
@@ -132,7 +132,7 @@ export function collectExportedItems(
 
     for (const { description, location, name, symbol, type } of exportedSymbols) {
       // Get a declaration for type parsing context
-      const declarations = symbol.getDeclarations()
+      const declarations = symbol.declarations
       const declaration = declarations && declarations.length > 0 ? declarations[0] : sourceFile
 
       // Check if it's a Context.Tag (has _Identifier and _Service variance)

--- a/src/cli/utils/ExportedSymbols.ts
+++ b/src/cli/utils/ExportedSymbols.ts
@@ -69,7 +69,7 @@ export const collectSourceFileExportedSymbols = (
   // Work queue: [symbol, qualifiedName, location | undefined, depth]
   // Initialize with exported symbols using their names and declaration locations at depth 0
   const workQueue: Array<[ts.Symbol, string, SymbolLocation | undefined, number]> = exports.map((s) => {
-    const declarations = s.getDeclarations()
+    const declarations = s.declarations
     const location = declarations && declarations.length > 0
       ? getLocationFromDeclaration(declarations[0], tsInstance)
       : undefined

--- a/src/core/TypeScriptApi.ts
+++ b/src/core/TypeScriptApi.ts
@@ -157,6 +157,11 @@ declare module "typescript" {
     readonly text: string
   }
 
+  export interface Symbol {
+    /** @deprecated Use the .declarations property instead */
+    getDeclarations(): ReadonlyArray<ts.Declaration> | undefined
+  }
+
   export interface Signature {
     /** @deprecated Use the .parameters property instead */
     getParameters(): ReadonlyArray<ts.Symbol>

--- a/src/diagnostics/effectFnOpportunity.ts
+++ b/src/diagnostics/effectFnOpportunity.ts
@@ -120,7 +120,7 @@ export const effectFnOpportunity = LSP.createDiagnostic({
 
       // Check if a symbol's declaration is within the parameters range
       const isSymbolDeclaredInParams = (symbol: ts.Symbol): boolean => {
-        const declarations = symbol.getDeclarations()
+        const declarations = symbol.declarations
         if (!declarations) return false
         return declarations.some((decl) => decl.pos >= paramsStart && decl.end <= paramsEnd)
       }

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity.ts.codefixes
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity.ts.codefixes
@@ -13,6 +13,3 @@ missedPipeableOpportunity_skipFile from 1119 to 1159
 missedPipeableOpportunity_fix from 1340 to 1377
 missedPipeableOpportunity_skipNextLine from 1340 to 1377
 missedPipeableOpportunity_skipFile from 1340 to 1377
-missedPipeableOpportunity_fix from 1649 to 1687
-missedPipeableOpportunity_skipNextLine from 1649 to 1687
-missedPipeableOpportunity_skipFile from 1649 to 1687

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity.ts.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity.ts.output
@@ -12,6 +12,3 @@ double(wrapInEffect(regularFunction(5)))
 
 triple(addHundred(double(addOne(7))))
 28:29 - 28:66 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
-
-Effect.runPromise(Effect.log("Hello"))
-36:28 - 36:66 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.codefixes
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.codefixes
@@ -1,0 +1,6 @@
+missedPipeableOpportunity_fix from 505 to 571
+missedPipeableOpportunity_skipNextLine from 505 to 571
+missedPipeableOpportunity_skipFile from 505 to 571
+missedPipeableOpportunity_fix from 841 to 979
+missedPipeableOpportunity_skipNextLine from 841 to 979
+missedPipeableOpportunity_skipFile from 841 to 979

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_fix.from505to571.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_fix.from505to571.output
@@ -1,0 +1,26 @@
+// code fix missedPipeableOpportunity_fix  output for range 505 - 571
+// @effect-diagnostics missedPipeableOpportunity:warning
+// @test-config {"pipeableMinArgCount": 2}
+import * as Effect from "effect/Effect"
+
+// this should not trigger because console.log is not a pipeable operation
+// so it would be console.log(Effect.log("Hello").pipe(Effect.runPromise))
+// which has not 2 arguments
+console.log(Effect.runPromise(Effect.log("Hello")))
+
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+console.log(
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello"))))
+    )
+  )
+)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_fix.from841to979.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_fix.from841to979.output
@@ -1,0 +1,21 @@
+// code fix missedPipeableOpportunity_fix  output for range 841 - 979
+// @effect-diagnostics missedPipeableOpportunity:warning
+// @test-config {"pipeableMinArgCount": 2}
+import * as Effect from "effect/Effect"
+
+// this should not trigger because console.log is not a pipeable operation
+// so it would be console.log(Effect.log("Hello").pipe(Effect.runPromise))
+// which has not 2 arguments
+console.log(Effect.runPromise(Effect.log("Hello")))
+
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipFile.from505to571.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipFile.from505to571.output
@@ -1,0 +1,25 @@
+// code fix missedPipeableOpportunity_skipFile  output for range 505 - 571
+/** @effect-diagnostics missedPipeableOpportunity:skip-file */
+// @effect-diagnostics missedPipeableOpportunity:warning
+// @test-config {"pipeableMinArgCount": 2}
+import * as Effect from "effect/Effect"
+
+// this should not trigger because console.log is not a pipeable operation
+// so it would be console.log(Effect.log("Hello").pipe(Effect.runPromise))
+// which has not 2 arguments
+console.log(Effect.runPromise(Effect.log("Hello")))
+
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+console.log(
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello"))))
+    )
+  )
+)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipFile.from841to979.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipFile.from841to979.output
@@ -1,0 +1,25 @@
+// code fix missedPipeableOpportunity_skipFile  output for range 841 - 979
+/** @effect-diagnostics missedPipeableOpportunity:skip-file */
+// @effect-diagnostics missedPipeableOpportunity:warning
+// @test-config {"pipeableMinArgCount": 2}
+import * as Effect from "effect/Effect"
+
+// this should not trigger because console.log is not a pipeable operation
+// so it would be console.log(Effect.log("Hello").pipe(Effect.runPromise))
+// which has not 2 arguments
+console.log(Effect.runPromise(Effect.log("Hello")))
+
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+console.log(
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello"))))
+    )
+  )
+)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipNextLine.from505to571.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipNextLine.from505to571.output
@@ -1,0 +1,25 @@
+// code fix missedPipeableOpportunity_skipNextLine  output for range 505 - 571
+// @effect-diagnostics missedPipeableOpportunity:warning
+// @test-config {"pipeableMinArgCount": 2}
+import * as Effect from "effect/Effect"
+
+// this should not trigger because console.log is not a pipeable operation
+// so it would be console.log(Effect.log("Hello").pipe(Effect.runPromise))
+// which has not 2 arguments
+console.log(Effect.runPromise(Effect.log("Hello")))
+
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+// @effect-diagnostics-next-line missedPipeableOpportunity:off
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+console.log(
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello"))))
+    )
+  )
+)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipNextLine.from841to979.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.missedPipeableOpportunity_skipNextLine.from841to979.output
@@ -1,0 +1,25 @@
+// code fix missedPipeableOpportunity_skipNextLine  output for range 841 - 979
+// @effect-diagnostics missedPipeableOpportunity:warning
+// @test-config {"pipeableMinArgCount": 2}
+import * as Effect from "effect/Effect"
+
+// this should not trigger because console.log is not a pipeable operation
+// so it would be console.log(Effect.log("Hello").pipe(Effect.runPromise))
+// which has not 2 arguments
+console.log(Effect.runPromise(Effect.log("Hello")))
+
+// this instead should trigger, but the output should be
+// console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+
+// this is silly, but shows how we can move back and forth between the two styles
+// I would expect it to be triggered, but the output should be
+// console.log(Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(Effect.ignore, Effect.runPromise))
+// @effect-diagnostics-next-line missedPipeableOpportunity:off
+console.log(
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello"))))
+    )
+  )
+)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.output
@@ -1,0 +1,11 @@
+console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
+12:0 - 12:66 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+
+console.log(
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello"))))
+    )
+  )
+)
+17:0 - 23:1 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)


### PR DESCRIPTION
## Summary

- Improved `missedPipeableOpportunity` diagnostic to check if callees are safe to use in pipes without losing `this` context
- When hitting an unsafe callee (like `console.log`), the diagnostic stops accumulating transformations and wraps the result with any remaining outer transformations
- Also replaced deprecated `symbol.getDeclarations()` with `symbol.declarations` property

## Safe callees include:
- Property access on modules/namespaces (e.g., `Effect.map`)
- Standalone function identifiers
- Call expressions (already evaluated)
- Arrow functions and function expressions

## Example

**Before this change**, the diagnostic would incorrectly suggest:
```typescript
// Input
console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))

// Would produce (incorrect - loses console.log wrapper)
Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise)
```

**Now it correctly produces:**
```typescript
// Input
console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))

// Output (correct - preserves console.log wrapper)
console.log(Effect.log("Hello").pipe(Effect.ignore, Effect.runPromise))
```

## Test plan
- [x] All 463 tests pass
- [x] Added new test example `missedPipeableOpportunity_safer.ts` with various scenarios
- [x] Verified fix output preserves outer wrappers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)