### PR TITLE
Fix unnecessary Effect.gen nested yield false positive

### DIFF
--- a/.changeset/fix-unnecessary-effect-gen-nested-yield.md
+++ b/.changeset/fix-unnecessary-effect-gen-nested-yield.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Avoid suggesting removal of `Effect.gen` when a single return statement contains multiple `yield*` expressions, which would produce invalid code.

--- a/packages/harness-effect-v3/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.codefixes
+++ b/packages/harness-effect-v3/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.codefixes
@@ -1,0 +1,1 @@
+no codefixes

--- a/packages/harness-effect-v3/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.output
+++ b/packages/harness-effect-v3/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.output
@@ -1,0 +1,1 @@
+// no diagnostics

--- a/packages/harness-effect-v3/examples/diagnostics/unnecessaryEffectGen_nestedYield.ts
+++ b/packages/harness-effect-v3/examples/diagnostics/unnecessaryEffectGen_nestedYield.ts
@@ -1,0 +1,8 @@
+import * as Effect from "effect/Effect"
+
+const foo = () => Effect.succeed(100)
+const bar = (x: number) => Effect.succeed(x + x)
+
+export const program = Effect.gen(function*() {
+  return yield* bar(yield* foo())
+})

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.codefixes
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.codefixes
@@ -1,0 +1,1 @@
+no codefixes

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/unnecessaryEffectGen_nestedYield.ts.output
@@ -1,0 +1,1 @@
+// no diagnostics

--- a/packages/harness-effect-v4/examples/diagnostics/unnecessaryEffectGen_nestedYield.ts
+++ b/packages/harness-effect-v4/examples/diagnostics/unnecessaryEffectGen_nestedYield.ts
@@ -1,0 +1,8 @@
+import * as Effect from "effect/Effect"
+
+const foo = () => Effect.succeed(100)
+const bar = (x: number) => Effect.succeed(x + x)
+
+export const program = Effect.gen(function*() {
+  return yield* bar(yield* foo())
+})

--- a/packages/language-service/src/core/TypeParser.ts
+++ b/packages/language-service/src/core/TypeParser.ts
@@ -1566,6 +1566,24 @@ export function make(
         // yield* XXX
         if (ts.isYieldExpression(nodeToCheck) && nodeToCheck.asteriskToken && nodeToCheck.expression) {
           const yieldedExpression = nodeToCheck.expression
+          let hasNestedYieldStar = false
+          const findNestedYieldStar = (current: ts.Node) => {
+            if (hasNestedYieldStar) return
+            if (current !== yieldedExpression && ts.isFunctionLike(current)) return
+            if (ts.isYieldExpression(current) && current.asteriskToken) {
+              hasNestedYieldStar = true
+              return
+            }
+            ts.forEachChild(current, findNestedYieldStar)
+          }
+          findNestedYieldStar(yieldedExpression)
+          if (hasNestedYieldStar) {
+            return yield* typeParserIssue(
+              "Yielded expression should not contain a nested yield* expression",
+              undefined,
+              node
+            )
+          }
           const type = typeCheckerUtils.getTypeAtLocation(yieldedExpression)
           if (!type) continue
           const { A: successType } = yield* effectType(type, yieldedExpression)


### PR DESCRIPTION
## Summary
- Avoid reporting `unnecessaryEffectGen` when the yielded expression contains a nested `yield*`.
- Add v3 and v4 regression fixtures for a single-return `Effect.gen` with multiple `yield*` expressions.
- Add a patch changeset.

## Tests
- `pnpm codegen`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test`
- `pnpm test:v4`