### PR TITLE
Fix effectFnOpportunity inferred name for Layer.*(this, ...)

### DIFF
--- a/.changeset/effect-fn-opportunity-inferred-layer-this.md
+++ b/.changeset/effect-fn-opportunity-inferred-layer-this.md
@@ -1,0 +1,7 @@
+---
+"@effect/language-service": patch
+---
+
+Fix `effectFnOpportunity` inferred span naming for `Layer.*(this, ...)` patterns in class static members.
+
+When the inferred layer target is `this`, the diagnostic now uses the nearest enclosing class name (for example `MyService`) instead of the literal `this` token.

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.codefixes
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.codefixes
@@ -1,0 +1,9 @@
+effectFnOpportunity_toEffectFnSpanInferred from 451 to 454
+effectFnOpportunity_skipNextLine from 451 to 454
+effectFnOpportunity_skipFile from 451 to 454
+effectFnOpportunity_toEffectFnSpanInferred from 564 to 567
+effectFnOpportunity_skipNextLine from 564 to 567
+effectFnOpportunity_skipFile from 564 to 567
+effectFnOpportunity_toEffectFnSpanInferred from 344 to 347
+effectFnOpportunity_skipNextLine from 344 to 347
+effectFnOpportunity_skipFile from 344 to 347

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.effectFnOpportunity_toEffectFnSpanInferred.from344to347.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.effectFnOpportunity_toEffectFnSpanInferred.from344to347.output
@@ -1,0 +1,22 @@
+// code fix effectFnOpportunity_toEffectFnSpanInferred  output for range 344 - 347
+// @test-config { "effectFn": ["inferred-span"] }
+import { Effect, Layer, ServiceMap } from "effect"
+
+export class MyService extends ServiceMap.Service<MyService, {
+  log: (_what: string) => Effect.Effect<void>
+}>()("MyService") {
+    static layer = Layer.effect(this, Effect.gen(function*() {
+        yield* Effect.log("log")
+        return { log: Effect.fn("MyService.log")(function(what: string) {
+            return Effect.log(what)
+        }) }
+    }))
+
+    static layerSucceed = Layer.succeed(this)({
+        log: (what: string) => Effect.log(what)
+    })
+
+    static layerSync = Layer.sync(this)(() => {
+        return { log: (what: string) => Effect.log(what) }
+    })
+}

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.effectFnOpportunity_toEffectFnSpanInferred.from451to454.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.effectFnOpportunity_toEffectFnSpanInferred.from451to454.output
@@ -1,0 +1,22 @@
+// code fix effectFnOpportunity_toEffectFnSpanInferred  output for range 451 - 454
+// @test-config { "effectFn": ["inferred-span"] }
+import { Effect, Layer, ServiceMap } from "effect"
+
+export class MyService extends ServiceMap.Service<MyService, {
+  log: (_what: string) => Effect.Effect<void>
+}>()("MyService") {
+    static layer = Layer.effect(this, Effect.gen(function*() {
+        yield* Effect.log("log")
+        return { log: (what: string) => Effect.log(what) }
+    }))
+
+    static layerSucceed = Layer.succeed(this)({
+        log: Effect.fn("MyService.log")(function(what: string) {
+            return Effect.log(what)
+        })
+    })
+
+    static layerSync = Layer.sync(this)(() => {
+        return { log: (what: string) => Effect.log(what) }
+    })
+}

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.effectFnOpportunity_toEffectFnSpanInferred.from564to567.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.effectFnOpportunity_toEffectFnSpanInferred.from564to567.output
@@ -1,0 +1,22 @@
+// code fix effectFnOpportunity_toEffectFnSpanInferred  output for range 564 - 567
+// @test-config { "effectFn": ["inferred-span"] }
+import { Effect, Layer, ServiceMap } from "effect"
+
+export class MyService extends ServiceMap.Service<MyService, {
+  log: (_what: string) => Effect.Effect<void>
+}>()("MyService") {
+    static layer = Layer.effect(this, Effect.gen(function*() {
+        yield* Effect.log("log")
+        return { log: (what: string) => Effect.log(what) }
+    }))
+
+    static layerSucceed = Layer.succeed(this)({
+        log: (what: string) => Effect.log(what)
+    })
+
+    static layerSync = Layer.sync(this)(() => {
+        return { log: Effect.fn("MyService.log")(function(what: string) {
+            return Effect.log(what)
+        }) }
+    })
+}

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/effectFnOpportunity_inferredLayerThis.ts.output
@@ -1,0 +1,8 @@
+log
+9:17 - 9:20 | 2 | Can be rewritten as a reusable function: Effect.fn("MyService.log")((what) => { ... })    effect(effectFnOpportunity)
+
+log
+13:8 - 13:11 | 2 | Can be rewritten as a reusable function: Effect.fn("MyService.log")((what) => { ... })    effect(effectFnOpportunity)
+
+log
+17:17 - 17:20 | 2 | Can be rewritten as a reusable function: Effect.fn("MyService.log")((what) => { ... })    effect(effectFnOpportunity)

--- a/packages/harness-effect-v4/examples/diagnostics/effectFnOpportunity_inferredLayerThis.ts
+++ b/packages/harness-effect-v4/examples/diagnostics/effectFnOpportunity_inferredLayerThis.ts
@@ -1,0 +1,19 @@
+// @test-config { "effectFn": ["inferred-span"] }
+import { Effect, Layer, ServiceMap } from "effect"
+
+export class MyService extends ServiceMap.Service<MyService, {
+  log: (_what: string) => Effect.Effect<void>
+}>()("MyService") {
+    static layer = Layer.effect(this, Effect.gen(function*() {
+        yield* Effect.log("log")
+        return { log: (what: string) => Effect.log(what) }
+    }))
+
+    static layerSucceed = Layer.succeed(this)({
+        log: (what: string) => Effect.log(what)
+    })
+
+    static layerSync = Layer.sync(this)(() => {
+        return { log: (what: string) => Effect.log(what) }
+    })
+}

--- a/packages/language-service/src/diagnostics/effectFnOpportunity.ts
+++ b/packages/language-service/src/diagnostics/effectFnOpportunity.ts
@@ -112,7 +112,16 @@ export const effectFnOpportunity = LSP.createDiagnostic({
       return modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false
     }
 
-    const textOfExpression = (expression: ts.Expression): string => {
+    const layerServiceNameFromExpression = (expression: ts.Expression): string | undefined => {
+      if (expression.kind === ts.SyntaxKind.ThisKeyword) {
+        const enclosingClass = ts.findAncestor(
+          expression,
+          (node): node is ts.ClassDeclaration => ts.isClassDeclaration(node)
+        )
+        if (enclosingClass?.name) {
+          return ts.idText(enclosingClass.name)
+        }
+      }
       if (ts.isIdentifier(expression)) return ts.idText(expression)
       return sourceFile.text.slice(expression.pos, expression.end).trim()
     }
@@ -153,7 +162,7 @@ export const effectFnOpportunity = LSP.createDiagnostic({
           directMethod === method && callExpression.arguments.length >= 2 &&
           callExpression.arguments[1] === implementationExpression
         ) {
-          return textOfExpression(callExpression.arguments[0])
+          return layerServiceNameFromExpression(callExpression.arguments[0])
         }
         if (ts.isCallExpression(callExpression.expression)) {
           const innerCall = callExpression.expression
@@ -162,7 +171,7 @@ export const effectFnOpportunity = LSP.createDiagnostic({
             innerMethod === method && innerCall.arguments.length >= 1 && callExpression.arguments.length >= 1 &&
             callExpression.arguments[0] === implementationExpression
           ) {
-            return textOfExpression(innerCall.arguments[0])
+            return layerServiceNameFromExpression(innerCall.arguments[0])
           }
         }
         return undefined


### PR DESCRIPTION
## Summary
- fix inferred trace name generation in `effectFnOpportunity` for layer inference cases using `this` as service target
- when layer target is `this`, resolve nearest enclosing class declaration and use its name
- add v4 regression example and snapshots for `effectFnOpportunity_inferredLayerThis.ts`

## Example
Given:
```ts
export class MyService extends ServiceMap.Service<...>()("MyService") {
  static layer = Layer.effect(this, Effect.gen(function*() {
    return { log: (what) => Effect.log(what) }
  }))
}
```

Inferred span names now use `MyService.log` instead of `this.log`.

## Validation
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test`
- `pnpm test:v4`
