### PR TITLE
Add ignoreEffectWarningsInTscExitCode option

### DIFF
--- a/.changeset/ignore-effect-warnings-exit-code.md
+++ b/.changeset/ignore-effect-warnings-exit-code.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add `ignoreEffectWarningsInTscExitCode` option to allow Effect-related warnings to not affect the TSC exit code. When enabled, `tsc` will compile successfully even if Effect warnings are emitted. This is useful for CI/CD pipelines where Effect diagnostics should be informational rather than blocking.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Few options can be provided alongside the initialization of the Language Service
         "diagnosticsName": true, // controls whether to include the rule name in diagnostic messages (default: true)
         "missingDiagnosticNextLine": "warning", // controls the severity of warnings for unused @effect-diagnostics-next-line comments (default: "warning", allowed values: off,error,warning,message,suggestion)
         "includeSuggestionsInTsc": true, // when enabled with effect-language-service patch enabled, diagnostics with "suggestion" severity will be reported as "message" in TSC with "[suggestion]" prefix; useful to help steer LLM output (default: true)
+        "ignoreEffectWarningsInTscExitCode": false, // if set to true, effect-related warnings won't change the exit code of tsc, meaning that tsc will compile fine even if effect warnings are emitted (default: false)
         "quickinfo": true, // controls Effect quickinfo (default: true)
         "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
         "quickinfoMaximumLength": -1, // controls how long can be the types in the quickinfo hover (helps with very long type to improve perfs, defaults to -1 for no truncation, can be any number eg. 1000 and TS will try to fit as much as possible in that budget, higher number means more info.)

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -22,6 +22,7 @@ export interface LanguageServicePluginOptions {
   diagnosticsName: boolean
   missingDiagnosticNextLine: DiagnosticSeverity | "off"
   includeSuggestionsInTsc: boolean
+  ignoreEffectWarningsInTscExitCode: boolean
   quickinfoEffectParameters: "always" | "never" | "whentruncated"
   quickinfo: boolean
   quickinfoMaximumLength: number
@@ -91,6 +92,7 @@ export const defaults: LanguageServicePluginOptions = {
     skipLeadingPath: ["src/"]
   }],
   extendedKeyDetection: false,
+  ignoreEffectWarningsInTscExitCode: false,
   pipeableMinArgCount: 2,
   effectFn: ["span"],
   layerGraphFollowDepth: 0,
@@ -142,6 +144,10 @@ export function parse(config: any): LanguageServicePluginOptions {
         isBoolean(config.includeSuggestionsInTsc)
       ? config.includeSuggestionsInTsc
       : defaults.includeSuggestionsInTsc,
+    ignoreEffectWarningsInTscExitCode: isObject(config) && hasProperty(config, "ignoreEffectWarningsInTscExitCode") &&
+        isBoolean(config.ignoreEffectWarningsInTscExitCode)
+      ? config.ignoreEffectWarningsInTscExitCode
+      : defaults.ignoreEffectWarningsInTscExitCode,
     quickinfo: isObject(config) && hasProperty(config, "quickinfo") && isBoolean(config.quickinfo)
       ? config.quickinfo
       : defaults.quickinfo,

--- a/src/effect-lsp-patch-utils.ts
+++ b/src/effect-lsp-patch-utils.ts
@@ -105,3 +105,28 @@ export function checkSourceFileWorker(
     Array.map(addDiagnostic)
   )
 }
+
+export function extractDiagnosticsForExitStatus(
+  tsInstance: TypeScriptApi.TypeScriptApi,
+  program: ts.Program,
+  diagnostics: Array<ts.Diagnostic>,
+  _moduleName: string
+) {
+  // always exclude suggestions
+  let newDiagnostics = Array.filter(
+    diagnostics,
+    (_) => !(_.source === "effect" && _.category === tsInstance.DiagnosticCategory.Message)
+  )
+  const options = extractEffectLspOptions(program.getCompilerOptions())
+  const parsedOptions = LanguageServicePluginOptions.parse(options)
+
+  // if the option is enabled, exclude warnings
+  if (parsedOptions.ignoreEffectWarningsInTscExitCode) {
+    newDiagnostics = Array.filter(
+      newDiagnostics,
+      (_) => !(_.source === "effect" && _.category === tsInstance.DiagnosticCategory.Warning)
+    )
+  }
+
+  return newDiagnostics
+}


### PR DESCRIPTION
## Summary
- Add `ignoreEffectWarningsInTscExitCode` configuration option that allows Effect-related warnings to not affect the TSC exit code
- When enabled (set to `true`), `tsc` will compile successfully (exit code 0) even if Effect warnings are emitted
- Useful for CI/CD pipelines where Effect diagnostics should be informational rather than blocking

## Configuration Example

```json
{
  "compilerOptions": {
    "plugins": [{
      "name": "@effect/language-service",
      "ignoreEffectWarningsInTscExitCode": true
    }]
  }
}
```

## Test plan
- [x] Lint passes (`pnpm lint-fix`)
- [x] Type check passes (`pnpm check`)
- [x] All 489 tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)