### PR TITLE
Improve global Error diagnostic messages

### DIFF
--- a/.changeset/improve-global-error-diagnostic-messages.md
+++ b/.changeset/improve-global-error-diagnostic-messages.md
@@ -1,0 +1,15 @@
+---
+"@effect/language-service": patch
+---
+
+Improve diagnostic messages for `globalErrorInEffectFailure` and `globalErrorInEffectCatch` to be more concise and actionable.
+
+Before:
+```
+The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.
+```
+
+After:
+```
+Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.
+```

--- a/src/diagnostics/globalErrorInEffectCatch.ts
+++ b/src/diagnostics/globalErrorInEffectCatch.ts
@@ -64,7 +64,7 @@ export const globalErrorInEffectCatch = LSP.createDiagnostic({
                   report({
                     location: node.expression,
                     messageText:
-                      `The 'catch' callback in ${nodeText} returns the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together.\nInstead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.`,
+                      `The 'catch' callback in ${nodeText} returns global 'Error', which loses type safety as untagged errors merge together. Consider using a tagged error and optionally wrapping the original in a 'cause' property.`,
                     fixes: []
                   })
                 }

--- a/src/diagnostics/globalErrorInEffectFailure.ts
+++ b/src/diagnostics/globalErrorInEffectFailure.ts
@@ -59,7 +59,7 @@ export const globalErrorInEffectFailure = LSP.createDiagnostic({
                 report({
                   location: node,
                   messageText:
-                    `The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.`,
+                    `Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.`,
                   fixes: []
                 })
               }

--- a/test/__snapshots__/diagnostics/globalErrorInEffectCatch.ts.output
+++ b/test/__snapshots__/diagnostics/globalErrorInEffectCatch.ts.output
@@ -1,7 +1,5 @@
 Effect.tryPromise
-13:35 - 13:52 | 0 | The 'catch' callback in Effect.tryPromise returns the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together.
-Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectCatch)
+13:35 - 13:52 | 0 | The 'catch' callback in Effect.tryPromise returns global 'Error', which loses type safety as untagged errors merge together. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectCatch)
 
 Effect.tryMapPromise
-23:60 - 23:80 | 0 | The 'catch' callback in Effect.tryMapPromise returns the global Error type. It's not recommended to use the global Error type in Effect failures as they can get merged together.
-Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectCatch)
+23:60 - 23:80 | 0 | The 'catch' callback in Effect.tryMapPromise returns global 'Error', which loses type safety as untagged errors merge together. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectCatch)

--- a/test/__snapshots__/diagnostics/globalErrorInEffectFailure.ts.output
+++ b/test/__snapshots__/diagnostics/globalErrorInEffectFailure.ts.output
@@ -1,17 +1,17 @@
 new Error("global error")
-7:40 - 7:65 | 0 | The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+7:40 - 7:65 | 0 | Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectFailure)
 
 new globalThis.Error("global error")
-8:41 - 8:77 | 0 | The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+8:41 - 8:77 | 0 | Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectFailure)
 
 new BaseExtendsError()
-14:41 - 14:63 | 0 | The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+14:41 - 14:63 | 0 | Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectFailure)
 
 new Error("global error in gen")
-27:28 - 27:60 | 0 | The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+27:28 - 27:60 | 0 | Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectFailure)
 
 new Error("global error in map")
-37:35 - 37:67 | 0 | The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+37:35 - 37:67 | 0 | Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectFailure)
 
 new Error("mapped to global error")
-47:24 - 47:59 | 0 | The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.    effect(globalErrorInEffectFailure)
+47:24 - 47:59 | 0 | Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.    effect(globalErrorInEffectFailure)


### PR DESCRIPTION
## Summary
- Make `globalErrorInEffectFailure` and `globalErrorInEffectCatch` diagnostic messages more concise and actionable
- Lead with the problem (type safety loss) and end with actionable guidance (use tagged errors, wrap in cause)

## Example

Before:
```
The global Error type is used in an Effect failure channel. It's not recommended to use the global Error type in Effect failures as they can get merged together. Instead, use tagged errors or custom errors with a discriminator property to get properly type-checked errors.
```

After:
```
Global 'Error' loses type safety as untagged errors merge together in the Effect failure channel. Consider using a tagged error and optionally wrapping the original in a 'cause' property.
```

## Test plan
- [x] `pnpm lint-fix` passes
- [x] `pnpm check` passes
- [x] `pnpm test` passes (489 tests)
- [x] Snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)