### PR TITLE
Fix TypeParser to reject generic call signatures

### DIFF
--- a/.changeset/fix-type-parser-generic-signatures.md
+++ b/.changeset/fix-type-parser-generic-signatures.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix TypeParser to skip types with generic call signatures. When parsing covariant, contravariant, or invariant types, signatures with type parameters are now correctly rejected instead of being treated as concrete types.

--- a/packages/language-service/src/core/TypeParser.ts
+++ b/packages/language-service/src/core/TypeParser.ts
@@ -641,6 +641,9 @@ export function make(
     if (signatures.length !== 1) {
       return typeParserIssue("Covariant type has no call signature", type)
     }
+    if (signatures[0].typeParameters && signatures[0].typeParameters.length > 0) {
+      return typeParserIssue("Invariant type should not have type parameters", type)
+    }
     // get the return type
     return Nano.succeed(typeChecker.getReturnTypeOfSignature(signatures[0]))
   }
@@ -651,6 +654,9 @@ export function make(
     if (signatures.length !== 1) {
       return typeParserIssue("Contravariant type has no call signature", type)
     }
+    if (signatures[0].typeParameters && signatures[0].typeParameters.length > 0) {
+      return typeParserIssue("Invariant type should not have type parameters", type)
+    }
     // get the return type
     return Nano.succeed(typeCheckerUtils.getTypeParameterAtPosition(signatures[0], 0))
   }
@@ -660,6 +666,9 @@ export function make(
     // Invariant<A> has only 1 type signature
     if (signatures.length !== 1) {
       return typeParserIssue("Invariant type has no call signature", type)
+    }
+    if (signatures[0].typeParameters && signatures[0].typeParameters.length > 0) {
+      return typeParserIssue("Invariant type should not have type parameters", type)
     }
     // get the return type
     return Nano.succeed(typeChecker.getReturnTypeOfSignature(signatures[0]))


### PR DESCRIPTION
## Summary

- Fix TypeParser to correctly skip types with generic call signatures when parsing covariant, contravariant, and invariant types
- When a call signature has type parameters, it is now rejected with a type parser issue instead of being treated as a concrete type

### Example

Previously, if a covariant/contravariant/invariant type had a generic call signature like `<A>(a: A) => ...`, the parser would incorrectly proceed and extract the return/parameter type. Now it correctly reports an issue:

```ts
// Covariant: "Invariant type should not have type parameters"
// Contravariant: "Invariant type should not have type parameters"  
// Invariant: "Invariant type should not have type parameters"
```

## Test plan

- [x] `pnpm lint-fix` passes
- [x] `pnpm check` passes  
- [x] `pnpm test` — all 493 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)