### PR TITLE
Update Effect v4 beta dependencies to 4.0.0-beta.68

### DIFF
--- a/.changeset/update-effect-v4-beta-68.md
+++ b/.changeset/update-effect-v4-beta-68.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Update the Effect v4 beta dependencies to 4.0.0-beta.68.

--- a/packages/harness-effect-v4/package.json
+++ b/packages/harness-effect-v4/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "effect": "^4.0.0-beta.66"
+    "effect": "^4.0.0-beta.68"
   },
   "devDependencies": {
     "@types/node": "^25.0.6"

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -43,10 +43,10 @@
     "perf": "tsx test/perf.ts"
   },
   "devDependencies": {
-    "@effect/platform-node": "^4.0.0-beta.66",
+    "@effect/platform-node": "^4.0.0-beta.68",
     "@types/pako": "^2.0.4",
     "@typescript-eslint/project-service": "^8.52.0",
-    "effect": "^4.0.0-beta.66",
+    "effect": "^4.0.0-beta.68",
     "pako": "^2.1.0",
     "ts-patch": "^3.3.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       effect:
-        specifier: ^4.0.0-beta.66
-        version: 4.0.0-beta.66
+        specifier: ^4.0.0-beta.68
+        version: 4.0.0-beta.68
     devDependencies:
       '@types/node':
         specifier: ^25.0.6
@@ -134,8 +134,8 @@ importers:
   packages/language-service:
     devDependencies:
       '@effect/platform-node':
-        specifier: ^4.0.0-beta.66
-        version: 4.0.0-beta.66(effect@4.0.0-beta.66)(ioredis@5.10.0)
+        specifier: ^4.0.0-beta.68
+        version: 4.0.0-beta.68(effect@4.0.0-beta.68)(ioredis@5.10.0)
       '@types/pako':
         specifier: ^2.0.4
         version: 2.0.4
@@ -143,8 +143,8 @@ importers:
         specifier: ^8.52.0
         version: 8.52.0(typescript@5.9.3)
       effect:
-        specifier: ^4.0.0-beta.66
-        version: 4.0.0-beta.66
+        specifier: ^4.0.0-beta.68
+        version: 4.0.0-beta.68
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -575,29 +575,29 @@ packages:
       uuid: 11.1.0
     dev: false
 
-  /@effect/platform-node-shared@4.0.0-beta.66(effect@4.0.0-beta.66):
-    resolution: {integrity: sha512-+ymrhBnESv/hmn5SKTe2//IY9Ox/hGPeoogEWhW47ZGyhFI5eMYFxdEUBa+3IAV05rrBzrxON9lynu68n0DM7w==}
+  /@effect/platform-node-shared@4.0.0-beta.68(effect@4.0.0-beta.68):
+    resolution: {integrity: sha512-a6q/Rid2CQQBSoTIhBnT2oCozeaEvx5DXreSdT4jbvxPSC0j2l0EqcYdHgvEGDqvhocIAezgmSQbcHNcnyDg8w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.66
+      effect: ^4.0.0-beta.68
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.66
+      effect: 4.0.0-beta.68
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: true
 
-  /@effect/platform-node@4.0.0-beta.66(effect@4.0.0-beta.66)(ioredis@5.10.0):
-    resolution: {integrity: sha512-s/0RgaQFuszzdorRnX1PwEQNnSOi+JgMJo3zEe9O2NR3sosMhTr0Uk+1AF6bUOI9uJ2CPT3KpTIIU7q5/TpOkg==}
+  /@effect/platform-node@4.0.0-beta.68(effect@4.0.0-beta.68)(ioredis@5.10.0):
+    resolution: {integrity: sha512-q2WakGBfZ5wIg9WdL4flbIwxC5TNFq1/qroT4HRT9yOl19dLg0khd2LE9ewOybOPrTQHV3PUyV3Sx6Y3eMYTWQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.66
+      effect: ^4.0.0-beta.68
       ioredis: ^5.7.0
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.66(effect@4.0.0-beta.66)
-      effect: 4.0.0-beta.66
+      '@effect/platform-node-shared': 4.0.0-beta.68(effect@4.0.0-beta.68)
+      effect: 4.0.0-beta.68
       ioredis: 5.10.0
       mime: 4.1.0
       undici: 8.2.0
@@ -2835,18 +2835,18 @@ packages:
       fast-check: 3.23.2
     dev: false
 
-  /effect@4.0.0-beta.66:
-    resolution: {integrity: sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw==}
+  /effect@4.0.0-beta.68:
+    resolution: {integrity: sha512-JVmKXJvpyKBzr4xEr9nRlA6wQoInsI2WCfu2F69On49hvyDAmAOMb5ACa51HJksvRdqbSg7Zf0d++NQebY9cFQ==}
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
       find-my-way-ts: 0.1.6
-      ini: 6.0.0
+      ini: 7.0.0
       kubernetes-types: 1.30.0
-      msgpackr: 1.11.12
+      msgpackr: 2.0.1
       multipasta: 0.2.7
       toml: 4.1.1
-      uuid: 13.0.0
+      uuid: 14.0.0
       yaml: 2.9.0
 
   /electron-to-chromium@1.5.267:
@@ -3878,9 +3878,9 @@ packages:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  /ini@6.0.0:
-    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  /ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   /internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -4622,16 +4622,16 @@ packages:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
     optional: true
 
-  /msgpackr@1.11.12:
-    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
-    optionalDependencies:
-      msgpackr-extract: 3.0.3
-
   /msgpackr@1.11.8:
     resolution: {integrity: sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==}
     optionalDependencies:
       msgpackr-extract: 3.0.3
     dev: false
+
+  /msgpackr@2.0.1:
+    resolution: {integrity: sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==}
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
 
   /multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
@@ -6095,8 +6095,8 @@ packages:
     hasBin: true
     dev: false
 
-  /uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  /uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   /validate-npm-package-license@3.0.4:


### PR DESCRIPTION
## Summary
- update `effect` to `4.0.0-beta.68` in the v4 harness and language service package
- update `@effect/platform-node` to `4.0.0-beta.68`
- refresh `pnpm-lock.yaml` and add a patch changeset

## Verification
- `pnpm --filter @effect/language-service check`

## Notes
- full TypeScript workflow steps were skipped because this branch only changes package manifests and the lockfile