### PR TITLE
Expose diagnostic quick fixes as refactoring actions

### DIFF
--- a/.changeset/codefixes-as-refactors.md
+++ b/.changeset/codefixes-as-refactors.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Expose diagnostic quick fixes as refactoring actions to work around TypeScript's limited quick fix handling in some contexts

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "circular": "pnpm --filter @effect/language-service circular",
     "clean": "pnpm -r clean",
     "perf": "pnpm -r perf",
-    "pr-ai": "claude 'perform the actions described in CLAUDE.md under the section push PR to github workflow'"
+    "pr-ai": "claude 'perform the actions described in CLAUDE.md under the section push PR to github workflow'",
+    "code-debug": "TSS_DEBUG=5667 code --user-data-dir ~/.vscode-debug/"
   },
   "devDependencies": {
     "@effect/language-service": "link:packages/language-service/dist",


### PR DESCRIPTION
## Summary
- Surfaces diagnostic code fixes through the refactoring menu in addition to the standard quick fix mechanism
- Works around TypeScript's limited quick fix handling that doesn't work reliably in all editor contexts
- Adds `codeFixesToApplicableRefactor` and `getEditsForCodeFixes` to LSP core, and integrates them into the `getApplicableRefactors` and `getEditsForRefactor` plugin hooks

## Test plan
- [x] TypeScript type checking passes (`pnpm check`)
- [x] All 493 tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint-fix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)