### PR TITLE
Add Effect.Service to Context.Tag with Layer refactor

### DIFF
--- a/.changeset/effect-service-to-class-with-layer.md
+++ b/.changeset/effect-service-to-class-with-layer.md
@@ -1,0 +1,25 @@
+---
+"@effect/language-service": minor
+---
+
+Add refactor to convert `Effect.Service` to `Context.Tag` with a static `Layer` property.
+
+Supports all combinator kinds (`effect`, `scoped`, `sync`, `succeed`) and `dependencies`. The refactor replaces the `Effect.Service` class declaration with a `Context.Tag` class that has a `static layer` property using the corresponding `Layer` combinator.
+
+Before:
+```ts
+export class MyService extends Effect.Service<MyService>()("MyService", {
+  effect: Effect.gen(function*() {
+    return { value: "hello" }
+  })
+}){}
+```
+
+After:
+```ts
+export class MyService extends Context.Tag("MyService")<MyService, { value: string }>() {
+  static layer = Layer.effect(this, Effect.gen(function*() {
+    return { value: "hello" }
+  }));
+}
+```

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ And you're done! You'll now be able to use a set of refactors and diagnostics th
 - Toggle between pipe styles `X.pipe(Y)` and `pipe(X, Y)`
 - Layer Magic: Automatically compose and build layers based on service dependencies
 - Structural Type to Schema: Convert TypeScript interfaces and type aliases to Effect Schema classes, with automatic detection and reuse of existing schemas
+- Convert `Effect.Service` to `Context.Tag` with a static `Layer` property (supports `effect`, `scoped`, `sync`, `succeed` combinators and `dependencies`)
 
 ### Codegens
 

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln100col20.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln100col20.output
@@ -1,0 +1,119 @@
+// Result of running refactor effectServiceToClassWithLayer at position 100:20
+import { Effect, Context } from "effect"
+import * as Layer from "effect/Layer"
+
+// this can be converted to a Context.Tag with a static layer property
+export class MyService extends Effect.Service<MyService>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyService", {
+    effect: Effect.gen(function*() {
+        return {
+            value: "MyService"
+        }
+    })
+}){}
+
+// example result
+export class MyServiceAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceAsContextTag")<MyServiceAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: "MyService"
+        }
+    }))
+}
+
+export class MyServiceWithArgs extends Effect.Service<MyServiceWithArgs>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgs", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+// example result
+export class MyServiceWithArgsAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsAsContextTag")<MyServiceWithArgsAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// there is also a scoped variant, which should behave the same as the effect variant, but uses the scoped combinator.
+export class MyServiceWithArgsScoped extends Effect.Service<MyServiceWithArgsScoped>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScoped", {
+    scoped: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+export class MyServiceWithArgsScopedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAsContextTag")<MyServiceWithArgsScopedAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// the sync variant returns the structure directly, without using an intermediate effect
+export class MyServiceSync extends Effect.Service<MyServiceSync>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSync", {
+    sync: () => {
+        return {
+            value: "MyService"
+        }
+    }
+}){}
+
+// example result
+export class MyServiceSyncAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSyncAsContextTag")<MyServiceSyncAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    })
+}
+
+// the succeed variant returns the structure directly, without using an intermediate effect
+export class MyServiceSucceed extends Effect.Service<MyServiceSucceed>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceed", {
+    succeed: {
+        value: "MyService"
+    }
+}){}
+
+// example result
+export class MyServiceSucceedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceedAsContextTag")<MyServiceSucceedAsContextTag, {
+    value: "MyService"
+}>(){
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    })
+}
+
+// all variants support dependencies as well
+export class MyServiceWithArgsScopedAndDependencies extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependencies")<MyServiceWithArgsScopedAndDependencies, { value: string }>() {
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*() {
+        return {
+            value: arg
+        }
+    })).pipe(Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello"))));
+}
+
+// example result
+export class MyServiceWithArgsScopedAndDependenciesAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependenciesAsContextTag")<MyServiceWithArgsScopedAndDependenciesAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })).pipe(
+        Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello")))
+    )
+}

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln25col20.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln25col20.output
@@ -1,0 +1,120 @@
+// Result of running refactor effectServiceToClassWithLayer at position 25:20
+import { Effect, Context } from "effect"
+import * as Layer from "effect/Layer"
+
+// this can be converted to a Context.Tag with a static layer property
+export class MyService extends Effect.Service<MyService>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyService", {
+    effect: Effect.gen(function*() {
+        return {
+            value: "MyService"
+        }
+    })
+}){}
+
+// example result
+export class MyServiceAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceAsContextTag")<MyServiceAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: "MyService"
+        }
+    }))
+}
+
+export class MyServiceWithArgs extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgs")<MyServiceWithArgs, { value: string }>() {
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*() {
+        return {
+            value: arg
+        }
+    }));
+}
+
+// example result
+export class MyServiceWithArgsAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsAsContextTag")<MyServiceWithArgsAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// there is also a scoped variant, which should behave the same as the effect variant, but uses the scoped combinator.
+export class MyServiceWithArgsScoped extends Effect.Service<MyServiceWithArgsScoped>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScoped", {
+    scoped: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+export class MyServiceWithArgsScopedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAsContextTag")<MyServiceWithArgsScopedAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// the sync variant returns the structure directly, without using an intermediate effect
+export class MyServiceSync extends Effect.Service<MyServiceSync>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSync", {
+    sync: () => {
+        return {
+            value: "MyService"
+        }
+    }
+}){}
+
+// example result
+export class MyServiceSyncAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSyncAsContextTag")<MyServiceSyncAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    })
+}
+
+// the succeed variant returns the structure directly, without using an intermediate effect
+export class MyServiceSucceed extends Effect.Service<MyServiceSucceed>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceed", {
+    succeed: {
+        value: "MyService"
+    }
+}){}
+
+// example result
+export class MyServiceSucceedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceedAsContextTag")<MyServiceSucceedAsContextTag, {
+    value: "MyService"
+}>(){
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    })
+}
+
+// all variants support dependencies as well
+export class MyServiceWithArgsScopedAndDependencies extends Effect.Service<MyServiceWithArgsScopedAndDependencies>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependencies", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }),
+    dependencies: [MyServiceWithArgsScoped.Default("hello")]
+}){}
+
+// example result
+export class MyServiceWithArgsScopedAndDependenciesAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependenciesAsContextTag")<MyServiceWithArgsScopedAndDependenciesAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })).pipe(
+        Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello")))
+    )
+}

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln45col20.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln45col20.output
@@ -1,0 +1,120 @@
+// Result of running refactor effectServiceToClassWithLayer at position 45:20
+import { Effect, Context } from "effect"
+import * as Layer from "effect/Layer"
+
+// this can be converted to a Context.Tag with a static layer property
+export class MyService extends Effect.Service<MyService>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyService", {
+    effect: Effect.gen(function*() {
+        return {
+            value: "MyService"
+        }
+    })
+}){}
+
+// example result
+export class MyServiceAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceAsContextTag")<MyServiceAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: "MyService"
+        }
+    }))
+}
+
+export class MyServiceWithArgs extends Effect.Service<MyServiceWithArgs>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgs", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+// example result
+export class MyServiceWithArgsAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsAsContextTag")<MyServiceWithArgsAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// there is also a scoped variant, which should behave the same as the effect variant, but uses the scoped combinator.
+export class MyServiceWithArgsScoped extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScoped")<MyServiceWithArgsScoped, { value: string }>() {
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*() {
+        return {
+            value: arg
+        }
+    }));
+}
+
+export class MyServiceWithArgsScopedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAsContextTag")<MyServiceWithArgsScopedAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// the sync variant returns the structure directly, without using an intermediate effect
+export class MyServiceSync extends Effect.Service<MyServiceSync>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSync", {
+    sync: () => {
+        return {
+            value: "MyService"
+        }
+    }
+}){}
+
+// example result
+export class MyServiceSyncAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSyncAsContextTag")<MyServiceSyncAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    })
+}
+
+// the succeed variant returns the structure directly, without using an intermediate effect
+export class MyServiceSucceed extends Effect.Service<MyServiceSucceed>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceed", {
+    succeed: {
+        value: "MyService"
+    }
+}){}
+
+// example result
+export class MyServiceSucceedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceedAsContextTag")<MyServiceSucceedAsContextTag, {
+    value: "MyService"
+}>(){
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    })
+}
+
+// all variants support dependencies as well
+export class MyServiceWithArgsScopedAndDependencies extends Effect.Service<MyServiceWithArgsScopedAndDependencies>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependencies", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }),
+    dependencies: [MyServiceWithArgsScoped.Default("hello")]
+}){}
+
+// example result
+export class MyServiceWithArgsScopedAndDependenciesAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependenciesAsContextTag")<MyServiceWithArgsScopedAndDependenciesAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })).pipe(
+        Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello")))
+    )
+}

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln64col20.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln64col20.output
@@ -1,0 +1,120 @@
+// Result of running refactor effectServiceToClassWithLayer at position 64:20
+import { Effect, Context } from "effect"
+import * as Layer from "effect/Layer"
+
+// this can be converted to a Context.Tag with a static layer property
+export class MyService extends Effect.Service<MyService>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyService", {
+    effect: Effect.gen(function*() {
+        return {
+            value: "MyService"
+        }
+    })
+}){}
+
+// example result
+export class MyServiceAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceAsContextTag")<MyServiceAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: "MyService"
+        }
+    }))
+}
+
+export class MyServiceWithArgs extends Effect.Service<MyServiceWithArgs>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgs", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+// example result
+export class MyServiceWithArgsAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsAsContextTag")<MyServiceWithArgsAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// there is also a scoped variant, which should behave the same as the effect variant, but uses the scoped combinator.
+export class MyServiceWithArgsScoped extends Effect.Service<MyServiceWithArgsScoped>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScoped", {
+    scoped: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+export class MyServiceWithArgsScopedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAsContextTag")<MyServiceWithArgsScopedAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// the sync variant returns the structure directly, without using an intermediate effect
+export class MyServiceSync extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSync")<MyServiceSync, { value: string }>() {
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    });
+}
+
+// example result
+export class MyServiceSyncAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSyncAsContextTag")<MyServiceSyncAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    })
+}
+
+// the succeed variant returns the structure directly, without using an intermediate effect
+export class MyServiceSucceed extends Effect.Service<MyServiceSucceed>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceed", {
+    succeed: {
+        value: "MyService"
+    }
+}){}
+
+// example result
+export class MyServiceSucceedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceedAsContextTag")<MyServiceSucceedAsContextTag, {
+    value: "MyService"
+}>(){
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    })
+}
+
+// all variants support dependencies as well
+export class MyServiceWithArgsScopedAndDependencies extends Effect.Service<MyServiceWithArgsScopedAndDependencies>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependencies", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }),
+    dependencies: [MyServiceWithArgsScoped.Default("hello")]
+}){}
+
+// example result
+export class MyServiceWithArgsScopedAndDependenciesAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependenciesAsContextTag")<MyServiceWithArgsScopedAndDependenciesAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })).pipe(
+        Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello")))
+    )
+}

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln6col20.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln6col20.output
@@ -1,0 +1,120 @@
+// Result of running refactor effectServiceToClassWithLayer at position 6:20
+import { Effect, Context } from "effect"
+import * as Layer from "effect/Layer"
+
+// this can be converted to a Context.Tag with a static layer property
+export class MyService extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyService")<MyService, { value: string }>() {
+    static layer = Layer.effect(this, Effect.gen(function*() {
+        return {
+            value: "MyService"
+        }
+    }));
+}
+
+// example result
+export class MyServiceAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceAsContextTag")<MyServiceAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: "MyService"
+        }
+    }))
+}
+
+export class MyServiceWithArgs extends Effect.Service<MyServiceWithArgs>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgs", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+// example result
+export class MyServiceWithArgsAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsAsContextTag")<MyServiceWithArgsAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// there is also a scoped variant, which should behave the same as the effect variant, but uses the scoped combinator.
+export class MyServiceWithArgsScoped extends Effect.Service<MyServiceWithArgsScoped>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScoped", {
+    scoped: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+export class MyServiceWithArgsScopedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAsContextTag")<MyServiceWithArgsScopedAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// the sync variant returns the structure directly, without using an intermediate effect
+export class MyServiceSync extends Effect.Service<MyServiceSync>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSync", {
+    sync: () => {
+        return {
+            value: "MyService"
+        }
+    }
+}){}
+
+// example result
+export class MyServiceSyncAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSyncAsContextTag")<MyServiceSyncAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    })
+}
+
+// the succeed variant returns the structure directly, without using an intermediate effect
+export class MyServiceSucceed extends Effect.Service<MyServiceSucceed>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceed", {
+    succeed: {
+        value: "MyService"
+    }
+}){}
+
+// example result
+export class MyServiceSucceedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceedAsContextTag")<MyServiceSucceedAsContextTag, {
+    value: "MyService"
+}>(){
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    })
+}
+
+// all variants support dependencies as well
+export class MyServiceWithArgsScopedAndDependencies extends Effect.Service<MyServiceWithArgsScopedAndDependencies>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependencies", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }),
+    dependencies: [MyServiceWithArgsScoped.Default("hello")]
+}){}
+
+// example result
+export class MyServiceWithArgsScopedAndDependenciesAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependenciesAsContextTag")<MyServiceWithArgsScopedAndDependenciesAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })).pipe(
+        Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello")))
+    )
+}

--- a/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln84col20.output
+++ b/packages/harness-effect-v3/__snapshots__/refactors/effectServiceToClassWithLayer.ts.ln84col20.output
@@ -1,0 +1,120 @@
+// Result of running refactor effectServiceToClassWithLayer at position 84:20
+import { Effect, Context } from "effect"
+import * as Layer from "effect/Layer"
+
+// this can be converted to a Context.Tag with a static layer property
+export class MyService extends Effect.Service<MyService>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyService", {
+    effect: Effect.gen(function*() {
+        return {
+            value: "MyService"
+        }
+    })
+}){}
+
+// example result
+export class MyServiceAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceAsContextTag")<MyServiceAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: "MyService"
+        }
+    }))
+}
+
+export class MyServiceWithArgs extends Effect.Service<MyServiceWithArgs>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgs", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+// example result
+export class MyServiceWithArgsAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsAsContextTag")<MyServiceWithArgsAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// there is also a scoped variant, which should behave the same as the effect variant, but uses the scoped combinator.
+export class MyServiceWithArgsScoped extends Effect.Service<MyServiceWithArgsScoped>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScoped", {
+    scoped: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+export class MyServiceWithArgsScopedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAsContextTag")<MyServiceWithArgsScopedAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// the sync variant returns the structure directly, without using an intermediate effect
+export class MyServiceSync extends Effect.Service<MyServiceSync>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSync", {
+    sync: () => {
+        return {
+            value: "MyService"
+        }
+    }
+}){}
+
+// example result
+export class MyServiceSyncAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSyncAsContextTag")<MyServiceSyncAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    })
+}
+
+// the succeed variant returns the structure directly, without using an intermediate effect
+export class MyServiceSucceed extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceed")<MyServiceSucceed, { value: "MyService" }>() {
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    });
+}
+
+// example result
+export class MyServiceSucceedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceedAsContextTag")<MyServiceSucceedAsContextTag, {
+    value: "MyService"
+}>(){
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    })
+}
+
+// all variants support dependencies as well
+export class MyServiceWithArgsScopedAndDependencies extends Effect.Service<MyServiceWithArgsScopedAndDependencies>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependencies", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }),
+    dependencies: [MyServiceWithArgsScoped.Default("hello")]
+}){}
+
+// example result
+export class MyServiceWithArgsScopedAndDependenciesAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependenciesAsContextTag")<MyServiceWithArgsScopedAndDependenciesAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })).pipe(
+        Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello")))
+    )
+}

--- a/packages/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer.ts
+++ b/packages/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer.ts
@@ -1,0 +1,120 @@
+// 6:20,25:20,45:20,64:20,84:20,100:20
+import { Effect, Context } from "effect"
+import * as Layer from "effect/Layer"
+
+// this can be converted to a Context.Tag with a static layer property
+export class MyService extends Effect.Service<MyService>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyService", {
+    effect: Effect.gen(function*() {
+        return {
+            value: "MyService"
+        }
+    })
+}){}
+
+// example result
+export class MyServiceAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceAsContextTag")<MyServiceAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: "MyService"
+        }
+    }))
+}
+
+export class MyServiceWithArgs extends Effect.Service<MyServiceWithArgs>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgs", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+// example result
+export class MyServiceWithArgsAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsAsContextTag")<MyServiceWithArgsAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// there is also a scoped variant, which should behave the same as the effect variant, but uses the scoped combinator.
+export class MyServiceWithArgsScoped extends Effect.Service<MyServiceWithArgsScoped>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScoped", {
+    scoped: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })
+}){}
+
+export class MyServiceWithArgsScopedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAsContextTag")<MyServiceWithArgsScopedAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.scoped(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }))
+}
+
+// the sync variant returns the structure directly, without using an intermediate effect
+export class MyServiceSync extends Effect.Service<MyServiceSync>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSync", {
+    sync: () => {
+        return {
+            value: "MyService"
+        }
+    }
+}){}
+
+// example result
+export class MyServiceSyncAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSyncAsContextTag")<MyServiceSyncAsContextTag, {
+    value: string
+}>(){
+    static layer = Layer.sync(this, () => {
+        return {
+            value: "MyService"
+        }
+    })
+}
+
+// the succeed variant returns the structure directly, without using an intermediate effect
+export class MyServiceSucceed extends Effect.Service<MyServiceSucceed>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceed", {
+    succeed: {
+        value: "MyService"
+    }
+}){}
+
+// example result
+export class MyServiceSucceedAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceSucceedAsContextTag")<MyServiceSucceedAsContextTag, {
+    value: "MyService"
+}>(){
+    static layer = Layer.succeed(this, {
+        value: "MyService"
+    })
+}
+
+// all variants support dependencies as well
+export class MyServiceWithArgsScopedAndDependencies extends Effect.Service<MyServiceWithArgsScopedAndDependencies>()("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependencies", {
+    effect: (arg: string) => Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    }),
+    dependencies: [MyServiceWithArgsScoped.Default("hello")]
+}){}
+
+// example result
+export class MyServiceWithArgsScopedAndDependenciesAsContextTag extends Context.Tag("@effect/harness-effect-v3/examples/refactors/effectServiceToClassWithLayer/MyServiceWithArgsScopedAndDependenciesAsContextTag")<MyServiceWithArgsScopedAndDependenciesAsContextTag, {
+    value: string
+}>(){
+    static layer = (arg: string) => Layer.effect(this, Effect.gen(function*(){
+        return {
+            value: arg
+        }
+    })).pipe(
+        Layer.provide(Layer.mergeAll(MyServiceWithArgsScoped.Default("hello")))
+    )
+}

--- a/packages/language-service/src/refactors.ts
+++ b/packages/language-service/src/refactors.ts
@@ -5,6 +5,7 @@ import { asyncAwaitToGen } from "./refactors/asyncAwaitToGen.js"
 import { asyncAwaitToGenTryPromise } from "./refactors/asyncAwaitToGenTryPromise.js"
 import { debugPerformance } from "./refactors/debugPerformance.js"
 import { effectGenToFn } from "./refactors/effectGenToFn.js"
+import { effectServiceToClassWithLayer } from "./refactors/effectServiceToClassWithLayer.js"
 import { functionToArrow } from "./refactors/functionToArrow.js"
 import { layerMagic } from "./refactors/layerMagic.js"
 import { makeSchemaOpaque } from "./refactors/makeSchemaOpaque.js"
@@ -43,5 +44,6 @@ export const refactors = [
   wrapWithPipe,
   effectGenToFn,
   togglePipeStyle,
-  writeTagClassAccessors
+  writeTagClassAccessors,
+  effectServiceToClassWithLayer
 ].concat(Nano.debugPerformance ? [debugPerformance] : [])

--- a/packages/language-service/src/refactors/effectServiceToClassWithLayer.ts
+++ b/packages/language-service/src/refactors/effectServiceToClassWithLayer.ts
@@ -1,0 +1,281 @@
+import { pipe } from "effect/Function"
+import type * as ts from "typescript"
+import * as LSP from "../core/LSP.js"
+import * as Nano from "../core/Nano.js"
+import * as TypeCheckerApi from "../core/TypeCheckerApi.js"
+import * as TypeParser from "../core/TypeParser.js"
+import * as TypeScriptApi from "../core/TypeScriptApi.js"
+import * as TypeScriptUtils from "../core/TypeScriptUtils.js"
+
+export const effectServiceToClassWithLayer = LSP.createRefactor({
+  name: "effectServiceToClassWithLayer",
+  description: "Convert Effect.Service to Context.Tag with Layer",
+  apply: Nano.fn("effectServiceToClassWithLayer.apply")(function*(sourceFile, textRange) {
+    const ts = yield* Nano.service(TypeScriptApi.TypeScriptApi)
+    const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
+    const typeChecker = yield* Nano.service(TypeCheckerApi.TypeCheckerApi)
+    const typeParser = yield* Nano.service(TypeParser.TypeParser)
+
+    if (typeParser.supportedEffect() !== "v3") {
+      return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    }
+
+    // Find class declaration at cursor position
+    const parentNodes = tsUtils.getAncestorNodesInRange(sourceFile, textRange)
+
+    const findClassAtCursor = (node: ts.Node): Nano.Nano<
+      ts.ClassDeclaration,
+      LSP.RefactorNotApplicableError,
+      never
+    > => {
+      // Check if node is a class keyword or identifier name of a class declaration
+      if (ts.isClassDeclaration(node)) {
+        return Nano.succeed(node)
+      }
+      if (node.parent && ts.isClassDeclaration(node.parent)) {
+        if (node.kind === ts.SyntaxKind.ClassKeyword || (ts.isIdentifier(node) && node === node.parent.name)) {
+          return Nano.succeed(node.parent)
+        }
+      }
+      return Nano.fail(new LSP.RefactorNotApplicableError())
+    }
+
+    const classDeclaration = yield* pipe(
+      Nano.firstSuccessOf(parentNodes.map(findClassAtCursor)),
+      Nano.orElse(() => Nano.fail(new LSP.RefactorNotApplicableError()))
+    )
+
+    // Parse the class as Effect.Service
+    const parsed = yield* pipe(
+      typeParser.extendsEffectService(classDeclaration),
+      Nano.orElse(() => Nano.fail(new LSP.RefactorNotApplicableError()))
+    )
+
+    const { className, keyStringLiteral, options } = parsed
+
+    // Options must be an object literal with an `effect` property
+    if (!options || !ts.isObjectLiteralExpression(options)) {
+      return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    }
+
+    type CombinatorKind = "effect" | "scoped" | "sync" | "succeed"
+    let combinatorKind: CombinatorKind | undefined
+    let combinatorInitializer: ts.Expression | undefined
+    let dependencies: Array<ts.Expression> = []
+    for (const property of options.properties) {
+      if (
+        ts.isPropertyAssignment(property) && property.name && ts.isIdentifier(property.name)
+      ) {
+        const name = ts.idText(property.name)
+        if (name === "effect" || name === "scoped" || name === "sync" || name === "succeed") {
+          combinatorKind = name
+          combinatorInitializer = property.initializer
+        }
+        if (name === "dependencies" && ts.isArrayLiteralExpression(property.initializer)) {
+          dependencies = Array.from(property.initializer.elements)
+        }
+      }
+    }
+    if (!combinatorKind || !combinatorInitializer) {
+      return yield* Nano.fail(new LSP.RefactorNotApplicableError())
+    }
+
+    return {
+      kind: "refactor.rewrite.effect.effectServiceToClassWithLayer",
+      description: "Convert Effect.Service to Context.Tag with Layer",
+      apply: pipe(
+        Nano.fn("effectServiceToClassWithLayer.apply.inner")(function*() {
+          const changeTracker = yield* Nano.service(TypeScriptApi.ChangeTracker)
+
+          // Resolve import identifiers
+          const contextIdentifier = tsUtils.findImportedModuleIdentifierByPackageAndNameOrBarrel(
+            sourceFile,
+            "effect",
+            "Context"
+          ) || "Context"
+
+          const layerIdentifier = tsUtils.findImportedModuleIdentifierByPackageAndNameOrBarrel(
+            sourceFile,
+            "effect",
+            "Layer"
+          ) || "Layer"
+
+          // Build Layer.<combinator>(this, <body>) expression
+          const buildLayerCall = (body: ts.Expression, dependencies: Array<ts.Expression>) => {
+            const base = ts.factory.createCallExpression(
+              ts.factory.createPropertyAccessExpression(
+                ts.factory.createIdentifier(layerIdentifier),
+                combinatorKind!
+              ),
+              undefined,
+              [
+                ts.factory.createThis(),
+                body
+              ]
+            )
+            if (dependencies.length === 0) return base
+            return ts.factory.createCallExpression(
+              ts.factory.createPropertyAccessExpression(
+                base,
+                "pipe"
+              ),
+              undefined,
+              [
+                ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    ts.factory.createIdentifier(layerIdentifier),
+                    "provide"
+                  ),
+                  undefined,
+                  [
+                    ts.factory.createCallExpression(
+                      ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier(layerIdentifier),
+                        "mergeAll"
+                      ),
+                      undefined,
+                      dependencies
+                    )
+                  ]
+                )
+              ]
+            )
+          }
+
+          let shapeTypeNode: ts.TypeNode | undefined
+          let layerExpression: ts.Expression
+
+          if (combinatorKind === "succeed") {
+            const succeedType = typeChecker.getTypeAtLocation(combinatorInitializer!)
+            if (!succeedType) return
+            shapeTypeNode = typeChecker.typeToTypeNode(
+              succeedType,
+              classDeclaration,
+              ts.NodeBuilderFlags.NoTruncation
+            )
+            if (!shapeTypeNode) return
+            layerExpression = buildLayerCall(combinatorInitializer!, dependencies)
+          } else if (combinatorKind === "sync") {
+            const syncType = typeChecker.getTypeAtLocation(combinatorInitializer!)
+            const syncSignatures = typeChecker.getSignaturesOfType(syncType, ts.SignatureKind.Call)
+            const shapeType = syncSignatures.length > 0
+              ? typeChecker.getReturnTypeOfSignature(syncSignatures[0])
+              : syncType
+            shapeTypeNode = typeChecker.typeToTypeNode(
+              shapeType,
+              classDeclaration,
+              ts.NodeBuilderFlags.NoTruncation
+            )
+            if (!shapeTypeNode) return
+            layerExpression = buildLayerCall(combinatorInitializer!, dependencies)
+          } else {
+            // effect / scoped: use factory detection and effectType parsing
+            const combinatorInitializerType = typeChecker.getTypeAtLocation(combinatorInitializer!)
+            const callSignatures = typeChecker.getSignaturesOfType(combinatorInitializerType, ts.SignatureKind.Call)
+            const isFactory = callSignatures.length > 0
+
+            const effectResultType = isFactory
+              ? typeChecker.getReturnTypeOfSignature(callSignatures[0])
+              : combinatorInitializerType
+
+            const parsedEffect = yield* pipe(
+              typeParser.effectType(effectResultType, classDeclaration),
+              Nano.orUndefined
+            )
+            if (!parsedEffect) return
+            shapeTypeNode = typeChecker.typeToTypeNode(
+              parsedEffect.A,
+              classDeclaration,
+              ts.NodeBuilderFlags.NoTruncation
+            )
+            if (!shapeTypeNode) return
+
+            if (isFactory && ts.isArrowFunction(combinatorInitializer!)) {
+              const fn = combinatorInitializer as ts.ArrowFunction
+              const effectBody = ts.isBlock(fn.body) ? fn.body as unknown as ts.Expression : fn.body
+              layerExpression = ts.factory.createArrowFunction(
+                fn.modifiers,
+                fn.typeParameters,
+                fn.parameters,
+                undefined,
+                fn.equalsGreaterThanToken,
+                buildLayerCall(effectBody, dependencies)
+              )
+            } else if (isFactory && ts.isFunctionExpression(combinatorInitializer!)) {
+              const fn = combinatorInitializer as ts.FunctionExpression
+              layerExpression = ts.factory.createArrowFunction(
+                undefined,
+                fn.typeParameters,
+                fn.parameters,
+                undefined,
+                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                buildLayerCall(fn.body as unknown as ts.Expression, dependencies)
+              )
+            } else if (isFactory) {
+              return
+            } else {
+              layerExpression = buildLayerCall(combinatorInitializer!, dependencies)
+            }
+          }
+
+          // Build static layer property
+          const layerProperty = ts.factory.createPropertyDeclaration(
+            [ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)],
+            "layer",
+            undefined,
+            undefined,
+            layerExpression
+          )
+
+          // Build heritage clause: extends Context.Tag(<keyString>)<ClassName, ShapeType>()
+          const keyArg = keyStringLiteral
+            ? keyStringLiteral
+            : ts.factory.createStringLiteral(ts.idText(className))
+
+          // Inner: Context.Tag(<keyString>)
+          const contextTagCall = ts.factory.createCallExpression(
+            ts.factory.createPropertyAccessExpression(
+              ts.factory.createIdentifier(contextIdentifier),
+              "Tag"
+            ),
+            undefined,
+            [keyArg]
+          )
+
+          // Outer call: Context.Tag(<keyString>)<ClassName, ShapeType>()
+          const outerCall = ts.factory.createCallExpression(
+            contextTagCall,
+            [
+              ts.factory.createTypeReferenceNode(ts.idText(className)),
+              shapeTypeNode
+            ],
+            []
+          )
+
+          const heritageClause = ts.factory.createHeritageClause(
+            ts.SyntaxKind.ExtendsKeyword,
+            [ts.factory.createExpressionWithTypeArguments(outerCall, undefined)]
+          )
+
+          // Build new class declaration — recreate modifiers to strip leading trivia
+          const freshModifiers = classDeclaration.modifiers?.map((m) =>
+            ts.isModifier(m) ? ts.factory.createModifier(m.kind) : m
+          )
+          const newClassDeclaration = ts.factory.createClassDeclaration(
+            freshModifiers,
+            ts.idText(className),
+            undefined,
+            [heritageClause],
+            [layerProperty]
+          )
+
+          changeTracker.replaceNode(sourceFile, classDeclaration, newClassDeclaration)
+        })(),
+        Nano.provideService(TypeScriptUtils.TypeScriptUtils, tsUtils),
+        Nano.provideService(TypeParser.TypeParser, typeParser),
+        Nano.provideService(TypeCheckerApi.TypeCheckerApi, typeChecker),
+        Nano.provideService(TypeScriptApi.TypeScriptApi, ts)
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a new refactoring action that converts `Effect.Service` class declarations into `Context.Tag` classes with a static `layer` property
- Supports all combinator kinds: `effect`, `scoped`, `sync`, and `succeed`
- Supports `dependencies` option, generating `.pipe(Layer.provide(Layer.mergeAll(...)))` when present
- Handles both factory functions (arrow/function expressions) and direct values

### Example

Before:
```ts
export class MyService extends Effect.Service<MyService>()("MyService", {
  effect: Effect.gen(function*() {
    return { value: "hello" }
  })
}){}
```

After:
```ts
export class MyService extends Context.Tag("MyService")<MyService, { value: string }>() {
  static layer = Layer.effect(this, Effect.gen(function*() {
    return { value: "hello" }
  }));
}
```

## Test plan

- [x] All 499 existing tests pass
- [x] Snapshot tests cover all combinator variants (`effect`, `scoped`, `sync`, `succeed`) and `dependencies`
- [x] TypeScript type checking passes (`pnpm check`)
- [x] Lint passes (`pnpm lint-fix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)