### PR TITLE
Fix lazyPromiseInEffectSync any false positives

### DIFF
--- a/.changeset/fix-lazy-promise-any.md
+++ b/.changeset/fix-lazy-promise-any.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Fix `lazyPromiseInEffectSync` false positives for `Effect.sync` thunks whose return type degrades to `any`. Promise detection now ignores `any` and `unknown` before falling back to assignability against the global `Promise` type.

--- a/packages/harness-effect-v3/examples/diagnostics/lazyPromiseInEffectSync.ts
+++ b/packages/harness-effect-v3/examples/diagnostics/lazyPromiseInEffectSync.ts
@@ -18,3 +18,12 @@ export const fromThenable = Effect.sync(() => thenableValue)
 
 // Should NOT trigger - already using the async constructor
 export const fromEffectPromise = Effect.promise(() => Promise.resolve(1))
+
+declare const anyValue: any
+declare const unknownValue: unknown
+
+// Should NOT trigger - any is not enough evidence that the thunk returns a Promise
+export const fromAny = Effect.sync(() => anyValue)
+
+// Should NOT trigger - unknown is not enough evidence that the thunk returns a Promise
+export const fromUnknown = Effect.sync(() => unknownValue)

--- a/packages/harness-effect-v4/examples/diagnostics/lazyPromiseInEffectSync.ts
+++ b/packages/harness-effect-v4/examples/diagnostics/lazyPromiseInEffectSync.ts
@@ -18,3 +18,12 @@ export const fromThenable = Effect.sync(() => thenableValue)
 
 // Should NOT trigger - already using the async constructor
 export const fromEffectPromise = Effect.promise(() => Promise.resolve(1))
+
+declare const anyValue: any
+declare const unknownValue: unknown
+
+// Should NOT trigger - any is not enough evidence that the thunk returns a Promise
+export const fromAny = Effect.sync(() => anyValue)
+
+// Should NOT trigger - unknown is not enough evidence that the thunk returns a Promise
+export const fromUnknown = Effect.sync(() => unknownValue)

--- a/packages/language-service/src/core/TypeParser.ts
+++ b/packages/language-service/src/core/TypeParser.ts
@@ -2012,6 +2012,10 @@ export function make(
       if (!promiseSymbol) return typeParserIssue("global Promise type not found", type, atLocation)
       const globalPromiseType = typeChecker.getDeclaredTypeOfSymbol(promiseSymbol)
 
+      if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+        return typeParserIssue("type is not a Promise (any/unknown)", type, atLocation)
+      }
+
       if (
         type === globalPromiseType ||
         ("target" in type && (type as ts.TypeReference).target === globalPromiseType) ||


### PR DESCRIPTION
## Summary
- Stop treating `any` and `unknown` return types as Promise types in `TypeParser.promiseType` before the assignability fallback.
- Add v3 and v4 `lazyPromiseInEffectSync` regression fixture cases for `Effect.sync` thunks returning `any` and `unknown`.
- Add a patch changeset.

## Testing
- `pnpm codegen`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test`
- `pnpm test:v4`