### PR TITLE
add file glob overrides and inline cli path filters

### DIFF
--- a/.changeset/wise-walls-rule.md
+++ b/.changeset/wise-walls-rule.md
@@ -3,3 +3,29 @@
 ---
 
 Add per-file diagnostic severity overrides in plugin config and inline `--paths` glob filtering for CLI commands.
+
+Example plugin config:
+
+```json
+{
+  "diagnosticSeverity": {
+    "strictEffectProvide": "warning"
+  },
+  "overrides": [
+    {
+      "include": ["test/**/*"],
+      "diagnosticSeverity": {
+        "strictEffectProvide": "off"
+      }
+    }
+  ]
+}
+```
+
+Example inline CLI filtering:
+
+```bash
+effect-language-service diagnostics \
+  --project tsconfig.json \
+  --paths '{"include":["src/**/*"],"exclude":["**/*.test.ts"]}'
+```

--- a/.changeset/wise-walls-rule.md
+++ b/.changeset/wise-walls-rule.md
@@ -2,7 +2,7 @@
 "@effect/language-service": minor
 ---
 
-Add per-file diagnostic severity overrides in plugin config and inline `--paths` glob filtering for CLI commands.
+Add per-file diagnostic severity overrides in plugin config and inline `--include` / `--exclude` glob filtering for CLI commands.
 
 Example plugin config:
 
@@ -27,5 +27,6 @@ Example inline CLI filtering:
 ```bash
 effect-language-service diagnostics \
   --project tsconfig.json \
-  --paths '{"include":["src/**/*"],"exclude":["**/*.test.ts"]}'
+  --include 'src/**/*' \
+  --exclude '**/*.test.ts'
 ```

--- a/.changeset/wise-walls-rule.md
+++ b/.changeset/wise-walls-rule.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": minor
+---
+
+Add per-file diagnostic severity overrides in plugin config and inline `--paths` glob filtering for CLI commands.

--- a/packages/language-service/src/cli/codegen.ts
+++ b/packages/language-service/src/cli/codegen.ts
@@ -52,10 +52,17 @@ const force = Flag.boolean("force").pipe(
   Flag.withDescription("Force codegen even if no changes are needed.")
 )
 
-const paths = Flag.string("paths").pipe(
+const include = Flag.string("include").pipe(
   Flag.optional,
   Flag.withDescription(
-    "Optional inline JSON path globs used to filter files after tsconfig discovery. e.g. '{ \"include\": [\"src/**/*\"], \"exclude\": [\"**/*.test.ts\"] }'"
+    "Optional comma-separated include globs used to filter files after tsconfig discovery. e.g. 'src/**/*,test/**/*'"
+  )
+)
+
+const exclude = Flag.string("exclude").pipe(
+  Flag.optional,
+  Flag.withDescription(
+    "Optional comma-separated exclude globs used to filter files after tsconfig discovery. e.g. '**/*.test.ts,**/*.spec.ts'"
   )
 )
 
@@ -63,8 +70,8 @@ const BATCH_SIZE = 50
 
 export const codegen = Command.make(
   "codegen",
-  { file, project, verbose, force, paths },
-  Effect.fn("codegen")(function*({ file, force, paths, project, verbose }) {
+  { file, project, verbose, force, include, exclude },
+  Effect.fn("codegen")(function*({ exclude, file, force, include, project, verbose }) {
     const path = yield* Path.Path
     const fs = yield* FileSystem.FileSystem
     const tsInstance = yield* TypeScriptContext
@@ -80,7 +87,7 @@ export const codegen = Command.make(
     if (Option.isSome(file)) {
       filesToCodegen.add(path.resolve(file.value))
     }
-    filesToCodegen = yield* filterFilesByPaths(filesToCodegen, projectRoot, paths)
+    filesToCodegen = yield* filterFilesByPaths(filesToCodegen, projectRoot, { include, exclude })
     if (filesToCodegen.size === 0) {
       return yield* new NoFilesToCodegenError()
     }

--- a/packages/language-service/src/cli/codegen.ts
+++ b/packages/language-service/src/cli/codegen.ts
@@ -18,7 +18,13 @@ import * as TypeCheckerUtils from "../core/TypeCheckerUtils"
 import * as TypeParser from "../core/TypeParser"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
-import { applyTextChanges, extractEffectLspOptions, getFileNamesInTsConfig, TypeScriptContext } from "./utils"
+import {
+  applyTextChanges,
+  extractEffectLspOptions,
+  filterFilesByPaths,
+  getFileNamesInTsConfig,
+  TypeScriptContext
+} from "./utils"
 
 export class NoFilesToCodegenError extends Data.TaggedError("NoFilesToCodegenError")<{}> {
   get message(): string {
@@ -46,15 +52,23 @@ const force = Flag.boolean("force").pipe(
   Flag.withDescription("Force codegen even if no changes are needed.")
 )
 
+const paths = Flag.string("paths").pipe(
+  Flag.optional,
+  Flag.withDescription(
+    "Optional inline JSON path globs used to filter files after tsconfig discovery. e.g. '{ \"include\": [\"src/**/*\"], \"exclude\": [\"**/*.test.ts\"] }'"
+  )
+)
+
 const BATCH_SIZE = 50
 
 export const codegen = Command.make(
   "codegen",
-  { file, project, verbose, force },
-  Effect.fn("codegen")(function*({ file, force, project, verbose }) {
+  { file, project, verbose, force, paths },
+  Effect.fn("codegen")(function*({ file, force, paths, project, verbose }) {
     const path = yield* Path.Path
     const fs = yield* FileSystem.FileSystem
     const tsInstance = yield* TypeScriptContext
+    const projectRoot = Option.isSome(project) ? path.dirname(project.value) : path.resolve(".")
     let filesToCodegen = new Set<string>()
     let checkedFilesCount = 0
     let updatedFilesCount = 0
@@ -66,6 +80,7 @@ export const codegen = Command.make(
     if (Option.isSome(file)) {
       filesToCodegen.add(path.resolve(file.value))
     }
+    filesToCodegen = yield* filterFilesByPaths(filesToCodegen, projectRoot, paths)
     if (filesToCodegen.size === 0) {
       return yield* new NoFilesToCodegenError()
     }
@@ -153,7 +168,10 @@ export const codegen = Command.make(
             Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
             Nano.provideService(
               LanguageServicePluginOptions.LanguageServicePluginOptions,
-              { ...LanguageServicePluginOptions.parse(pluginConfig), diagnosticsName: false }
+              {
+                ...LanguageServicePluginOptions.parse(pluginConfig, { projectRoot }),
+                diagnosticsName: false
+              }
             ),
             Nano.run,
             Result.getOrElse(() => [] as Array<ts.FileTextChanges>)

--- a/packages/language-service/src/cli/diagnostics.ts
+++ b/packages/language-service/src/cli/diagnostics.ts
@@ -323,158 +323,166 @@ export const diagnostics = Command.make(
         "An optional inline JSON lsp config that replaces the current project lsp config. e.g. '{ \"effectFn\": [\"untraced\"] }'"
       )
     ),
-    paths: Flag.string("paths").pipe(
+    include: Flag.string("include").pipe(
       Flag.optional,
       Flag.withDescription(
-        "Optional inline JSON path globs used to filter files after tsconfig discovery. e.g. '{ \"include\": [\"src/**/*\"], \"exclude\": [\"**/*.test.ts\"] }'"
+        "Optional comma-separated include globs used to filter files after tsconfig discovery. e.g. 'src/**/*,test/**/*'"
+      )
+    ),
+    exclude: Flag.string("exclude").pipe(
+      Flag.optional,
+      Flag.withDescription(
+        "Optional comma-separated exclude globs used to filter files after tsconfig discovery. e.g. '**/*.test.ts,**/*.spec.ts'"
       )
     )
   },
-  Effect.fn("diagnostics")(function*({ file, format, lspconfig, paths, progress, project, severity, strict }) {
-    const path = yield* Path.Path
-    const projectRoot = Option.isSome(project) ? path.dirname(project.value) : path.resolve(".")
-    const severityFilter = parseSeverityFilter(severity)
-    const state: DiagnosticReporterState = {
-      tsInstance: yield* TypeScriptContext,
-      checkedCount: 0,
-      errorsCount: 0,
-      warningsCount: 0,
-      messagesCount: 0,
-      languageService: undefined,
-      totalFilesCount: 0,
-      currentFileIndex: 0
-    }
-
-    const filesToCheck = Option.isSome(project)
-      ? yield* getFileNamesInTsConfig(project.value)
-      : new Set<string>()
-
-    if (Option.isSome(file)) {
-      filesToCheck.add(path.resolve(file.value))
-    }
-    const filteredFilesToCheck = yield* filterFilesByPaths(filesToCheck, projectRoot, paths)
-
-    if (filteredFilesToCheck.size === 0) {
-      return yield* new NoFilesToCheckError()
-    }
-
-    state.totalFilesCount = filteredFilesToCheck.size
-
-    let reporter: DiagnosticReporter | undefined
-    switch (format) {
-      case "pretty":
-        reporter = yield* diagnosticPrettyFormatter
-        break
-      case "text":
-        reporter = yield* diagnosticTextFormatter
-        break
-      case "json":
-        reporter = yield* diagnosticJsonFormatter
-        break
-      case "github-actions":
-        reporter = yield* diagnosticGitHubActionsFormatter
-        break
-      default:
-        reporter = yield* diagnosticPrettyFormatter
-    }
-    if (progress) {
-      reporter = yield* withDiagnosticsProgressFormatter(reporter)
-    }
-
-    yield* reporter.onBegin(state)
-
-    const disposeIfLanguageServiceChanged = (languageService: ts.LanguageService | undefined) => {
-      if (state.languageService !== languageService) {
-        state.languageService?.dispose()
-        state.languageService = languageService
+  Effect.fn("diagnostics")(
+    function*({ exclude, file, format, include, lspconfig, progress, project, severity, strict }) {
+      const path = yield* Path.Path
+      const projectRoot = Option.isSome(project) ? path.dirname(project.value) : path.resolve(".")
+      const severityFilter = parseSeverityFilter(severity)
+      const state: DiagnosticReporterState = {
+        tsInstance: yield* TypeScriptContext,
+        checkedCount: 0,
+        errorsCount: 0,
+        warningsCount: 0,
+        messagesCount: 0,
+        languageService: undefined,
+        totalFilesCount: 0,
+        currentFileIndex: 0
       }
-    }
 
-    for (const batch of Array.chunksOf(filteredFilesToCheck, BATCH_SIZE)) {
-      const { service } = createProjectService({ options: { loadTypeScriptPlugins: false } })
+      const filesToCheck = Option.isSome(project)
+        ? yield* getFileNamesInTsConfig(project.value)
+        : new Set<string>()
 
-      for (const filePath of batch) {
-        state.currentFileIndex++
-        yield* reporter.onFile(state, filePath)
+      if (Option.isSome(file)) {
+        filesToCheck.add(path.resolve(file.value))
+      }
+      const filteredFilesToCheck = yield* filterFilesByPaths(filesToCheck, projectRoot, { include, exclude })
 
-        service.openClientFile(filePath)
-        try {
-          const scriptInfo = service.getScriptInfo(filePath)
-          if (!scriptInfo) continue
+      if (filteredFilesToCheck.size === 0) {
+        return yield* new NoFilesToCheckError()
+      }
 
-          const projectInfo = scriptInfo.getDefaultProject()
-          const languageService = projectInfo.getLanguageService(true)
-          disposeIfLanguageServiceChanged(languageService)
-          const program = languageService.getProgram()
-          if (!program) continue
-          const sourceFile = program.getSourceFile(filePath)
-          if (!sourceFile) continue
-          let pluginConfig = extractEffectLspOptions(program.getCompilerOptions())
-          if (Option.isSome(lspconfig)) {
-            try {
-              pluginConfig = { name: "@effect/language-service", ...JSON.parse(lspconfig.value) }
-            } catch {
-              return yield* new InvalidLspConfigError({ lspconfig: lspconfig.value })
-            }
-          }
-          if (!pluginConfig) continue
+      state.totalFilesCount = filteredFilesToCheck.size
 
-          const rawResults = pipe(
-            LSP.getSemanticDiagnosticsWithCodeFixes(diagnosticsDefinitions, sourceFile),
-            TypeParser.nanoLayer,
-            TypeCheckerUtils.nanoLayer,
-            TypeScriptUtils.nanoLayer,
-            Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
-            Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
-            Nano.provideService(TypeScriptApi.TypeScriptApi, state.tsInstance),
-            Nano.provideService(
-              LanguageServicePluginOptions.LanguageServicePluginOptions,
-              {
-                ...LanguageServicePluginOptions.parse(pluginConfig, { projectRoot }),
-                diagnosticsName: false
-              }
-            ),
-            Nano.run,
-            Result.map((_) => _.diagnostics),
-            Result.map(
-              Array.map((_) =>
-                _.category === state.tsInstance.DiagnosticCategory.Suggestion
-                  ? { ..._, category: state.tsInstance.DiagnosticCategory.Message }
-                  : _
-              )
-            ),
-            Result.getOrElse(() => [])
-          )
+      let reporter: DiagnosticReporter | undefined
+      switch (format) {
+        case "pretty":
+          reporter = yield* diagnosticPrettyFormatter
+          break
+        case "text":
+          reporter = yield* diagnosticTextFormatter
+          break
+        case "json":
+          reporter = yield* diagnosticJsonFormatter
+          break
+        case "github-actions":
+          reporter = yield* diagnosticGitHubActionsFormatter
+          break
+        default:
+          reporter = yield* diagnosticPrettyFormatter
+      }
+      if (progress) {
+        reporter = yield* withDiagnosticsProgressFormatter(reporter)
+      }
 
-          // Apply severity filter if specified
-          const results = severityFilter
-            ? rawResults.filter((d) => severityFilter.has(categoryToSeverity(d.category, state.tsInstance)))
-            : rawResults
+      yield* reporter.onBegin(state)
 
-          state.checkedCount++
-          state.errorsCount += results.filter((_) => _.category === state.tsInstance.DiagnosticCategory.Error).length
-          state.warningsCount += results.filter((_) =>
-            _.category === state.tsInstance.DiagnosticCategory.Warning
-          ).length
-          state.messagesCount += results.filter((_) =>
-            _.category === state.tsInstance.DiagnosticCategory.Message
-          ).length
-
-          yield* reporter.onDiagnostics(state, filePath, results)
-        } finally {
-          service.closeClientFile(filePath)
+      const disposeIfLanguageServiceChanged = (languageService: ts.LanguageService | undefined) => {
+        if (state.languageService !== languageService) {
+          state.languageService?.dispose()
+          state.languageService = languageService
         }
       }
-      yield* Effect.yieldNow
+
+      for (const batch of Array.chunksOf(filteredFilesToCheck, BATCH_SIZE)) {
+        const { service } = createProjectService({ options: { loadTypeScriptPlugins: false } })
+
+        for (const filePath of batch) {
+          state.currentFileIndex++
+          yield* reporter.onFile(state, filePath)
+
+          service.openClientFile(filePath)
+          try {
+            const scriptInfo = service.getScriptInfo(filePath)
+            if (!scriptInfo) continue
+
+            const projectInfo = scriptInfo.getDefaultProject()
+            const languageService = projectInfo.getLanguageService(true)
+            disposeIfLanguageServiceChanged(languageService)
+            const program = languageService.getProgram()
+            if (!program) continue
+            const sourceFile = program.getSourceFile(filePath)
+            if (!sourceFile) continue
+            let pluginConfig = extractEffectLspOptions(program.getCompilerOptions())
+            if (Option.isSome(lspconfig)) {
+              try {
+                pluginConfig = { name: "@effect/language-service", ...JSON.parse(lspconfig.value) }
+              } catch {
+                return yield* new InvalidLspConfigError({ lspconfig: lspconfig.value })
+              }
+            }
+            if (!pluginConfig) continue
+
+            const rawResults = pipe(
+              LSP.getSemanticDiagnosticsWithCodeFixes(diagnosticsDefinitions, sourceFile),
+              TypeParser.nanoLayer,
+              TypeCheckerUtils.nanoLayer,
+              TypeScriptUtils.nanoLayer,
+              Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
+              Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
+              Nano.provideService(TypeScriptApi.TypeScriptApi, state.tsInstance),
+              Nano.provideService(
+                LanguageServicePluginOptions.LanguageServicePluginOptions,
+                {
+                  ...LanguageServicePluginOptions.parse(pluginConfig, { projectRoot }),
+                  diagnosticsName: false
+                }
+              ),
+              Nano.run,
+              Result.map((_) => _.diagnostics),
+              Result.map(
+                Array.map((_) =>
+                  _.category === state.tsInstance.DiagnosticCategory.Suggestion
+                    ? { ..._, category: state.tsInstance.DiagnosticCategory.Message }
+                    : _
+                )
+              ),
+              Result.getOrElse(() => [])
+            )
+
+            // Apply severity filter if specified
+            const results = severityFilter
+              ? rawResults.filter((d) => severityFilter.has(categoryToSeverity(d.category, state.tsInstance)))
+              : rawResults
+
+            state.checkedCount++
+            state.errorsCount += results.filter((_) => _.category === state.tsInstance.DiagnosticCategory.Error).length
+            state.warningsCount += results.filter((_) =>
+              _.category === state.tsInstance.DiagnosticCategory.Warning
+            ).length
+            state.messagesCount += results.filter((_) =>
+              _.category === state.tsInstance.DiagnosticCategory.Message
+            ).length
+
+            yield* reporter.onDiagnostics(state, filePath, results)
+          } finally {
+            service.closeClientFile(filePath)
+          }
+        }
+        yield* Effect.yieldNow
+      }
+      disposeIfLanguageServiceChanged(undefined)
+
+      yield* reporter.onEnd(state)
+
+      // Determine if we should fail based on errors (and warnings if --strict)
+      const hasFailures = state.errorsCount > 0 || (strict && state.warningsCount > 0)
+      if (hasFailures) return yield* Effect.sync(() => process.exit(1))
     }
-    disposeIfLanguageServiceChanged(undefined)
-
-    yield* reporter.onEnd(state)
-
-    // Determine if we should fail based on errors (and warnings if --strict)
-    const hasFailures = state.errorsCount > 0 || (strict && state.warningsCount > 0)
-    if (hasFailures) return yield* Effect.sync(() => process.exit(1))
-  })
+  )
 ).pipe(
   Command.withDescription("Gets the effect-language-service diagnostics on the given files or project.")
 )

--- a/packages/language-service/src/cli/diagnostics.ts
+++ b/packages/language-service/src/cli/diagnostics.ts
@@ -18,7 +18,7 @@ import * as TypeParser from "../core/TypeParser"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
 import { diagnostics as diagnosticsDefinitions } from "../diagnostics"
-import { extractEffectLspOptions, getFileNamesInTsConfig, TypeScriptContext } from "./utils"
+import { extractEffectLspOptions, filterFilesByPaths, getFileNamesInTsConfig, TypeScriptContext } from "./utils"
 
 interface DiagnosticReporterState {
   tsInstance: typeof ts
@@ -322,10 +322,17 @@ export const diagnostics = Command.make(
       Flag.withDescription(
         "An optional inline JSON lsp config that replaces the current project lsp config. e.g. '{ \"effectFn\": [\"untraced\"] }'"
       )
+    ),
+    paths: Flag.string("paths").pipe(
+      Flag.optional,
+      Flag.withDescription(
+        "Optional inline JSON path globs used to filter files after tsconfig discovery. e.g. '{ \"include\": [\"src/**/*\"], \"exclude\": [\"**/*.test.ts\"] }'"
+      )
     )
   },
-  Effect.fn("diagnostics")(function*({ file, format, lspconfig, progress, project, severity, strict }) {
+  Effect.fn("diagnostics")(function*({ file, format, lspconfig, paths, progress, project, severity, strict }) {
     const path = yield* Path.Path
+    const projectRoot = Option.isSome(project) ? path.dirname(project.value) : path.resolve(".")
     const severityFilter = parseSeverityFilter(severity)
     const state: DiagnosticReporterState = {
       tsInstance: yield* TypeScriptContext,
@@ -345,12 +352,13 @@ export const diagnostics = Command.make(
     if (Option.isSome(file)) {
       filesToCheck.add(path.resolve(file.value))
     }
+    const filteredFilesToCheck = yield* filterFilesByPaths(filesToCheck, projectRoot, paths)
 
-    if (filesToCheck.size === 0) {
+    if (filteredFilesToCheck.size === 0) {
       return yield* new NoFilesToCheckError()
     }
 
-    state.totalFilesCount = filesToCheck.size
+    state.totalFilesCount = filteredFilesToCheck.size
 
     let reporter: DiagnosticReporter | undefined
     switch (format) {
@@ -382,7 +390,7 @@ export const diagnostics = Command.make(
       }
     }
 
-    for (const batch of Array.chunksOf(filesToCheck, BATCH_SIZE)) {
+    for (const batch of Array.chunksOf(filteredFilesToCheck, BATCH_SIZE)) {
       const { service } = createProjectService({ options: { loadTypeScriptPlugins: false } })
 
       for (const filePath of batch) {
@@ -421,7 +429,10 @@ export const diagnostics = Command.make(
             Nano.provideService(TypeScriptApi.TypeScriptApi, state.tsInstance),
             Nano.provideService(
               LanguageServicePluginOptions.LanguageServicePluginOptions,
-              { ...LanguageServicePluginOptions.parse(pluginConfig), diagnosticsName: false }
+              {
+                ...LanguageServicePluginOptions.parse(pluginConfig, { projectRoot }),
+                diagnosticsName: false
+              }
             ),
             Nano.run,
             Result.map((_) => _.diagnostics),

--- a/packages/language-service/src/cli/pathGlobs.ts
+++ b/packages/language-service/src/cli/pathGlobs.ts
@@ -1,0 +1,25 @@
+import * as Option from "effect/Option"
+import * as LanguageServicePluginOptions from "../core/LanguageServicePluginOptions"
+
+export function parseGlobList(value: Option.Option<string>): Array<string> {
+  if (Option.isNone(value)) return []
+  return value.value
+    .split(",")
+    .map((glob) => glob.trim())
+    .filter((glob) => glob.length > 0)
+}
+
+export function makeFileGlobSpec(filters: {
+  include: Option.Option<string>
+  exclude: Option.Option<string>
+}): LanguageServicePluginOptions.LanguageServiceFileGlobSpec | undefined {
+  const include = parseGlobList(filters.include)
+  const exclude = parseGlobList(filters.exclude)
+  if (include.length === 0 && exclude.length === 0) {
+    return undefined
+  }
+  return LanguageServicePluginOptions.parseFileGlobSpec({
+    include: include.length > 0 ? include : ["**/*"],
+    exclude
+  })
+}

--- a/packages/language-service/src/cli/quickfixes.ts
+++ b/packages/language-service/src/cli/quickfixes.ts
@@ -159,14 +159,20 @@ export const quickfixes = Command.make(
       Flag.withDescription("Filter by fix name (e.g., 'floatingEffect_yieldStar')."),
       Flag.optional
     ),
-    paths: Flag.string("paths").pipe(
+    include: Flag.string("include").pipe(
       Flag.optional,
       Flag.withDescription(
-        "Optional inline JSON path globs used to filter files after tsconfig discovery. e.g. '{ \"include\": [\"src/**/*\"], \"exclude\": [\"**/*.test.ts\"] }'"
+        "Optional comma-separated include globs used to filter files after tsconfig discovery. e.g. 'src/**/*,test/**/*'"
+      )
+    ),
+    exclude: Flag.string("exclude").pipe(
+      Flag.optional,
+      Flag.withDescription(
+        "Optional comma-separated exclude globs used to filter files after tsconfig discovery. e.g. '**/*.test.ts,**/*.spec.ts'"
       )
     )
   },
-  Effect.fn("quickfixes")(function*({ code, column, file, fix, line, paths, project }) {
+  Effect.fn("quickfixes")(function*({ code, column, exclude, file, fix, include, line, project }) {
     // Validate that column requires line
     if (Option.isSome(column) && Option.isNone(line)) {
       return yield* new ColumnRequiresLineError()
@@ -184,7 +190,7 @@ export const quickfixes = Command.make(
     if (Option.isSome(file)) {
       filesToCheck.add(path.resolve(file.value))
     }
-    const filteredFilesToCheck = yield* filterFilesByPaths(filesToCheck, projectRoot, paths)
+    const filteredFilesToCheck = yield* filterFilesByPaths(filesToCheck, projectRoot, { include, exclude })
 
     if (filteredFilesToCheck.size === 0) {
       return yield* new NoFilesToCheckError()

--- a/packages/language-service/src/cli/quickfixes.ts
+++ b/packages/language-service/src/cli/quickfixes.ts
@@ -21,7 +21,7 @@ import { diagnostics as diagnosticsDefinitions } from "../diagnostics"
 import { ansi, BOLD, CYAN, DIM, YELLOW } from "./ansi"
 import { NoFilesToCheckError } from "./diagnostics"
 import { renderTextChange } from "./setup/diff-renderer"
-import { extractEffectLspOptions, getFileNamesInTsConfig, TypeScriptContext } from "./utils"
+import { extractEffectLspOptions, filterFilesByPaths, getFileNamesInTsConfig, TypeScriptContext } from "./utils"
 
 // Build a set of valid diagnostic names and codes for validation
 const validDiagnosticNames = new Set(diagnosticsDefinitions.map((_) => _.name))
@@ -158,9 +158,15 @@ export const quickfixes = Command.make(
     fix: Flag.string("fix").pipe(
       Flag.withDescription("Filter by fix name (e.g., 'floatingEffect_yieldStar')."),
       Flag.optional
+    ),
+    paths: Flag.string("paths").pipe(
+      Flag.optional,
+      Flag.withDescription(
+        "Optional inline JSON path globs used to filter files after tsconfig discovery. e.g. '{ \"include\": [\"src/**/*\"], \"exclude\": [\"**/*.test.ts\"] }'"
+      )
     )
   },
-  Effect.fn("quickfixes")(function*({ code, column, file, fix, line, project }) {
+  Effect.fn("quickfixes")(function*({ code, column, file, fix, line, paths, project }) {
     // Validate that column requires line
     if (Option.isSome(column) && Option.isNone(line)) {
       return yield* new ColumnRequiresLineError()
@@ -168,6 +174,7 @@ export const quickfixes = Command.make(
 
     const path = yield* Path.Path
     const tsInstance = yield* TypeScriptContext
+    const projectRoot = Option.isSome(project) ? path.dirname(project.value) : path.resolve(".")
 
     // Collect files to check
     const filesToCheck = Option.isSome(project)
@@ -177,14 +184,15 @@ export const quickfixes = Command.make(
     if (Option.isSome(file)) {
       filesToCheck.add(path.resolve(file.value))
     }
+    const filteredFilesToCheck = yield* filterFilesByPaths(filesToCheck, projectRoot, paths)
 
-    if (filesToCheck.size === 0) {
+    if (filteredFilesToCheck.size === 0) {
       return yield* new NoFilesToCheckError()
     }
 
     let totalDiagnosticsWithFixes = 0
 
-    for (const batch of Arr.chunksOf(filesToCheck, BATCH_SIZE)) {
+    for (const batch of Arr.chunksOf(filteredFilesToCheck, BATCH_SIZE)) {
       const { service } = createProjectService({ options: { loadTypeScriptPlugins: false } })
 
       for (const filePath of batch) {
@@ -215,7 +223,10 @@ export const quickfixes = Command.make(
             Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
             Nano.provideService(
               LanguageServicePluginOptions.LanguageServicePluginOptions,
-              { ...LanguageServicePluginOptions.parse(pluginConfig), diagnosticsName: false }
+              {
+                ...LanguageServicePluginOptions.parse(pluginConfig, { projectRoot }),
+                diagnosticsName: false
+              }
             ),
             Nano.run,
             Result.getOrElse(

--- a/packages/language-service/src/cli/utils.ts
+++ b/packages/language-service/src/cli/utils.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect"
 import * as Encoding from "effect/Encoding"
 import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
-import * as Option from "effect/Option"
+import type * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import * as Predicate from "effect/Predicate"
 import * as Result from "effect/Result"
@@ -12,6 +12,7 @@ import * as Schema from "effect/Schema"
 import type * as ts from "typescript"
 import * as LanguageServicePluginOptions from "../core/LanguageServicePluginOptions"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
+import { makeFileGlobSpec } from "./pathGlobs"
 
 const PackageJsonSchema = Schema.Struct({
   name: Schema.String,
@@ -344,14 +345,6 @@ export const getFileNamesInTsConfig = Effect.fn("getFileNamesInTsConfig")(functi
   return filesToCheck
 })
 
-function parseGlobList(value: Option.Option<string>): Array<string> {
-  if (Option.isNone(value)) return []
-  return value.value
-    .split(",")
-    .map((glob) => glob.trim())
-    .filter((glob) => glob.length > 0)
-}
-
 export const filterFilesByPaths = Effect.fn("filterFilesByPaths")(function*(
   files: Set<string>,
   projectRoot: string,
@@ -361,15 +354,10 @@ export const filterFilesByPaths = Effect.fn("filterFilesByPaths")(function*(
   }
 ) {
   const tsInstance = yield* TypeScriptContext
-  const include = parseGlobList(filters.include)
-  const exclude = parseGlobList(filters.exclude)
-  if (include.length === 0 && exclude.length === 0) {
+  const parsedPaths = makeFileGlobSpec(filters)
+  if (!parsedPaths) {
     return files
   }
-  const parsedPaths = LanguageServicePluginOptions.parseFileGlobSpec({
-    include: include.length > 0 ? include : ["**/*"],
-    exclude
-  })
   return new Set(
     [...files].filter((filePath) =>
       LanguageServicePluginOptions.matchesFileGlobs(tsInstance, parsedPaths, filePath, projectRoot)

--- a/packages/language-service/src/cli/utils.ts
+++ b/packages/language-service/src/cli/utils.ts
@@ -4,11 +4,13 @@ import * as Effect from "effect/Effect"
 import * as Encoding from "effect/Encoding"
 import * as FileSystem from "effect/FileSystem"
 import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
 import * as Path from "effect/Path"
 import * as Predicate from "effect/Predicate"
 import * as Result from "effect/Result"
 import * as Schema from "effect/Schema"
 import type * as ts from "typescript"
+import * as LanguageServicePluginOptions from "../core/LanguageServicePluginOptions"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
 
 const PackageJsonSchema = Schema.Struct({
@@ -49,6 +51,14 @@ export class UnableToFindInstalledTypeScriptPackage extends Data.TaggedError("Un
 }> {
   get message(): string {
     return `Unable to find an installed typescript package`
+  }
+}
+
+export class InvalidPathsConfigError extends Data.TaggedError("InvalidPathsConfigError")<{
+  paths: string
+}> {
+  get message(): string {
+    return `Invalid JSON paths config: ${this.paths}`
   }
 }
 
@@ -340,4 +350,32 @@ export const getFileNamesInTsConfig = Effect.fn("getFileNamesInTsConfig")(functi
     parsedConfig.fileNames.forEach((_) => filesToCheck.add(_))
   }
   return filesToCheck
+})
+
+export const parseInlinePathsConfig = Effect.fn("parseInlinePathsConfig")(function*(paths: Option.Option<string>) {
+  if (Option.isNone(paths)) {
+    return Option.none<LanguageServicePluginOptions.LanguageServiceFileGlobSpec>()
+  }
+  try {
+    return Option.some(LanguageServicePluginOptions.parseFileGlobSpec(JSON.parse(paths.value)))
+  } catch {
+    return yield* new InvalidPathsConfigError({ paths: paths.value })
+  }
+})
+
+export const filterFilesByPaths = Effect.fn("filterFilesByPaths")(function*(
+  files: Set<string>,
+  projectRoot: string,
+  paths: Option.Option<string>
+) {
+  const tsInstance = yield* TypeScriptContext
+  const parsedPaths = yield* parseInlinePathsConfig(paths)
+  if (Option.isNone(parsedPaths)) {
+    return files
+  }
+  return new Set(
+    [...files].filter((filePath) =>
+      LanguageServicePluginOptions.matchesFileGlobs(tsInstance, parsedPaths.value, filePath, projectRoot)
+    )
+  )
 })

--- a/packages/language-service/src/cli/utils.ts
+++ b/packages/language-service/src/cli/utils.ts
@@ -54,14 +54,6 @@ export class UnableToFindInstalledTypeScriptPackage extends Data.TaggedError("Un
   }
 }
 
-export class InvalidPathsConfigError extends Data.TaggedError("InvalidPathsConfigError")<{
-  paths: string
-}> {
-  get message(): string {
-    return `Invalid JSON paths config: ${this.paths}`
-  }
-}
-
 export type TypeScriptApi = typeof ts
 
 /**
@@ -352,30 +344,35 @@ export const getFileNamesInTsConfig = Effect.fn("getFileNamesInTsConfig")(functi
   return filesToCheck
 })
 
-export const parseInlinePathsConfig = Effect.fn("parseInlinePathsConfig")(function*(paths: Option.Option<string>) {
-  if (Option.isNone(paths)) {
-    return Option.none<LanguageServicePluginOptions.LanguageServiceFileGlobSpec>()
-  }
-  try {
-    return Option.some(LanguageServicePluginOptions.parseFileGlobSpec(JSON.parse(paths.value)))
-  } catch {
-    return yield* new InvalidPathsConfigError({ paths: paths.value })
-  }
-})
+function parseGlobList(value: Option.Option<string>): Array<string> {
+  if (Option.isNone(value)) return []
+  return value.value
+    .split(",")
+    .map((glob) => glob.trim())
+    .filter((glob) => glob.length > 0)
+}
 
 export const filterFilesByPaths = Effect.fn("filterFilesByPaths")(function*(
   files: Set<string>,
   projectRoot: string,
-  paths: Option.Option<string>
+  filters: {
+    include: Option.Option<string>
+    exclude: Option.Option<string>
+  }
 ) {
   const tsInstance = yield* TypeScriptContext
-  const parsedPaths = yield* parseInlinePathsConfig(paths)
-  if (Option.isNone(parsedPaths)) {
+  const include = parseGlobList(filters.include)
+  const exclude = parseGlobList(filters.exclude)
+  if (include.length === 0 && exclude.length === 0) {
     return files
   }
+  const parsedPaths = LanguageServicePluginOptions.parseFileGlobSpec({
+    include: include.length > 0 ? include : ["**/*"],
+    exclude
+  })
   return new Set(
     [...files].filter((filePath) =>
-      LanguageServicePluginOptions.matchesFileGlobs(tsInstance, parsedPaths.value, filePath, projectRoot)
+      LanguageServicePluginOptions.matchesFileGlobs(tsInstance, parsedPaths, filePath, projectRoot)
     )
   )
 })

--- a/packages/language-service/src/core/LSP.ts
+++ b/packages/language-service/src/core/LSP.ts
@@ -384,7 +384,12 @@ const createDiagnosticExecutor = Nano.fn("LSP.createCommentDirectivesProcessor")
       const diagnostics: Array<ts.Diagnostic> = []
       const codeFixes: Array<ApplicableDiagnosticDefinitionFixWithPositionAndCode> = []
       const ruleNameLowered = rule.name.toLowerCase()
-      const defaultLevel = pluginOptions.diagnosticSeverity[ruleNameLowered] || rule.severity
+      const effectiveDiagnosticSeverity = LanguageServicePluginOptions.getEffectiveDiagnosticSeverity(
+        ts,
+        pluginOptions,
+        sourceFile.fileName
+      )
+      const defaultLevel = effectiveDiagnosticSeverity[ruleNameLowered] || rule.severity
       // if file is skipped entirely, do not process the rule
       if (skippedRules.indexOf(ruleNameLowered) > -1 || skippedRules.indexOf("*") > -1) {
         return { diagnostics, codeFixes }

--- a/packages/language-service/src/core/LanguageServicePluginOptions.ts
+++ b/packages/language-service/src/core/LanguageServicePluginOptions.ts
@@ -3,6 +3,8 @@ import * as Array from "effect/Array"
 import { pipe } from "effect/Function"
 import { hasProperty, isBoolean, isNumber, isObject, isString } from "effect/Predicate"
 import * as Record from "effect/Record"
+import * as path from "node:path"
+import type * as ts from "typescript"
 import * as Nano from "./Nano"
 
 export type DiagnosticSeverity = "error" | "warning" | "message" | "suggestion"
@@ -15,10 +17,26 @@ export interface LanguageServicePluginOptionsKeyPattern {
   skipLeadingPath: Array<string>
 }
 
+export interface LanguageServicePluginOptionsOverride {
+  include: Array<string>
+  exclude: Array<string>
+  diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
+}
+
+export interface LanguageServicePluginParseContext {
+  projectRoot?: string | undefined
+}
+
+export interface LanguageServiceFileGlobSpec {
+  include: Array<string>
+  exclude: Array<string>
+}
+
 export interface LanguageServicePluginOptions {
   refactors: boolean
   diagnostics: boolean
   diagnosticSeverity: Record<string, DiagnosticSeverity | "off">
+  overrides: Array<LanguageServicePluginOptionsOverride>
   diagnosticsName: boolean
   missingDiagnosticNextLine: DiagnosticSeverity | "off"
   includeSuggestionsInTsc: boolean
@@ -45,6 +63,7 @@ export interface LanguageServicePluginOptions {
   layerGraphFollowDepth: number
   mermaidProvider: "mermaid.com" | "mermaid.live" | ({} & string)
   skipDisabledOptimization: boolean
+  projectRoot: string | undefined
 }
 
 export interface JsonSchema {
@@ -82,10 +101,41 @@ function parseDiagnosticSeverity(config: Record<PropertyKey, unknown>): Record<s
   )
 }
 
+function parseStringArray(config: unknown, fallback: Array<string>): Array<string> {
+  return isArray(config) && config.every(isString) ? config : fallback
+}
+
+export function parseFileGlobSpec(
+  config: unknown,
+  fallback: LanguageServiceFileGlobSpec = { include: ["**/*"], exclude: [] }
+): LanguageServiceFileGlobSpec {
+  if (!isObject(config)) return fallback
+  return {
+    include: parseStringArray(hasProperty(config, "include") ? config.include : undefined, fallback.include),
+    exclude: parseStringArray(hasProperty(config, "exclude") ? config.exclude : undefined, fallback.exclude)
+  }
+}
+
+function parseOverrides(config: unknown): Array<LanguageServicePluginOptionsOverride> {
+  if (!isArray(config)) return []
+  const result: Array<LanguageServicePluginOptionsOverride> = []
+  for (const entry of config) {
+    if (!isObject(entry)) continue
+    result.push({
+      ...parseFileGlobSpec(entry),
+      diagnosticSeverity: hasProperty(entry, "diagnosticSeverity") && isObject(entry.diagnosticSeverity)
+        ? parseDiagnosticSeverity(entry.diagnosticSeverity as Record<PropertyKey, unknown>)
+        : {}
+    })
+  }
+  return result
+}
+
 export const defaults: LanguageServicePluginOptions = {
   refactors: true,
   diagnostics: true,
   diagnosticSeverity: {},
+  overrides: [],
   diagnosticsName: true,
   missingDiagnosticNextLine: "warning",
   includeSuggestionsInTsc: true,
@@ -119,7 +169,8 @@ export const defaults: LanguageServicePluginOptions = {
   effectFn: ["span"],
   layerGraphFollowDepth: 0,
   mermaidProvider: "mermaid.live",
-  skipDisabledOptimization: false
+  skipDisabledOptimization: false,
+  projectRoot: undefined
 }
 
 const booleanSchema = (description: string, defaultValue: boolean): JsonSchema => ({
@@ -146,11 +197,38 @@ const stringEnumSchema = <A extends ReadonlyArray<string>>(
   default: defaultValue
 })
 
-type LanguageServicePluginAdditionalProperty = Exclude<keyof LanguageServicePluginOptions, "diagnosticSeverity">
+const effectPluginDiagnosticSeverityDefinitionRef =
+  "#/definitions/effectLanguageServicePluginDiagnosticSeverityDefinition"
+
+type LanguageServicePluginAdditionalProperty = Exclude<
+  keyof LanguageServicePluginOptions,
+  "diagnosticSeverity" | "projectRoot"
+>
 
 export const languageServicePluginAdditionalPropertiesJsonSchema = {
   refactors: booleanSchema("Controls Effect refactors.", defaults.refactors),
   diagnostics: booleanSchema("Controls Effect diagnostics.", defaults.diagnostics),
+  overrides: {
+    type: "array",
+    description: "Ordered per-file diagnostic severity overrides. Later overrides win.",
+    default: defaults.overrides,
+    items: {
+      type: "object",
+      properties: {
+        include: stringArraySchema(
+          "Glob patterns to include. Patterns are resolved relative to the project root.",
+          ["**/*"]
+        ),
+        exclude: stringArraySchema(
+          "Glob patterns to exclude after include matching. Patterns are resolved relative to the project root.",
+          []
+        ),
+        diagnosticSeverity: {
+          $ref: effectPluginDiagnosticSeverityDefinitionRef
+        }
+      }
+    }
+  },
   diagnosticsName: booleanSchema(
     "Controls whether to include the rule name in diagnostic messages.",
     defaults.diagnosticsName
@@ -293,7 +371,7 @@ function parseKeyPatterns(patterns: Array<unknown>): Array<LanguageServicePlugin
   return result
 }
 
-export function parse(config: any): LanguageServicePluginOptions {
+export function parse(config: any, context: LanguageServicePluginParseContext = {}): LanguageServicePluginOptions {
   return {
     refactors: isObject(config) && hasProperty(config, "refactors") && isBoolean(config.refactors)
       ? config.refactors
@@ -305,6 +383,9 @@ export function parse(config: any): LanguageServicePluginOptions {
       isObject(config) && hasProperty(config, "diagnosticSeverity") && isObject(config.diagnosticSeverity)
         ? parseDiagnosticSeverity(config.diagnosticSeverity as Record<PropertyKey, unknown>)
         : defaults.diagnosticSeverity,
+    overrides: isObject(config) && hasProperty(config, "overrides")
+      ? parseOverrides(config.overrides)
+      : defaults.overrides,
     diagnosticsName: isObject(config) && hasProperty(config, "diagnosticsName") && isBoolean(config.diagnosticsName)
       ? config.diagnosticsName
       : defaults.diagnosticsName,
@@ -404,6 +485,59 @@ export function parse(config: any): LanguageServicePluginOptions {
     skipDisabledOptimization: isObject(config) && hasProperty(config, "skipDisabledOptimization") &&
         isBoolean(config.skipDisabledOptimization)
       ? config.skipDisabledOptimization
-      : defaults.skipDisabledOptimization
+      : defaults.skipDisabledOptimization,
+    projectRoot: context.projectRoot ?? defaults.projectRoot
   }
+}
+
+function normalizeFilePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/")
+}
+
+function resolveCandidateFilePath(filePath: string, projectRoot: string | undefined): string {
+  if (path.isAbsolute(filePath)) {
+    return normalizeFilePath(filePath)
+  }
+  return normalizeFilePath(projectRoot ? path.resolve(projectRoot, filePath) : filePath)
+}
+
+function matchesPatterns(
+  tsInstance: typeof ts,
+  filePath: string,
+  patterns: Array<string>,
+  projectRoot: string | undefined,
+  usage: "files" | "exclude"
+): boolean {
+  if (patterns.length === 0) return false
+  const candidate = resolveCandidateFilePath(filePath, projectRoot)
+  const basePath = normalizeFilePath(projectRoot ? path.resolve(projectRoot) : process.cwd())
+  const regexText = (tsInstance as typeof ts & {
+    getRegularExpressionForWildcard: (patterns: Array<string>, basePath: string, usage: "files" | "exclude") => string
+  }).getRegularExpressionForWildcard(patterns, basePath, usage)
+  return regexText ? new RegExp(regexText).test(candidate) : false
+}
+
+export function matchesFileGlobs(
+  tsInstance: typeof ts,
+  spec: LanguageServiceFileGlobSpec,
+  filePath: string,
+  projectRoot: string | undefined
+): boolean {
+  const isIncluded = matchesPatterns(tsInstance, filePath, spec.include, projectRoot, "files")
+  const isExcluded = matchesPatterns(tsInstance, filePath, spec.exclude, projectRoot, "exclude")
+  return isIncluded && !isExcluded
+}
+
+export function getEffectiveDiagnosticSeverity(
+  tsInstance: typeof ts,
+  pluginOptions: LanguageServicePluginOptions,
+  filePath: string
+): Record<string, DiagnosticSeverity | "off"> {
+  let severity = pluginOptions.diagnosticSeverity
+  for (const override of pluginOptions.overrides) {
+    if (matchesFileGlobs(tsInstance, override, filePath, pluginOptions.projectRoot)) {
+      severity = { ...severity, ...override.diagnosticSeverity }
+    }
+  }
+  return severity
 }

--- a/packages/language-service/src/effect-lsp-patch-utils.ts
+++ b/packages/language-service/src/effect-lsp-patch-utils.ts
@@ -2,6 +2,7 @@ import * as Array from "effect/Array"
 import { pipe } from "effect/Function"
 import * as Predicate from "effect/Predicate"
 import * as Result from "effect/Result"
+import * as path from "node:path"
 import type * as ts from "typescript"
 import * as LanguageServicePluginOptions from "./core/LanguageServicePluginOptions"
 import * as LSP from "./core/LSP"
@@ -56,9 +57,12 @@ export function checkSourceFileWorker(
   // check if the plugin is enabled
   const pluginOptions = extractEffectLspOptions(compilerOptions)
   if (!pluginOptions) return
+  const projectRoot = typeof compilerOptions.configFilePath === "string"
+    ? path.dirname(compilerOptions.configFilePath)
+    : process.cwd()
 
   const parsedOptions: LanguageServicePluginOptions.LanguageServicePluginOptions = {
-    ...LanguageServicePluginOptions.parse(pluginOptions),
+    ...LanguageServicePluginOptions.parse(pluginOptions, { projectRoot }),
     diagnosticsName: true
   }
 
@@ -113,7 +117,11 @@ export function extractDiagnosticsForExitStatus(
   _moduleName: string
 ) {
   const options = extractEffectLspOptions(program.getCompilerOptions())
-  const parsedOptions = LanguageServicePluginOptions.parse(options)
+  const compilerOptions = program.getCompilerOptions()
+  const projectRoot = typeof compilerOptions.configFilePath === "string"
+    ? path.dirname(compilerOptions.configFilePath)
+    : process.cwd()
+  const parsedOptions = LanguageServicePluginOptions.parse(options, { projectRoot })
 
   let newDiagnostics = diagnostics
 

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -43,16 +43,20 @@ const init = (
     // eslint-disable-next-line no-empty, @typescript-eslint/no-unused-vars
   } catch (_) {}
 
+  let projectRoot: string | undefined
   let languageServicePluginOptions: LanguageServicePluginOptions.LanguageServicePluginOptions =
     LanguageServicePluginOptions.parse({})
 
+  const parseProjectConfig = (config: unknown) => LanguageServicePluginOptions.parse(config, { projectRoot })
+
   function onConfigurationChanged(config: any) {
-    languageServicePluginOptions = LanguageServicePluginOptions.parse(config)
+    languageServicePluginOptions = parseProjectConfig(config)
   }
 
   function create(info: ts.server.PluginCreateInfo) {
     const languageService = info.languageService
-    languageServicePluginOptions = LanguageServicePluginOptions.parse(info.config)
+    projectRoot = info.project.getCurrentDirectory?.()
+    languageServicePluginOptions = parseProjectConfig(info.config)
 
     // prevent double-injection of the effect language service
     if ((languageService as any)[LSP_INJECTED_URI]) return languageService

--- a/packages/language-service/src/transform.ts
+++ b/packages/language-service/src/transform.ts
@@ -1,6 +1,7 @@
 import * as Array from "effect/Array"
 import { pipe } from "effect/Function"
 import * as Result from "effect/Result"
+import * as path from "node:path"
 import type { PluginConfig, TransformerExtras } from "ts-patch"
 import type * as ts from "typescript"
 import * as LanguageServicePluginOptions from "./core/LanguageServicePluginOptions"
@@ -18,6 +19,7 @@ export default function(
   pluginConfig: PluginConfig,
   { addDiagnostic, ts: tsInstance }: TransformerExtras
 ) {
+  const configFilePath = program.getCompilerOptions().configFilePath
   return (_: ts.TransformationContext) => {
     return (sourceFile: ts.SourceFile) => {
       // run the diagnostics and pipe them into addDiagnostic
@@ -31,7 +33,11 @@ export default function(
         Nano.provideService(TypeScriptApi.TypeScriptApi, tsInstance),
         Nano.provideService(
           LanguageServicePluginOptions.LanguageServicePluginOptions,
-          LanguageServicePluginOptions.parse(pluginConfig)
+          LanguageServicePluginOptions.parse(pluginConfig, {
+            projectRoot: typeof configFilePath === "string"
+              ? path.dirname(configFilePath)
+              : process.cwd()
+          })
         ),
         Nano.run,
         Result.map((_) => _.diagnostics),

--- a/packages/language-service/test/cli-diagnostics.test.ts
+++ b/packages/language-service/test/cli-diagnostics.test.ts
@@ -1,3 +1,4 @@
+import { makeFileGlobSpec, parseGlobList } from "@effect/language-service/cli/pathGlobs"
 import * as Option from "effect/Option"
 import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
@@ -114,6 +115,42 @@ describe("CLI Diagnostics", () => {
       expect(result?.has("error")).toBe(true)
       expect(result?.has("warning")).toBe(true)
       expect(result?.has("message")).toBe(true)
+    })
+  })
+
+  describe("parseGlobList", () => {
+    it("should return an empty array for None option", () => {
+      expect(parseGlobList(Option.none())).toEqual([])
+    })
+
+    it("should parse a single glob", () => {
+      expect(parseGlobList(Option.some("src/**/*"))).toEqual(["src/**/*"])
+    })
+
+    it("should parse comma-separated globs", () => {
+      expect(parseGlobList(Option.some("src/**/*,test/**/*"))).toEqual([
+        "src/**/*",
+        "test/**/*"
+      ])
+    })
+
+    it("should trim whitespace and drop empty entries", () => {
+      expect(parseGlobList(Option.some(" src/**/* , , **/*.test.ts "))).toEqual([
+        "src/**/*",
+        "**/*.test.ts"
+      ])
+    })
+
+    it("should build a file glob spec from include and exclude flags", () => {
+      expect(
+        makeFileGlobSpec({
+          include: Option.some("src/**/*,test/**/*"),
+          exclude: Option.some("**/*.test.ts")
+        })
+      ).toEqual({
+        include: ["src/**/*", "test/**/*"],
+        exclude: ["**/*.test.ts"]
+      })
     })
   })
 

--- a/packages/language-service/test/internals.test.ts
+++ b/packages/language-service/test/internals.test.ts
@@ -1,6 +1,8 @@
+import * as LanguageServicePluginOptions from "@effect/language-service/core/LanguageServicePluginOptions"
 import * as Nano from "@effect/language-service/core/Nano"
 import { pipe } from "effect/Function"
 import * as Result from "effect/Result"
+import * as ts from "typescript"
 import { configFromSourceComment } from "./utils/mocks"
 
 import { describe, expect, it } from "vitest"
@@ -16,6 +18,103 @@ describe("configFromSourceComment", () => {
   it("should return an empty object if there is no config", () => {
     const config = configFromSourceComment("console.log('hello')")
     expect(config).toEqual({})
+  })
+})
+
+describe("getEffectiveDiagnosticSeverity", () => {
+  it("parses file glob specs with sane defaults", () => {
+    expect(LanguageServicePluginOptions.parseFileGlobSpec({})).toEqual({
+      include: ["**/*"],
+      exclude: []
+    })
+    expect(
+      LanguageServicePluginOptions.parseFileGlobSpec({
+        include: ["src/**/*"],
+        exclude: ["**/*.test.ts"]
+      })
+    ).toEqual({
+      include: ["src/**/*"],
+      exclude: ["**/*.test.ts"]
+    })
+  })
+
+  it("matches file globs relative to the project root", () => {
+    const spec = LanguageServicePluginOptions.parseFileGlobSpec({
+      include: ["src/**/*"],
+      exclude: ["src/**/*.test.ts"]
+    })
+
+    expect(LanguageServicePluginOptions.matchesFileGlobs(ts, spec, "/repo/src/index.ts", "/repo")).toBe(true)
+    expect(LanguageServicePluginOptions.matchesFileGlobs(ts, spec, "/repo/src/index.test.ts", "/repo")).toBe(false)
+    expect(LanguageServicePluginOptions.matchesFileGlobs(ts, spec, "/repo/test/index.ts", "/repo")).toBe(false)
+  })
+
+  it("applies ordered overrides by file glob", () => {
+    const options = LanguageServicePluginOptions.parse(
+      {
+        diagnosticSeverity: {
+          strictEffectProvide: "warning"
+        },
+        overrides: [
+          {
+            include: ["test/**/*"],
+            diagnosticSeverity: {
+              strictEffectProvide: "off"
+            }
+          },
+          {
+            include: ["test/integration/**/*"],
+            diagnosticSeverity: {
+              strictEffectProvide: "error"
+            }
+          },
+          {
+            include: ["test/fixtures/**/*"],
+            exclude: ["test/fixtures/allowed/**/*"],
+            diagnosticSeverity: {
+              strictEffectProvide: "message"
+            }
+          }
+        ]
+      },
+      { projectRoot: "/repo" }
+    )
+
+    expect(LanguageServicePluginOptions.getEffectiveDiagnosticSeverity(ts, options, "/repo/src/index.ts")).toEqual({
+      stricteffectprovide: "warning"
+    })
+    expect(
+      LanguageServicePluginOptions.getEffectiveDiagnosticSeverity(ts, options, "/repo/test/unit/example.test.ts")
+    ).toEqual({
+      stricteffectprovide: "off"
+    })
+    expect(
+      LanguageServicePluginOptions.getEffectiveDiagnosticSeverity(
+        ts,
+        options,
+        "/repo/test/integration/example.test.ts"
+      )
+    ).toEqual({
+      stricteffectprovide: "error"
+    })
+    expect(
+      LanguageServicePluginOptions.getEffectiveDiagnosticSeverity(
+        ts,
+        options,
+        "/repo/test/fixtures/disallowed/example.test.ts"
+      )
+    ).toEqual({
+      stricteffectprovide: "message"
+    })
+    expect(
+      LanguageServicePluginOptions.getEffectiveDiagnosticSeverity(
+        ts,
+        options,
+        "/repo/test/fixtures/allowed/example.test.ts"
+      )
+    ).toEqual({
+      stricteffectprovide: "off"
+    })
   })
 })
 


### PR DESCRIPTION
## summary
- add ordered per-file `overrides` to plugin config so diagnostic severities can differ between `src` and `test` within one tsconfig
- add shell-native `--include` / `--exclude` filtering to `diagnostics`, `quickfixes`, and `codegen`
- thread project root through the plugin, patched tsc flow, and transformer so glob resolution is stable

## example
```json
{
  "overrides": [
    {
      "include": ["test/**/*"],
      "diagnosticSeverity": {
        "strictEffectProvide": "off"
      }
    }
  ]
}
```

```bash
effect-language-service diagnostics \
  --project tsconfig.json \
  --include 'src/**/*' \
  --exclude '**/*.test.ts'
```

## validation
- `pnpm --filter @effect/language-service test -- --run test/internals.test.ts test/cli-diagnostics.test.ts`
- `git diff --check`
- `pnpm --filter @effect/language-service exec eslint src/cli/utils.ts src/cli/diagnostics.ts src/cli/quickfixes.ts src/cli/codegen.ts --fix`

## note
- `pnpm --filter @effect/language-service build` is already red on current `main` because `src/cli/utils.ts` imports `effect/Context`, but the pinned `effect@4.0.0-beta.37` package no longer exports that path. this pr does not introduce that mismatch.
- current branch head: `d806738`
