### PR TITLE
fix: improve effectFnOpportunity message for pipe transformations

### DIFF
--- a/.changeset/effectfn-pipe-args-message.md
+++ b/.changeset/effectfn-pipe-args-message.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Improved `effectFnOpportunity` diagnostic message to mention that Effect.fn accepts piped transformations as additional arguments when pipe transformations are detected.
+
+When a function has `.pipe()` calls that would be absorbed by Effect.fn, the message now includes: "Effect.fn also accepts the piped transformations as additional arguments."

--- a/src/diagnostics/effectFnOpportunity.ts
+++ b/src/diagnostics/effectFnOpportunity.ts
@@ -421,11 +421,15 @@ export const effectFnOpportunity = LSP.createDiagnostic({
         })
       }
 
+      const pipeArgsSuffix = pipeArguments.length > 0
+        ? ` Effect.fn also accepts the piped transformations as additional arguments.`
+        : ``
+
       report({
         location: nameIdentifier ?? targetNode,
         messageText: target.value.generatorFunction
-          ? `This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax.`
-          : `This function could benefit from Effect.fn's automatic tracing and concise syntax.`,
+          ? `This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax.${pipeArgsSuffix}`
+          : `This function could benefit from Effect.fn's automatic tracing and concise syntax.${pipeArgsSuffix}`,
         fixes
       })
     }

--- a/test/__snapshots__/diagnostics/effectFnOpportunity_exports.ts.output
+++ b/test/__snapshots__/diagnostics/effectFnOpportunity_exports.ts.output
@@ -5,7 +5,7 @@ withReturnTypeAnnotation
 12:16 - 12:40 | 2 | This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax.    effect(effectFnOpportunity)
 
 withoutReturnTypeAnnotation
-20:16 - 20:43 | 2 | This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax.    effect(effectFnOpportunity)
+20:16 - 20:43 | 2 | This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax. Effect.fn also accepts the piped transformations as additional arguments.    effect(effectFnOpportunity)
 
 withParameters
 28:16 - 28:30 | 2 | This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax.    effect(effectFnOpportunity)

--- a/test/__snapshots__/diagnostics/effectFnOpportunity_pipe.ts.output
+++ b/test/__snapshots__/diagnostics/effectFnOpportunity_pipe.ts.output
@@ -1,2 +1,2 @@
 shouldTrigger
-4:13 - 4:26 | 2 | This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax.    effect(effectFnOpportunity)
+4:13 - 4:26 | 2 | This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax. Effect.fn also accepts the piped transformations as additional arguments.    effect(effectFnOpportunity)


### PR DESCRIPTION
## Summary

- Improved `effectFnOpportunity` diagnostic message to mention that Effect.fn accepts piped transformations as additional arguments

## Change

When a function has `.pipe()` calls that would be absorbed by Effect.fn, the diagnostic message now includes an additional sentence:

> "Effect.fn also accepts the piped transformations as additional arguments."

**Example - before:**
```
This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax.
```

**Example - after (when pipe args are present):**
```
This function could benefit from Effect.fn's automatic tracing and concise syntax, or Effect.fnUntraced to get just a more concise syntax. Effect.fn also accepts the piped transformations as additional arguments.
```

## Test plan
- [x] All 463 tests pass
- [x] Verified message appears only when pipe transformations are detected
- [x] Verified message does not appear for cases without pipe transformations

🤖 Generated with [Claude Code](https://claude.com/claude-code)