### PR TITLE
Add ServiceMap.Service completion and fix Schema class completions for Effect v4

### DIFF
--- a/.changeset/service-map-completions.md
+++ b/.changeset/service-map-completions.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add `ServiceMap.Service` class completion for Effect v4, and fix Schema class completions for v4 (`TaggedErrorClass`, `TaggedClass` now available, `ErrorClass` fully-qualified form fixed, `RequestClass` removed)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 
 ### Completions
 
-- Autocomplete 'Self' in `Effect.Service`, `Context.Tag`, `Schema.TaggedClass`, `Schema.TaggedRequest`, `Model.Class` and family
+- Autocomplete 'Self' in `Effect.Service`, `Context.Tag`, `Schema.TaggedClass`, `Schema.TaggedRequest`, `ServiceMap.Service`, `Model.Class` and family
 - Autocomplete `Effect.gen` with `function*(){}`
 - Autocomplete `Effect.fn` with the span name given by the exported member
 - Completions for DurationInput string millis/seconds/etc...

--- a/packages/harness-effect-v4/__snapshots__/completions.test.ts.snap
+++ b/packages/harness-effect-v4/__snapshots__/completions.test.ts.snap
@@ -213,10 +213,10 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_dotTok
     "sortText": "11",
   },
   {
-    "insertText": "S.ErrorClass<Test>()({\${0}}){}",
+    "insertText": "S.TaggedErrorClass<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
-    "name": "ErrorClass<Test>",
+    "name": "TaggedError<Test>",
     "replacementSpan": {
       "length": 2,
       "start": 130,
@@ -224,10 +224,21 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_dotTok
     "sortText": "11",
   },
   {
-    "insertText": "S.RequestClass<Test>("Test")({\${0}}){}",
+    "insertText": "S.TaggedClass<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
-    "name": "RequestClass<Test>",
+    "name": "TaggedClass<Test>",
+    "replacementSpan": {
+      "length": 2,
+      "start": 130,
+    },
+    "sortText": "11",
+  },
+  {
+    "insertText": "S.ErrorClass<Test>("Test")({\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "ErrorClass<Test>",
     "replacementSpan": {
       "length": 2,
       "start": 130,
@@ -251,10 +262,10 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_tagg.t
     "sortText": "11",
   },
   {
-    "insertText": "S.ErrorClass<Test>()({\${0}}){}",
+    "insertText": "S.TaggedErrorClass<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
-    "name": "ErrorClass<Test>",
+    "name": "TaggedError<Test>",
     "replacementSpan": {
       "length": 5,
       "start": 130,
@@ -262,10 +273,21 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_tagg.t
     "sortText": "11",
   },
   {
-    "insertText": "S.RequestClass<Test>("Test")({\${0}}){}",
+    "insertText": "S.TaggedClass<Test>()("Test", {\${0}}){}",
     "isSnippet": true,
     "kind": "const",
-    "name": "RequestClass<Test>",
+    "name": "TaggedClass<Test>",
+    "replacementSpan": {
+      "length": 5,
+      "start": 130,
+    },
+    "sortText": "11",
+  },
+  {
+    "insertText": "S.ErrorClass<Test>("Test")({\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "ErrorClass<Test>",
     "replacementSpan": {
       "length": 5,
       "start": 130,

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -11,8 +11,10 @@ import { fnFunctionStar } from "./completions/fnFunctionStar.js"
 import { genFunctionStar } from "./completions/genFunctionStar.js"
 import { rpcMakeClasses } from "./completions/rpcMakeClasses.js"
 import { schemaBrand } from "./completions/schemaBrand.js"
+import { serviceMapSelfInClasses } from "./completions/serviceMapSelfInClasses.js"
 
 export const completions = [
+  serviceMapSelfInClasses,
   effectSqlModelSelfInClasses,
   effectSchemaSelfInClasses,
   effectSelfInClasses,

--- a/packages/language-service/src/completions/effectSchemaSelfInClasses.ts
+++ b/packages/language-service/src/completions/effectSchemaSelfInClasses.ts
@@ -75,26 +75,43 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
         })
       }
     }
-
-    // Check for Schema.TaggedClass or direct import TaggedClass
-    if (typeParser.supportedEffect() === "v3") {
-      const hasTaggedClassCompletion = isFullyQualified || Option.isSome(
+    if (typeParser.supportedEffect() === "v4") {
+      const hasTaggedErrorCompletion = isFullyQualified || Option.isSome(
         yield* pipe(
-          typeParser.isNodeReferenceToEffectSchemaModuleApi("TaggedClass")(accessedObject),
+          typeParser.isNodeReferenceToEffectSchemaModuleApi("TaggedErrorClass")(accessedObject),
           Nano.option
         )
       )
-      if (hasTaggedClassCompletion) {
+      if (hasTaggedErrorCompletion) {
         completions.push({
-          name: `TaggedClass<${name}>`,
+          name: `TaggedError<${name}>`,
           kind: ts.ScriptElementKind.constElement,
           insertText: isFullyQualified
-            ? `${schemaIdentifier}.TaggedClass<${name}>()("${name}", {${"${0}"}}){}`
-            : `TaggedClass<${name}>()("${name}", {${"${0}"}}){}`,
+            ? `${schemaIdentifier}.TaggedErrorClass<${name}>()("${errorTagKey}", {${"${0}"}}){}`
+            : `TaggedErrorClass<${name}>()("${errorTagKey}", {${"${0}"}}){}`,
           replacementSpan,
           isSnippet: true
         })
       }
+    }
+
+    // Check for Schema.TaggedClass or direct import TaggedClass
+    const hasTaggedClassCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToEffectSchemaModuleApi("TaggedClass")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasTaggedClassCompletion) {
+      completions.push({
+        name: `TaggedClass<${name}>`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${schemaIdentifier}.TaggedClass<${name}>()("${name}", {${"${0}"}}){}`
+          : `TaggedClass<${name}>()("${name}", {${"${0}"}}){}`,
+        replacementSpan,
+        isSnippet: true
+      })
     }
 
     // Check for Schema.TaggedRequest or direct import TaggedRequest
@@ -130,28 +147,8 @@ export const effectSchemaSelfInClasses = LSP.createCompletion({
           name: `ErrorClass<${name}>`,
           kind: ts.ScriptElementKind.constElement,
           insertText: isFullyQualified
-            ? `${schemaIdentifier}.ErrorClass<${name}>()({${"${0}"}}){}`
+            ? `${schemaIdentifier}.ErrorClass<${name}>("${name}")({${"${0}"}}){}`
             : `ErrorClass<${name}>()({${"${0}"}}){}`,
-          replacementSpan,
-          isSnippet: true
-        })
-      }
-    }
-
-    if (typeParser.supportedEffect() === "v4") {
-      const hasRequestClassCompletion = isFullyQualified || Option.isSome(
-        yield* pipe(
-          typeParser.isNodeReferenceToEffectSchemaModuleApi("RequestClass")(accessedObject),
-          Nano.option
-        )
-      )
-      if (hasRequestClassCompletion) {
-        completions.push({
-          name: `RequestClass<${name}>`,
-          kind: ts.ScriptElementKind.constElement,
-          insertText: isFullyQualified
-            ? `${schemaIdentifier}.RequestClass<${name}>("${name}")({${"${0}"}}){}`
-            : `RequestClass<${name}>("${name}")({${"${0}"}}){}`,
           replacementSpan,
           isSnippet: true
         })

--- a/packages/language-service/src/completions/serviceMapSelfInClasses.ts
+++ b/packages/language-service/src/completions/serviceMapSelfInClasses.ts
@@ -1,0 +1,70 @@
+import { pipe } from "effect"
+import * as Option from "effect/Option"
+import * as KeyBuilder from "../core/KeyBuilder.js"
+import * as LSP from "../core/LSP"
+import * as Nano from "../core/Nano"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi"
+import * as TypeScriptUtils from "../core/TypeScriptUtils"
+
+export const serviceMapSelfInClasses = LSP.createCompletion({
+  name: "serviceMapSelfInClasses",
+  apply: Nano.fn("serviceMapSelfInClasses")(function*(sourceFile, position) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+    if (typeParser.supportedEffect() === "v3") return []
+
+    const maybeInfos = tsUtils.parseDataForExtendsClassCompletion(sourceFile, position)
+    if (!maybeInfos) return []
+    const { accessedObject, className, replacementSpan } = maybeInfos
+
+    // first, given the position, we go back
+    const serviceMapIdentifier = tsUtils.findImportedModuleIdentifierByPackageAndNameOrBarrel(
+      sourceFile,
+      "effect",
+      "ServiceMap"
+    ) || "ServiceMap"
+
+    // Check if this is a fully qualified name (e.g., Effect.Service)
+    const isFullyQualified = serviceMapIdentifier === ts.idText(accessedObject)
+
+    const name = ts.idText(className)
+
+    // create the expected identifier
+    const tagKey = (yield* KeyBuilder.createString(sourceFile, name, "service")) || name
+
+    // Build completions based on what the user is extending
+    const completions: Array<LSP.CompletionEntryDefinition> = []
+
+    // If extending ServiceMap.Service (either ServiceMap.Service or direct import ServiceMap.Service)
+    const hasServiceCompletion = isFullyQualified || Option.isSome(
+      yield* pipe(
+        typeParser.isNodeReferenceToServiceMapModuleApi("Service")(accessedObject),
+        Nano.option
+      )
+    )
+    if (hasServiceCompletion) {
+      completions.push({
+        name: `Service<${name}, {}>`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${serviceMapIdentifier}.Service<${name}, {${"${0}"}}>()("${tagKey}"){}`
+          : `Service<${name}, {${"${0}"}}>()("${tagKey}"){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+      completions.push({
+        name: `Service<${name}>({ make })`,
+        kind: ts.ScriptElementKind.constElement,
+        insertText: isFullyQualified
+          ? `${serviceMapIdentifier}.Service<${name}>()("${tagKey}", { make: ${"${0}"} }){}`
+          : `Service<${name}>()("${tagKey}", { make: ${"${0}"} }){}`,
+        replacementSpan,
+        isSnippet: true
+      })
+    }
+
+    return completions
+  })
+})


### PR DESCRIPTION
## Summary

- Add `ServiceMap.Service` class completion for Effect v4, providing autocomplete for `Service<Name, {}>` and `Service<Name>({ make })` patterns
- Fix Schema class completions for Effect v4:
  - `TaggedErrorClass` now available (replaces v3's `TaggedError` in class context)
  - `TaggedClass` completion now available for v4
  - `ErrorClass` fully-qualified form fixed
  - `RequestClass` removed for v4 (not applicable)

### Example

When extending a class with `ServiceMap.Service` in Effect v4:

```ts
import { ServiceMap } from "effect"

class MyService extends ServiceMap.Se| // <- triggers completion
```

Produces completions like:
- `ServiceMap.Service<MyService, {}>()("MyService"){}`
- `ServiceMap.Service<MyService>()("MyService", { make: ... }){}`

## Test plan

- [x] All 493 tests pass (both v3 and v4 harnesses)
- [x] TypeScript type checking passes
- [x] Lint passes
- [x] Snapshot tests updated with new v4 completions

🤖 Generated with [Claude Code](https://claude.com/claude-code)