### PR TITLE
Improve missedPipeableOpportunity diagnostic message to show subject

### DIFF
--- a/.changeset/improve-missed-pipeable-message.md
+++ b/.changeset/improve-missed-pipeable-message.md
@@ -1,0 +1,15 @@
+---
+"@effect/language-service": patch
+---
+
+Improve `missedPipeableOpportunity` diagnostic message to show the suggested subject for `.pipe(...)`.
+
+Before:
+```
+Nested function calls can be converted to pipeable style for better readability.
+```
+
+After:
+```
+Nested function calls can be converted to pipeable style for better readability; consider using addOne(5).pipe(...) instead.
+```

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity.ts.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity.ts.output
@@ -1,14 +1,14 @@
 toString(double(addOne(5)))
-12:29 - 12:56 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+12:29 - 12:56 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using addOne(5).pipe(...) instead.    effect(missedPipeableOpportunity)
 
 toString(triple(double(addOne(10))))
-16:29 - 16:65 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+16:29 - 16:65 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using addOne(10).pipe(...) instead.    effect(missedPipeableOpportunity)
 
 double(addOne(5))
-19:29 - 19:46 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+19:29 - 19:46 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using addOne(5).pipe(...) instead.    effect(missedPipeableOpportunity)
 
 double(wrapInEffect(regularFunction(5)))
-24:32 - 24:72 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+24:32 - 24:72 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using wrapInEffect(regularFunction(5)).pipe(...) instead.    effect(missedPipeableOpportunity)
 
 triple(addHundred(double(addOne(7))))
-28:29 - 28:66 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+28:29 - 28:66 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using addOne(7).pipe(...) instead.    effect(missedPipeableOpportunity)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_error.ts.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_error.ts.output
@@ -1,2 +1,2 @@
 identity(identity(Schema.decodeUnknown(MyStruct)({ x: 42, y: 42 })))
-13:40 - 13:108 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+13:40 - 13:108 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using Schema.decodeUnknown(MyStruct)({ x: 42, y: 42 }).pipe(...) instead.    effect(missedPipeableOpportunity)

--- a/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.output
+++ b/test/__snapshots__/diagnostics/missedPipeableOpportunity_safer.ts.output
@@ -1,5 +1,5 @@
 console.log(Effect.runPromise(Effect.ignore(Effect.log("Hello"))))
-12:0 - 12:66 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+12:0 - 12:66 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using Effect.log("Hello").pipe(...) instead.    effect(missedPipeableOpportunity)
 
 console.log(
   Effect.runPromise(
@@ -8,4 +8,4 @@ console.log(
     )
   )
 )
-17:0 - 23:1 | 0 | Nested function calls can be converted to pipeable style for better readability.    effect(missedPipeableOpportunity)
+17:0 - 23:1 | 0 | Nested function calls can be converted to pipeable style for better readability; consider using Effect.succeed(console.log(Effect.runPromise(Effect.log("Hello")))).pipe(...) instead.    effect(missedPipeableOpportunity)


### PR DESCRIPTION
## Summary
- Improved the `missedPipeableOpportunity` diagnostic message to include the suggested subject expression
- The message now shows what expression should be used with `.pipe(...)` instead of a generic message

**Before:**
```
Nested function calls can be converted to pipeable style for better readability.
```

**After:**
```
Nested function calls can be converted to pipeable style for better readability; consider using addOne(5).pipe(...) instead.
```

## Test plan
- [x] All existing tests pass
- [x] Snapshot tests updated with new message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)