### PR TITLE
Add ignoreEffectSuggestionsInTscExitCode option

### DIFF
--- a/.changeset/ignore-effect-suggestions-exit-code.md
+++ b/.changeset/ignore-effect-suggestions-exit-code.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Add `ignoreEffectSuggestionsInTscExitCode` option (default: `true`) to control whether Effect-related suggestions affect the TSC exit code. When enabled, suggestions won't cause `tsc` to return a non-zero exit code.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Few options can be provided alongside the initialization of the Language Service
         "missingDiagnosticNextLine": "warning", // controls the severity of warnings for unused @effect-diagnostics-next-line comments (default: "warning", allowed values: off,error,warning,message,suggestion)
         "includeSuggestionsInTsc": true, // when enabled with effect-language-service patch enabled, diagnostics with "suggestion" severity will be reported as "message" in TSC with "[suggestion]" prefix; useful to help steer LLM output (default: true)
         "ignoreEffectWarningsInTscExitCode": false, // if set to true, effect-related warnings won't change the exit code of tsc, meaning that tsc will compile fine even if effect warnings are emitted (default: false)
+        "ignoreEffectSuggestionsInTscExitCode": true, // if set to true, effect-related suggestions won't change the exit code of tsc (default: true)
         "quickinfo": true, // controls Effect quickinfo (default: true)
         "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
         "quickinfoMaximumLength": -1, // controls how long can be the types in the quickinfo hover (helps with very long type to improve perfs, defaults to -1 for no truncation, can be any number eg. 1000 and TS will try to fit as much as possible in that budget, higher number means more info.)

--- a/src/core/LanguageServicePluginOptions.ts
+++ b/src/core/LanguageServicePluginOptions.ts
@@ -23,6 +23,7 @@ export interface LanguageServicePluginOptions {
   missingDiagnosticNextLine: DiagnosticSeverity | "off"
   includeSuggestionsInTsc: boolean
   ignoreEffectWarningsInTscExitCode: boolean
+  ignoreEffectSuggestionsInTscExitCode: boolean
   quickinfoEffectParameters: "always" | "never" | "whentruncated"
   quickinfo: boolean
   quickinfoMaximumLength: number
@@ -93,6 +94,7 @@ export const defaults: LanguageServicePluginOptions = {
   }],
   extendedKeyDetection: false,
   ignoreEffectWarningsInTscExitCode: false,
+  ignoreEffectSuggestionsInTscExitCode: true,
   pipeableMinArgCount: 2,
   effectFn: ["span"],
   layerGraphFollowDepth: 0,
@@ -148,6 +150,11 @@ export function parse(config: any): LanguageServicePluginOptions {
         isBoolean(config.ignoreEffectWarningsInTscExitCode)
       ? config.ignoreEffectWarningsInTscExitCode
       : defaults.ignoreEffectWarningsInTscExitCode,
+    ignoreEffectSuggestionsInTscExitCode:
+      isObject(config) && hasProperty(config, "ignoreEffectSuggestionsInTscExitCode") &&
+        isBoolean(config.ignoreEffectSuggestionsInTscExitCode)
+        ? config.ignoreEffectSuggestionsInTscExitCode
+        : defaults.ignoreEffectSuggestionsInTscExitCode,
     quickinfo: isObject(config) && hasProperty(config, "quickinfo") && isBoolean(config.quickinfo)
       ? config.quickinfo
       : defaults.quickinfo,

--- a/src/effect-lsp-patch-utils.ts
+++ b/src/effect-lsp-patch-utils.ts
@@ -112,13 +112,18 @@ export function extractDiagnosticsForExitStatus(
   diagnostics: Array<ts.Diagnostic>,
   _moduleName: string
 ) {
-  // always exclude suggestions
-  let newDiagnostics = Array.filter(
-    diagnostics,
-    (_) => !(_.source === "effect" && _.category === tsInstance.DiagnosticCategory.Message)
-  )
   const options = extractEffectLspOptions(program.getCompilerOptions())
   const parsedOptions = LanguageServicePluginOptions.parse(options)
+
+  let newDiagnostics = diagnostics
+
+  // if the option is enabled, exclude suggestions
+  if (parsedOptions.ignoreEffectSuggestionsInTscExitCode) {
+    newDiagnostics = Array.filter(
+      newDiagnostics,
+      (_) => !(_.source === "effect" && _.category === tsInstance.DiagnosticCategory.Message)
+    )
+  }
 
   // if the option is enabled, exclude warnings
   if (parsedOptions.ignoreEffectWarningsInTscExitCode) {


### PR DESCRIPTION
## Summary
- Add `ignoreEffectSuggestionsInTscExitCode` configuration option (default: `true`)
- Controls whether Effect-related suggestions affect the TSC exit code
- When enabled, suggestions won't cause `tsc` to return a non-zero exit code
- Makes the existing behavior (always filtering suggestions) configurable

## Configuration Example

```json
{
  "compilerOptions": {
    "plugins": [{
      "name": "@effect/language-service",
      "ignoreEffectSuggestionsInTscExitCode": true
    }]
  }
}
```

## Test plan
- [x] Lint passes (`pnpm lint-fix`)
- [x] Type check passes (`pnpm check`)
- [x] All 489 tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)