### PR TITLE
Disable schemaUnionOfLiterals diagnostic for Effect v4

### DIFF
--- a/.changeset/disable-schema-union-of-literals-v4.md
+++ b/.changeset/disable-schema-union-of-literals-v4.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Disable `schemaUnionOfLiterals` diagnostic for Effect v4, as `Schema.Union` of multiple `Schema.Literal` calls is no longer applicable in v4.

--- a/packages/language-service/src/diagnostics/schemaUnionOfLiterals.ts
+++ b/packages/language-service/src/diagnostics/schemaUnionOfLiterals.ts
@@ -14,6 +14,7 @@ export const schemaUnionOfLiterals = LSP.createDiagnostic({
   apply: Nano.fn("schemaUnionOfLiterals.apply")(function*(sourceFile, report) {
     const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
     const typeParser = yield* Nano.service(TypeParser.TypeParser)
+    if (typeParser.supportedEffect() === "v4") return
 
     const nodeToVisit: Array<ts.Node> = []
     const appendNodeToVisit = (node: ts.Node) => {


### PR DESCRIPTION
## Summary
- Disables the `schemaUnionOfLiterals` diagnostic when the detected Effect version is v4
- The `Schema.Union` of multiple `Schema.Literal` calls simplification is no longer applicable in Effect v4

### Example

The diagnostic that suggests simplifying:
```ts
Schema.Union(Schema.Literal("a"), Schema.Literal("b"))
// → Schema.Literal("a", "b")
```
is now skipped when using Effect v4, as this pattern no longer applies.

## Test plan
- [x] `pnpm lint-fix` passes
- [x] `pnpm check` passes  
- [x] `pnpm test` passes (493 tests across v3 and v4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)