### PR TITLE
Fix effectGenToFn return type conversion

### DIFF
--- a/.changeset/effectgentofn-return-type.md
+++ b/.changeset/effectgentofn-return-type.md
@@ -1,0 +1,18 @@
+---
+"@effect/language-service": patch
+---
+
+Fix effectGenToFn refactor to convert `Effect<A, E, R>` return types to `Effect.fn.Return<A, E, R>`
+
+Before this fix, the "Convert to fn" refactor would keep the original `Effect.Effect<A, E, R>` return type, producing code that doesn't compile. Now it correctly transforms the return type:
+
+```ts
+// Before refactor
+const someFunction = (value: string): Effect.Effect<number, boolean> =>
+  Effect.gen(function* () { /* ... */ })
+
+// After refactor (fixed)
+const someFunction = Effect.fn("someFunction")(function* (value: string): Effect.fn.Return<number, boolean, never> {
+  /* ... */
+})
+```

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectGenToFn_returns.ts.ln11col19.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectGenToFn_returns.ts.ln11col19.output
@@ -1,0 +1,16 @@
+// Result of running refactor effectGenToFn at position 11:19
+import * as Eff from "effect/Effect"
+
+export const sampleReturnsConciseBody = <A extends number, B extends number>(arg1: A, arg2: B): Eff.Effect<number> =>
+    Eff.gen(function*() {
+      const a = yield* Eff.succeed(arg1)
+      const b = yield* Eff.succeed(arg2)
+      return a + b
+    })
+
+export const withGenerics = Eff.fn("withGenerics")(function* <A extends number, B>(a: A, b: B): Eff.fn.Return<A, B, never> {
+    if (Math.random() > 0.5) {
+        return yield* Eff.fail(b)
+    }
+    return a
+})

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectGenToFn_returns.ts.ln4col19.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectGenToFn_returns.ts.ln4col19.output
@@ -1,0 +1,16 @@
+// Result of running refactor effectGenToFn at position 4:19
+import * as Eff from "effect/Effect"
+
+export const sampleReturnsConciseBody = Eff.fn("sampleReturnsConciseBody")(function* <A extends number, B extends number>(arg1: A, arg2: B): Eff.fn.Return<number, never, never> {
+    const a = yield* Eff.succeed(arg1)
+    const b = yield* Eff.succeed(arg2)
+    return a + b
+})
+
+export const withGenerics = <A extends number, B>(a: A, b: B): Eff.Effect<A, B> =>
+    Eff.gen(function*() {
+        if(Math.random() > 0.5){
+            return yield* Eff.fail(b)
+        }
+        return a
+    })

--- a/packages/harness-effect-v3/examples/refactors/effectGenToFn_returns.ts
+++ b/packages/harness-effect-v3/examples/refactors/effectGenToFn_returns.ts
@@ -1,0 +1,17 @@
+// 4:19, 11:19
+import * as Eff from "effect/Effect"
+
+export const sampleReturnsConciseBody = <A extends number, B extends number>(arg1: A, arg2: B): Eff.Effect<number> =>
+    Eff.gen(function*() {
+      const a = yield* Eff.succeed(arg1)
+      const b = yield* Eff.succeed(arg2)
+      return a + b
+    })
+
+export const withGenerics = <A extends number, B>(a: A, b: B): Eff.Effect<A, B> =>
+    Eff.gen(function*() {
+        if(Math.random() > 0.5){
+            return yield* Eff.fail(b)
+        }
+        return a
+    })


### PR DESCRIPTION
## Summary

- Fixes the `effectGenToFn` refactor to correctly convert `Effect<A, E, R>` return type annotations to `Effect.fn.Return<A, E, R>` when transforming `Effect.gen` to `Effect.fn`
- Previously the refactor kept the original `Effect.Effect<...>` return type, producing code that doesn't compile
- Resolves the imported Effect module identifier to use in the generated `Effect.fn.Return` type reference

## Example

Before this fix, the refactor would produce:

```ts
// Broken output (doesn't compile)
const someFunction = Effect.fn("someFunction")(function* (value: string): Effect.Effect<number, boolean> {
  // ...
})
```

After this fix:

```ts
// Correct output
const someFunction = Effect.fn("someFunction")(function* (value: string): Effect.fn.Return<number, boolean, never> {
  // ...
})
```

## Test plan

- [x] Added test example `effectGenToFn_returns.ts` with two cases (concise body and generics)
- [x] Verified snapshot outputs show correct `Effect.fn.Return<A, E, R>` type
- [x] All 491 existing tests pass
- [x] TypeScript type checking passes

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)