### PR TITLE
Add Model.Class support for completions and diagnostics in Effect v4

### DIFF
--- a/.changeset/model-class-support.md
+++ b/.changeset/model-class-support.md
@@ -1,0 +1,16 @@
+---
+"@effect/language-service": patch
+---
+
+Add support for `Model.Class` from `effect/unstable/schema` in completions and diagnostics.
+
+The `classSelfMismatch` diagnostic now detects mismatched Self type parameters in `Model.Class` declarations, and the autocomplete for Self type in classes now suggests `Model.Class` when typing after `Model.`.
+
+```ts
+import { Model } from "effect/unstable/schema"
+
+// autocomplete triggers after `Model.`
+export class MyDataModel extends Model.Class<MyDataModel>("MyDataModel")({
+  id: Schema.String
+}) {}
+```

--- a/packages/harness-effect-v4/__snapshots__/completions.test.ts.snap
+++ b/packages/harness-effect-v4/__snapshots__/completions.test.ts.snap
@@ -248,6 +248,22 @@ exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_dotTok
 ]
 `;
 
+exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_model.ts at 4:40 1`] = `
+[
+  {
+    "insertText": "Model.Class<MyDataModel>("MyDataModel")({\${0}}){}",
+    "isSnippet": true,
+    "kind": "const",
+    "name": "Class<MyDataModel>",
+    "replacementSpan": {
+      "length": 6,
+      "start": 156,
+    },
+    "sortText": "11",
+  },
+]
+`;
+
 exports[`Completion effectSchemaSelfInClasses > effectSchemaSelfInClasses_tagg.ts at 4:25 1`] = `
 [
   {

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/classSelfMismatch_sqlClass.ts.classSelfMismatch_fix.from412to427.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/classSelfMismatch_sqlClass.ts.classSelfMismatch_fix.from412to427.output
@@ -1,0 +1,13 @@
+// code fix classSelfMismatch_fix  output for range 412 - 427
+import { Model } from "effect/unstable/schema"
+import {Schema} from "effect"
+
+// valid usage
+export class ValidModelClass extends Model.Class<ValidModelClass>("ValidModelClass")({
+  id: Schema.String
+}) {}
+
+// invalid usage: Model.Class<ValidModelClass> should be Model.Class<InvalidModelClass> because the Self type parameter is not the same as the class name
+export class InvalidModelClass extends Model.Class<InvalidModelClass>("InvalidModelClass")({
+  id2: Schema.String
+}) {}

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/classSelfMismatch_sqlClass.ts.codefixes
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/classSelfMismatch_sqlClass.ts.codefixes
@@ -1,1 +1,3 @@
-no codefixes
+classSelfMismatch_fix from 412 to 427
+classSelfMismatch_skipNextLine from 412 to 427
+classSelfMismatch_skipFile from 412 to 427

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/classSelfMismatch_sqlClass.ts.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/classSelfMismatch_sqlClass.ts.output
@@ -1,1 +1,2 @@
-// no diagnostics
+ValidModelClass
+10:51 - 10:66 | 1 | Self type parameter should be 'InvalidModelClass'    effect(classSelfMismatch)

--- a/packages/harness-effect-v4/examples/completions/effectSchemaSelfInClasses_model.ts
+++ b/packages/harness-effect-v4/examples/completions/effectSchemaSelfInClasses_model.ts
@@ -1,0 +1,4 @@
+// 4:40
+import { Model } from "effect/unstable/schema"
+
+export class MyDataModel extends Model.

--- a/packages/language-service/src/diagnostics/classSelfMismatch.ts
+++ b/packages/language-service/src/diagnostics/classSelfMismatch.ts
@@ -41,6 +41,7 @@ export const classSelfMismatch = LSP.createDiagnostic({
             )
           ),
           Nano.orElse(() => typeParser.extendsEffectSqlModelClass(node)),
+          Nano.orElse(() => typeParser.extendsEffectSchemaModelClass(node)),
           Nano.orElse(() => Nano.void_)
         )
 


### PR DESCRIPTION
## Summary

Fixes #657

- Add `Model.Class` (from `effect/unstable/schema`) support to the Self type autocomplete in classes for Effect v4
- Extend the `classSelfMismatch` diagnostic to detect mismatched Self type parameters in `Model.Class` declarations
- Add `TypeParser` support for resolving `Model.Class` references from the `effect/unstable/schema` module

## Example

```ts
import { Model } from "effect/unstable/schema"

// autocomplete now triggers after `Model.` suggesting `Class<MyDataModel>`
export class MyDataModel extends Model.Class<MyDataModel>("MyDataModel")({
  id: Schema.String
}) {}

// classSelfMismatch diagnostic fires when Self type doesn't match class name
export class InvalidModelClass extends Model.Class<WrongName>("InvalidModelClass")({
  //                                                ^^^^^^^^^
  //                            Self type parameter should be 'InvalidModelClass'
}) {}
```

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm test` (v3) passes
- [x] `pnpm test:v4` passes (412 tests)
- [x] New completion snapshot for `effectSchemaSelfInClasses_model.ts` added
- [x] Updated diagnostic snapshots for `classSelfMismatch_sqlClass.ts` with Model.Class detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)