### PR TITLE
Improve leakingRequirements diagnostic message for clarity

### DIFF
--- a/.changeset/improve-leaking-requirements-message.md
+++ b/.changeset/improve-leaking-requirements-message.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Improve `leakingRequirements` diagnostic message for clarity

--- a/src/diagnostics/leakingRequirements.ts
+++ b/src/diagnostics/leakingRequirements.ts
@@ -111,11 +111,16 @@ export const leakingRequirements = LSP.createDiagnostic({
 
     function reportLeakingRequirements(node: ts.Node, requirements: Array<ts.Type>) {
       if (requirements.length === 0) return
+      const requirementsStr = requirements.map((_) => typeChecker.typeToString(_)).join(" | ")
       report({
         location: node,
-        messageText: `This Service is leaking the ${
-          requirements.map((_) => typeChecker.typeToString(_)).join(" | ")
-        } requirement.\nIf these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can either safely disable this diagnostic for this line through quickfixes or mark the service declaration with a JSDoc @effect-leakable-service.\nServices should usually be collected in the layer creation body, and then provided at each method that requires them.\nMore info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage`,
+        messageText: `Methods of this Service require \`${requirementsStr}\` from every caller.\n\n` +
+          `This leaks implementation details into the service's public type — callers shouldn't need to know *how* the service works internally, only *what* it provides.\n\n` +
+          `Resolve these dependencies at Layer creation and provide them to each method, so the service's type reflects its purpose, not its implementation.\n\n` +
+          `To suppress this diagnostic for specific dependency types that are intentionally passed through (e.g., HttpServerRequest), add \`@effect-leakable-service\` JSDoc to their interface declarations (e.g., the \`${
+            typeChecker.typeToString(requirements[0])
+          }\` interface), not to this service.\n\n` +
+          `More info and examples at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage`,
         fixes: []
       })
     }

--- a/test/__snapshots__/diagnostics/leakingRequirements.ts.output
+++ b/test/__snapshots__/diagnostics/leakingRequirements.ts.output
@@ -1,11 +1,21 @@
 LeakingDeps
-8:13 - 8:24 | 2 | This Service is leaking the FileSystem requirement.
-If these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can either safely disable this diagnostic for this line through quickfixes or mark the service declaration with a JSDoc @effect-leakable-service.
-Services should usually be collected in the layer creation body, and then provided at each method that requires them.
-More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)
+8:13 - 8:24 | 2 | Methods of this Service require `FileSystem` from every caller.
+
+This leaks implementation details into the service's public type — callers shouldn't need to know *how* the service works internally, only *what* it provides.
+
+Resolve these dependencies at Layer creation and provide them to each method, so the service's type reflects its purpose, not its implementation.
+
+To suppress this diagnostic for specific dependency types that are intentionally passed through (e.g., HttpServerRequest), add `@effect-leakable-service` JSDoc to their interface declarations (e.g., the `FileSystem` interface), not to this service.
+
+More info and examples at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)
 
 _LocalLeaking
-18:8 - 18:21 | 2 | This Service is leaking the FileSystem requirement.
-If these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can either safely disable this diagnostic for this line through quickfixes or mark the service declaration with a JSDoc @effect-leakable-service.
-Services should usually be collected in the layer creation body, and then provided at each method that requires them.
-More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)
+18:8 - 18:21 | 2 | Methods of this Service require `FileSystem` from every caller.
+
+This leaks implementation details into the service's public type — callers shouldn't need to know *how* the service works internally, only *what* it provides.
+
+Resolve these dependencies at Layer creation and provide them to each method, so the service's type reflects its purpose, not its implementation.
+
+To suppress this diagnostic for specific dependency types that are intentionally passed through (e.g., HttpServerRequest), add `@effect-leakable-service` JSDoc to their interface declarations (e.g., the `FileSystem` interface), not to this service.
+
+More info and examples at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)

--- a/test/__snapshots__/diagnostics/leakingRequirements_genericTag.ts.output
+++ b/test/__snapshots__/diagnostics/leakingRequirements_genericTag.ts.output
@@ -1,5 +1,10 @@
 Context.GenericTag<LeakingService>("LeakingService")
-13:26 - 13:78 | 2 | This Service is leaking the FileSystem requirement.
-If these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can either safely disable this diagnostic for this line through quickfixes or mark the service declaration with a JSDoc @effect-leakable-service.
-Services should usually be collected in the layer creation body, and then provided at each method that requires them.
-More info at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)
+13:26 - 13:78 | 2 | Methods of this Service require `FileSystem` from every caller.
+
+This leaks implementation details into the service's public type — callers shouldn't need to know *how* the service works internally, only *what* it provides.
+
+Resolve these dependencies at Layer creation and provide them to each method, so the service's type reflects its purpose, not its implementation.
+
+To suppress this diagnostic for specific dependency types that are intentionally passed through (e.g., HttpServerRequest), add `@effect-leakable-service` JSDoc to their interface declarations (e.g., the `FileSystem` interface), not to this service.
+
+More info and examples at https://effect.website/docs/requirements-management/layers/#avoiding-requirement-leakage    effect(leakingRequirements)


### PR DESCRIPTION
## Summary

- Rewrote the `leakingRequirements` diagnostic message to be clearer and more actionable
- The new message explains *why* leaking implementation details is problematic (callers shouldn't need to know how the service works internally)
- Clarifies that `@effect-leakable-service` JSDoc should be added to the dependency interface declarations, not to the service itself

**Before:**
> This Service is leaking the FileSystem | Path requirement. If these requirements cannot be cached and are expected to be provided per method invocation (e.g. HttpServerRequest), you can either safely disable this diagnostic for this line through quickfixes or mark the service declaration with a JSDoc @effect-leakable-service. Services should usually be collected in the layer creation body, and then provided at each method that requires them.

**After:**
> Methods of this Service require `FileSystem | Path` from every caller.
>
> This leaks implementation details into the service's public type — callers shouldn't need to know *how* the service works internally, only *what* it provides.
>
> Resolve these dependencies at Layer creation and provide them to each method, so the service's type reflects its purpose, not its implementation.
>
> To suppress this diagnostic for specific dependency types that are intentionally passed through (e.g., HttpServerRequest), add `@effect-leakable-service` JSDoc to their interface declarations (e.g., the `FileSystem` interface), not to this service.

## Test plan

- [x] Existing tests pass with updated snapshots
- [x] `pnpm lint-fix` passes
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)