### PR TITLE
improve effectFnIife diagnostic to suggest withSpan when trace name exists

### DIFF
--- a/.changeset/improve-effectfniife-message.md
+++ b/.changeset/improve-effectfniife-message.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Improve effectFnIife diagnostic message to suggest Effect.withSpan with the trace name when available
+
+When `Effect.fn("traceName")` is used as an IIFE, the diagnostic now suggests using `Effect.gen` with `Effect.withSpan("traceName")` piped at the end to maintain tracing spans. For `Effect.fnUntraced`, it simply suggests using `Effect.gen` without the span suggestion.

--- a/src/core/TypeParser.ts
+++ b/src/core/TypeParser.ts
@@ -128,6 +128,7 @@ export interface TypeParser {
       effectModule: ts.Node
       body: ts.Block
       pipeArguments: ReadonlyArray<ts.Expression>
+      traceExpression: ts.Expression | undefined
     },
     TypeParserIssue
   >
@@ -154,6 +155,7 @@ export interface TypeParser {
       effectModule: ts.Node
       regularFunction: ts.FunctionExpression | ts.ArrowFunction
       pipeArguments: ReadonlyArray<ts.Expression>
+      traceExpression: ts.Expression | undefined
     },
     TypeParserIssue
   >
@@ -1022,6 +1024,10 @@ export function make(
           node
         )
       }
+      const traceExpression: ts.Expression | undefined =
+        ts.isCallExpression(node.expression) && node.expression.arguments.length > 0
+          ? node.expression.arguments[0]
+          : undefined
       const propertyAccess = expressionToTest
       const pipeArguments = node.arguments.slice(1)
       return pipe(
@@ -1031,7 +1037,8 @@ export function make(
           generatorFunction,
           effectModule: propertyAccess.expression,
           body: generatorFunction.body,
-          pipeArguments
+          pipeArguments,
+          traceExpression
         }))
       )
     },
@@ -1147,6 +1154,10 @@ export function make(
       if (!ts.isPropertyAccessExpression(expressionToTest)) {
         return typeParserIssue("Node is not a property access expression", undefined, node)
       }
+      const traceExpression: ts.Expression | undefined =
+        ts.isCallExpression(node.expression) && node.expression.arguments.length > 0
+          ? node.expression.arguments[0]
+          : undefined
       const propertyAccess = expressionToTest
       const pipeArguments = node.arguments.slice(1)
       return pipe(
@@ -1155,7 +1166,8 @@ export function make(
           node,
           effectModule: propertyAccess.expression,
           regularFunction,
-          pipeArguments
+          pipeArguments,
+          traceExpression
         }))
       )
     },

--- a/test/__snapshots__/diagnostics/effectFnIife.ts.output
+++ b/test/__snapshots__/diagnostics/effectFnIife.ts.output
@@ -1,33 +1,33 @@
 Effect.fn("test")(function*() {
   yield* Effect.succeed(1)
 })()
-4:21 - 6:4 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).    effect(effectFnIife)
+4:21 - 6:4 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead with Effect.withSpan("test") piped in the end to mantain tracing spans.    effect(effectFnIife)
 
 Effect.fn("named")(function*() {
   yield* Effect.succeed(1)
   return 42
 })()
-9:21 - 12:4 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).    effect(effectFnIife)
+9:21 - 12:4 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead with Effect.withSpan("named") piped in the end to mantain tracing spans.    effect(effectFnIife)
 
 Effect.fnUntraced(function*() {
   yield* Effect.succeed(1)
 })()
-15:21 - 17:4 | 0 | Effect.fnUntraced returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).    effect(effectFnIife)
+15:21 - 17:4 | 0 | Effect.fnUntraced returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead.    effect(effectFnIife)
 
 Effect.fn("arrow")(() => Effect.succeed(1))()
-20:21 - 20:66 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).    effect(effectFnIife)
+20:21 - 20:66 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead with Effect.withSpan("arrow") piped in the end to mantain tracing spans.    effect(effectFnIife)
 
 Effect.fn("func")(function() {
   return Effect.succeed(1)
 })()
-23:21 - 25:4 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).    effect(effectFnIife)
+23:21 - 25:4 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead with Effect.withSpan("func") piped in the end to mantain tracing spans.    effect(effectFnIife)
 
 Effect.fn("piped")(function*() {
   return yield* Effect.succeed(1)
 }, Effect.map((n) => n + 1))()
-28:21 - 30:30 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).    effect(effectFnIife)
+28:21 - 30:30 | 0 | Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead with Effect.withSpan("piped") piped in the end to mantain tracing spans.    effect(effectFnIife)
 
 Effect.fnUntraced(function*() {
   return yield* Effect.succeed(1)
 }, Effect.map((n) => n + 1))()
-33:21 - 35:30 | 0 | Effect.fnUntraced returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).    effect(effectFnIife)
+33:21 - 35:30 | 0 | Effect.fnUntraced returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead.    effect(effectFnIife)


### PR DESCRIPTION
## Summary
- Enhanced `effectFnIife` diagnostic to provide more helpful suggestions when `Effect.fn` is used with a trace name
- When `Effect.fn("traceName")` is used as an IIFE, the diagnostic now suggests using `Effect.withSpan("traceName")` piped at the end to maintain tracing spans
- For `Effect.fnUntraced`, the message simply suggests `Effect.gen` without the span suggestion

## Example

Before:
```
Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead (optionally with Effect.withSpan for tracing).
```

After (with trace name):
```
Effect.fn returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead with Effect.withSpan("traceName") piped in the end to mantain tracing spans.
```

After (fnUntraced):
```
Effect.fnUntraced returns a reusable function that can take arguments, but here it's called immediately. Use Effect.gen instead.
```

## Test plan
- [x] Tests pass (`pnpm test`)
- [x] Type checks pass (`pnpm check`)
- [x] Lint passes (`pnpm lint-fix`)
- [x] Snapshot updated to reflect new message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)