### PR TITLE
Preserve applicableGotoDefinition when ancestor type cannot be resolved

### DIFF
--- a/.changeset/preserve-applicable-goto-on-jsx.md
+++ b/.changeset/preserve-applicable-goto-on-jsx.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix `effectRpcDefinition` wiping the upstream go-to-definition result when the user clicks on a JSX `<Namespace.Component />` tag name. The plugin's RpcClient → Rpc enrichment now skips ancestor nodes whose type cannot be resolved (such as JSX tag-name nodes) instead of returning `undefined` for the entire request.

--- a/packages/language-service/src/goto/effectRpcDefinition.ts
+++ b/packages/language-service/src/goto/effectRpcDefinition.ts
@@ -68,7 +68,12 @@ export function effectRpcDefinition(
         tsUtils.isNodeInRange(textRange)(node.name)
       ) {
         const type = typeCheckerUtils.getTypeAtLocation(node)
-        if (!type) return undefined
+        // Skip ancestors whose type the checker cannot resolve (e.g. JSX
+        // tag-name nodes, which `getTypeAtLocation` deliberately returns
+        // `undefined` for). Returning `undefined` here would wipe the
+        // upstream `applicableGotoDefinition`, breaking cmd+click on JSX
+        // components.
+        if (!type) continue
         for (const callSig of typeChecker.getSignaturesOfType(type, ts.SignatureKind.Call)) {
           // we detect if it is an RPC api based on where the options simbol is declared from
           if (callSig.parameters.length >= 2 && isSymbolFromEffectRpcClientModule(callSig.parameters[1])) {

--- a/packages/language-service/test/goto.test.ts
+++ b/packages/language-service/test/goto.test.ts
@@ -1,0 +1,108 @@
+import * as Nano from "@effect/language-service/core/Nano"
+import * as TypeCheckerApi from "@effect/language-service/core/TypeCheckerApi"
+import * as TypeCheckerUtils from "@effect/language-service/core/TypeCheckerUtils"
+import * as TypeScriptApi from "@effect/language-service/core/TypeScriptApi"
+import * as TypeScriptUtils from "@effect/language-service/core/TypeScriptUtils"
+import { effectRpcDefinition } from "@effect/language-service/goto/effectRpcDefinition"
+import { pipe } from "effect/Function"
+import * as Result from "effect/Result"
+import * as fs from "fs"
+import * as path from "path"
+import * as ts from "typescript"
+import { describe, expect, it } from "vitest"
+import { getExamplesSubdir, getHarnessDir } from "./utils/harness.js"
+import { createServicesWithMockedVFS } from "./utils/mocks.js"
+
+function runEffectRpcDefinition(
+  applicableGotoDefinition: ts.DefinitionInfoAndBoundSpan | undefined,
+  sourceFile: ts.SourceFile,
+  position: number,
+  program: ts.Program
+) {
+  return pipe(
+    effectRpcDefinition(applicableGotoDefinition, sourceFile, position),
+    TypeCheckerUtils.nanoLayer,
+    TypeScriptUtils.nanoLayer,
+    Nano.provideService(TypeCheckerApi.TypeCheckerApi, program.getTypeChecker()),
+    Nano.provideService(TypeScriptApi.TypeScriptProgram, program),
+    Nano.provideService(TypeScriptApi.TypeScriptApi, ts),
+    Nano.unsafeRun
+  )
+}
+
+const fakeApplicable = (span: ts.TextSpan, fileName: string): ts.DefinitionInfoAndBoundSpan => ({
+  textSpan: span,
+  definitions: [{
+    fileName,
+    textSpan: { start: 0, length: 0 },
+    kind: ts.ScriptElementKind.functionElement,
+    name: "ImaginaryDefinition",
+    containerKind: ts.ScriptElementKind.moduleElement,
+    containerName: "ImaginaryContainer"
+  }]
+})
+
+describe("effectRpcDefinition", () => {
+  it(
+    "preserves applicableGotoDefinition when clicking a JSX <Namespace.Component /> tag name",
+    () => {
+      const fileName = "/jsx.tsx"
+      const sourceText = `
+const Lib = { Component: () => null as any }
+export const x = <Lib.Component />
+`
+      const { program, sourceFile } = createServicesWithMockedVFS(
+        "/",
+        "/",
+        fileName,
+        sourceText,
+        { jsx: ts.JsxEmit.ReactJSX }
+      )
+
+      // Position the cursor in the middle of "Component" inside the JSX tag.
+      const idx = sourceText.indexOf("Lib.Component") + "Lib.".length + 1
+      const applicable = fakeApplicable(
+        { start: idx, length: "Component".length },
+        fileName
+      )
+
+      const result = runEffectRpcDefinition(applicable, sourceFile, idx, program)
+      expect(Result.isSuccess(result)).toBe(true)
+      // The bug: effectRpcDefinition returns `undefined` when the type
+      // checker cannot resolve a JSX tag-name node, wiping the upstream
+      // result. It must preserve `applicableGotoDefinition`.
+      if (Result.isSuccess(result)) {
+        expect(result.success).toEqual(applicable)
+      }
+    }
+  )
+
+  const fixtureFile = "rpc.ts"
+  const fixturePath = path.join(getExamplesSubdir("goto"), fixtureFile)
+
+  // The RPC enrichment fixture currently lives only in harness-effect-v3.
+  it.skipIf(!fs.existsSync(fixturePath))(
+    "enriches the definition with the server-side Rpc.fromTaggedRequest when clicking an RpcClient method call",
+    () => {
+      const sourceText = fs.readFileSync(fixturePath, "utf8")
+      const { program, sourceFile } = createServicesWithMockedVFS(
+        getHarnessDir(),
+        path.dirname(path.dirname(fixturePath)),
+        fixtureFile,
+        sourceText
+      )
+
+      // Position cursor inside `MakeReservation` of `client.MakeReservation({...})`.
+      const idx = sourceText.indexOf("MakeReservation({") + 1
+      const applicable = fakeApplicable({ start: idx, length: "MakeReservation".length }, fixtureFile)
+
+      const result = runEffectRpcDefinition(applicable, sourceFile, idx, program)
+      expect(Result.isSuccess(result)).toBe(true)
+      if (Result.isSuccess(result)) {
+        const defs = result.success?.definitions ?? []
+        const fromRpcDefs = defs.filter((d) => d.fileName.endsWith("rpc_defs.ts"))
+        expect(fromRpcDefs.length).toBeGreaterThan(0)
+      }
+    }
+  )
+})


### PR DESCRIPTION
## Problem

`effectRpcDefinition` walks the clicked position's ancestors and calls `typeCheckerUtils.getTypeAtLocation` on each `PropertyAccessExpression`. That helper returns `undefined` by design for JSX tag-name nodes (`TypeCheckerUtils.ts:488-491`). The current early-out — `if (!type) return undefined` — exits the whole function with `undefined`, and the wrapper's `getOrElse(() => applicableDefinition)` only catches Nano errors, not successful `undefined` results. The upstream go-to-definition is discarded and VS Code shows "No definition found".

The symptom is intermittent because whether the JSX `PropertyAccessExpression` is selected as the in-range ancestor depends on the exact cursor offset.

## Solution

Replace `return undefined` with `continue` so the loop skips ancestors whose type the checker won't resolve and keeps checking the rest. If no ancestor turns out to be an RpcClient call, the function falls through to the existing exit that returns `applicableGotoDefinition` unchanged.

## Verification

Two commits, in this order:

1. **`test:`** adds a failing reproducer for the JSX case plus a regression test for the existing RpcClient → `Rpc.fromTaggedRequest` enrichment. Check out this commit to see the JSX test red and the enrichment test green.
2. **fix** flips `return undefined` to `continue` and adds a changeset. Both tests green.

Full suite: 645 pass, 0 fail.

---

LLM-assisted; please sanity-check the reasoning.