### PR TITLE
Update the README for deprecated VSCode TypeScript settings

### DIFF
--- a/.changeset/update-vscode-typescript-settings-docs.md
+++ b/.changeset/update-vscode-typescript-settings-docs.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Update README to replace deprecated VSCode TypeScript settings (`typescript.tsdk` and `typescript.enablePromptUseWorkspaceTsdk`) with the current recommended configuration.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This package implements a TypeScript language service plugin that allows additio
        - Not required, but to remember the user to do so, you can update your `.vscode/settings.json`
          ```jsonc
          {
-           "typescript.tsdk": "./node_modules/typescript/lib",
-           "typescript.enablePromptUseWorkspaceTsdk": true
+            "js/ts.tsdk.path": "node_modules/typescript/lib",
+            "js/ts.tsdk.promptToUseWorkspaceVersion": true
          }
          ```
    - In JetBrains you may have to disable the Vue language service, and choose the workspace version of TypeScript in the settings from the dropdown.


### PR DESCRIPTION
## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The installation instructions in `README.md` recommended adding the following to `.vscode/settings.json`:

```json
{
  "typescript.tsdk": "./node_modules/typescript/lib",
  "typescript.enablePromptUseWorkspaceTsdk": true
}
```

Both settings are deprecated in newer VS Code versions:
- `typescript.tsdk` → replaced by `typescript.workspaceSymlink`
- `typescript.enablePromptUseWorkspaceTsdk` → replaced by `typescript.workspaceSymlinkPrompt`

This caused confusion for users setting up the workspace TypeScript version for the Effect language service plugin.

## Changes

Updated `README.md` to replace both deprecated settings with their current equivalents, so users get correct, warning-free configuration out of the box.