### PR TITLE
Add effectYieldableType for yield diagnostics and hover

### DIFF
--- a/.changeset/effect-yieldable-missing-return-yield-star.md
+++ b/.changeset/effect-yieldable-missing-return-yield-star.md
@@ -1,0 +1,10 @@
+---
+"@effect/language-service": patch
+---
+
+Improve yield-based diagnostics and hover behavior by introducing `effectYieldableType` in `TypeParser` and using it in `missingReturnYieldStar`.
+
+- In Effect v4, yieldable values are recognized through `asEffect()` and mapped to Effect `A/E/R`.
+- In Effect v3, `effectYieldableType` falls back to standard `effectType` behavior.
+- `missingReturnYieldStar` now correctly handles yieldable values such as `Option.none()`.
+- Hover support for `yield*` was updated to use yieldable parsing paths.

--- a/packages/harness-effect-v3/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.codefixes
+++ b/packages/harness-effect-v3/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.codefixes
@@ -1,0 +1,3 @@
+missingReturnYieldStar_fix from 201 to 231
+missingReturnYieldStar_skipNextLine from 201 to 231
+missingReturnYieldStar_skipFile from 201 to 231

--- a/packages/harness-effect-v3/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.missingReturnYieldStar_fix.from201to231.output
+++ b/packages/harness-effect-v3/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.missingReturnYieldStar_fix.from201to231.output
@@ -1,0 +1,13 @@
+// code fix missingReturnYieldStar_fix  output for range 201 - 231
+import * as Effect from "effect/Effect"
+
+export const shouldComplain = (n: number) =>
+  Effect.gen(function*() {
+    if (n === 0) {
+      // In v3, yieldable parsing falls back to Effect typing.
+      return
+            // In v3, yieldable parsing falls back to Effect typing.
+            yield* Effect.fail("no zero!")
+    }
+    return n / 1
+  })

--- a/packages/harness-effect-v3/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.output
+++ b/packages/harness-effect-v3/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.output
@@ -1,0 +1,2 @@
+yield* Effect.fail("no zero!")
+7:6 - 7:36 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.    effect(missingReturnYieldStar)

--- a/packages/harness-effect-v3/examples/diagnostics/missingReturnYieldStar_yieldable.ts
+++ b/packages/harness-effect-v3/examples/diagnostics/missingReturnYieldStar_yieldable.ts
@@ -1,0 +1,10 @@
+import * as Effect from "effect/Effect"
+
+export const shouldComplain = (n: number) =>
+  Effect.gen(function*() {
+    if (n === 0) {
+      // In v3, yieldable parsing falls back to Effect typing.
+      yield* Effect.fail("no zero!")
+    }
+    return n / 1
+  })

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.codefixes
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.codefixes
@@ -1,0 +1,3 @@
+missingReturnYieldStar_fix from 178 to 198
+missingReturnYieldStar_skipNextLine from 178 to 198
+missingReturnYieldStar_skipFile from 178 to 198

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.missingReturnYieldStar_fix.from178to198.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.missingReturnYieldStar_fix.from178to198.output
@@ -1,0 +1,12 @@
+// code fix missingReturnYieldStar_fix  output for range 178 - 198
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+
+export const shouldComplain = (n: number) =>
+  Effect.gen(function*() {
+    if (n === 0) {
+      return yield* Option.none() // should trigger because Option<A> is yieldable
+             // should trigger because Option<A> is yieldable
+    }
+    return n / 1
+  })

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/missingReturnYieldStar_yieldable.ts.output
@@ -1,0 +1,2 @@
+yield* Option.none()
+7:6 - 7:26 | 1 | It is recommended to use return yield* for Effects that never succeed to signal a definitive exit point for type narrowing and tooling support.    effect(missingReturnYieldStar)

--- a/packages/harness-effect-v4/examples/diagnostics/missingReturnYieldStar_yieldable.ts
+++ b/packages/harness-effect-v4/examples/diagnostics/missingReturnYieldStar_yieldable.ts
@@ -1,0 +1,10 @@
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+
+export const shouldComplain = (n: number) =>
+  Effect.gen(function*() {
+    if (n === 0) {
+      yield* Option.none() // should trigger because Option<A> is yieldable
+    }
+    return n / 1
+  })

--- a/packages/language-service/src/core/TypeParser.ts
+++ b/packages/language-service/src/core/TypeParser.ts
@@ -76,6 +76,10 @@ export interface TypeParser {
     type: ts.Type,
     atLocation: ts.Node
   ) => Nano.Nano<{ A: ts.Type; E: ts.Type; R: ts.Type }, TypeParserIssue>
+  effectYieldableType: (
+    type: ts.Type,
+    atLocation: ts.Node
+  ) => Nano.Nano<{ A: ts.Type; E: ts.Type; R: ts.Type }, TypeParserIssue>
   importedEffectModule: (
     node: ts.Node
   ) => Nano.Nano<ts.Node, TypeParserIssue>
@@ -937,6 +941,44 @@ export function make(
       return yield* effectType(type, atLocation)
     }),
     "TypeParser.effectSubtype",
+    (type) => type
+  )
+
+  const effectYieldableType = Nano.cachedBy(
+    Nano.fn("TypeParser.effectYieldableType")(function*(
+      type: ts.Type,
+      atLocation: ts.Node
+    ) {
+      // v3 models this through Effect subtyping, so keep legacy behavior.
+      if (supportedEffect() === "v3") {
+        return yield* effectType(type, atLocation)
+      }
+
+      // v4 supports both plain Effect values and yieldable wrappers (Option/Either/...).
+      return yield* Nano.firstSuccessOf([
+        effectType(type, atLocation),
+        Nano.gen(function*() {
+          // Yieldable shape: asEffect()
+          const asEffectSymbol = typeChecker.getPropertyOfType(type, "asEffect")
+          if (!asEffectSymbol) {
+            return yield* typeParserIssue("Type has no 'asEffect' property", type, atLocation)
+          }
+
+          const asEffectType = typeChecker.getTypeOfSymbolAtLocation(asEffectSymbol, atLocation)
+          const asEffectSignatures = typeChecker.getSignaturesOfType(asEffectType, ts.SignatureKind.Call)
+          if (asEffectSignatures.length === 0) {
+            return yield* typeParserIssue("'asEffect' property is not callable", type, atLocation)
+          }
+
+          return yield* Nano.firstSuccessOf(
+            asEffectSignatures.map((signature) =>
+              effectType(typeChecker.getReturnTypeOfSignature(signature), atLocation)
+            )
+          )
+        })
+      ])
+    }),
+    "TypeParser.effectYieldableType",
     (type) => type
   )
 
@@ -3079,6 +3121,7 @@ export function make(
     layerType,
     fiberType,
     effectSubtype,
+    effectYieldableType,
     importedEffectModule,
     effectGen,
     effectFnUntracedGen,

--- a/packages/language-service/src/diagnostics/missingReturnYieldStar.ts
+++ b/packages/language-service/src/diagnostics/missingReturnYieldStar.ts
@@ -37,7 +37,7 @@ export const missingReturnYieldStar = LSP.createDiagnostic({
       const type = typeCheckerUtils.getTypeAtLocation(unwrapped.expression)
       if (!type) continue
 
-      const maybeEffect = yield* Nano.option(typeParser.effectType(type, unwrapped.expression))
+      const maybeEffect = yield* Nano.option(typeParser.effectYieldableType(type, unwrapped.expression))
       if (!(Option.isSome(maybeEffect) && maybeEffect.value.A.flags & ts.TypeFlags.Never)) continue
 
       // Ensure we're in the direct body scope of an Effect.gen-like function.

--- a/packages/language-service/src/quickinfo/effectTypeArgs.ts
+++ b/packages/language-service/src/quickinfo/effectTypeArgs.ts
@@ -242,7 +242,7 @@ export function effectTypeArgs(
 
       // first try to get the effect type
       const effectTypeArgsDocumentation = yield* pipe(
-        typeParser.effectType(
+        typeParser.effectYieldableType(
           type,
           atLocation
         ),


### PR DESCRIPTION
## Summary
- add `TypeParser.effectYieldableType`
- v4: parse yieldable channels from `asEffect()` (and still support plain `Effect` values)
- v3: keep compatibility by falling back to `effectType`
- switch `missingReturnYieldStar` to `effectYieldableType`
- extend harness diagnostics coverage with `missingReturnYieldStar_yieldable.ts` for v3 and v4
- update quickinfo yield handling (`effectTypeArgs`) for yieldable support

## Example
```ts
import * as Effect from "effect/Effect"
import * as Option from "effect/Option"

export const shouldComplain = (n: number) =>
  Effect.gen(function*() {
    if (n === 0) {
      yield* Option.none()
    }
    return n / 1
  })
```

Now `missingReturnYieldStar` recognizes `Option.none()` as yieldable and suggests `return yield* ...` when appropriate.

## Validation
- `pnpm lint-fix`
- `pnpm check`
- `EFFECT_HARNESS_VERSION=v4 pnpm --filter @effect/language-service test -- test/diagnostics.test.ts -t missingReturnYieldStar`
- `EFFECT_HARNESS_VERSION=v3 pnpm --filter @effect/language-service test -- test/diagnostics.test.ts -t missingReturnYieldStar`
- `EFFECT_HARNESS_VERSION=v4 pnpm --filter @effect/language-service test -- test/layer-graph.test.ts`
- `EFFECT_HARNESS_VERSION=v3 pnpm --filter @effect/language-service test -- test/layer-graph.test.ts`
- full suite left to CI (not run locally due runtime)
