### PR TITLE
fix(cli): diagnostics no longer skips files resolved to an inferred project

### DIFF
--- a/.changeset/fix-diagnostics-inferred-project-skip.md
+++ b/.changeset/fix-diagnostics-inferred-project-skip.md
@@ -1,0 +1,9 @@
+---
+"@effect/language-service": patch
+---
+
+Fix the `diagnostics` CLI command silently skipping files that the project service resolves to an inferred project.
+
+The command read the plugin config per file from that file's program `compilerOptions` and skipped the file when no `@effect/language-service` plugin entry was found. Files assigned to an inferred project (common on a `moduleResolution: bundler` project that remaps `effect` through `paths`, or one whose `include` pulls in external files) carry no plugins entry, so they were dropped. This produced summaries like `Checked 3 files out of 27` even though `overview` processed all 27 with the same per-file machinery.
+
+The command now falls back to the plugin config parsed once from the `--project` tsconfig, and finally to a bare default, so every file with a source file is checked and the file's own `diagnosticSeverity` is still honored when present.

--- a/packages/language-service/src/cli/diagnostics.ts
+++ b/packages/language-service/src/cli/diagnostics.ts
@@ -18,7 +18,12 @@ import * as TypeParser from "../core/TypeParser"
 import * as TypeScriptApi from "../core/TypeScriptApi"
 import * as TypeScriptUtils from "../core/TypeScriptUtils"
 import { diagnostics as diagnosticsDefinitions } from "../diagnostics"
-import { extractEffectLspOptions, getFileNamesInTsConfig, TypeScriptContext } from "./utils"
+import {
+  getEffectLspOptionsFromTsConfig,
+  getFileNamesInTsConfig,
+  resolveEffectLspPluginConfig,
+  TypeScriptContext
+} from "./utils"
 
 interface DiagnosticReporterState {
   tsInstance: typeof ts
@@ -350,6 +355,13 @@ export const diagnostics = Command.make(
       return yield* new NoFilesToCheckError()
     }
 
+    // Plugin config read once from the --project tsconfig. Used as a fallback for
+    // files the project service resolves to an inferred project, whose per-file
+    // compilerOptions carry no plugins entry.
+    const projectPluginConfig = Option.isSome(project)
+      ? yield* getEffectLspOptionsFromTsConfig(project.value)
+      : undefined
+
     state.totalFilesCount = filesToCheck.size
 
     let reporter: DiagnosticReporter | undefined
@@ -401,7 +413,7 @@ export const diagnostics = Command.make(
           if (!program) continue
           const sourceFile = program.getSourceFile(filePath)
           if (!sourceFile) continue
-          let pluginConfig = extractEffectLspOptions(program.getCompilerOptions())
+          let pluginConfig = resolveEffectLspPluginConfig(program.getCompilerOptions(), projectPluginConfig)
           if (Option.isSome(lspconfig)) {
             try {
               pluginConfig = { name: "@effect/language-service", ...JSON.parse(lspconfig.value) }
@@ -409,7 +421,6 @@ export const diagnostics = Command.make(
               return yield* new InvalidLspConfigError({ lspconfig: lspconfig.value })
             }
           }
-          if (!pluginConfig) continue
 
           const rawResults = pipe(
             LSP.getSemanticDiagnosticsWithCodeFixes(diagnosticsDefinitions, sourceFile),

--- a/packages/language-service/src/cli/utils.ts
+++ b/packages/language-service/src/cli/utils.ts
@@ -316,6 +316,44 @@ export const extractEffectLspOptions = (compilerOptions: ts.CompilerOptions) => 
     : []).find((_) => Predicate.hasProperty(_, "name") && _.name === "@effect/language-service")
 }
 
+/**
+ * Resolves the effect-language-service plugin config to use when checking a file.
+ *
+ * The per-file program's compilerOptions are the primary source, so a file's own
+ * tsconfig diagnosticSeverity is honored. A file that the project service resolves
+ * to an inferred project carries no plugins entry, so we fall back to the config
+ * parsed once from the --project tsconfig, and finally to a bare default. Returning
+ * a config unconditionally (never undefined) means every file with a source file is
+ * checked, matching the overview command, instead of being silently skipped.
+ */
+export const resolveEffectLspPluginConfig = (
+  fileCompilerOptions: ts.CompilerOptions,
+  projectFallback: ts.PluginImport | undefined
+): ts.PluginImport =>
+  extractEffectLspOptions(fileCompilerOptions) ?? projectFallback ?? { name: "@effect/language-service" }
+
+/**
+ * Reads the effect-language-service plugin config directly from a tsconfig, so it
+ * can serve as a fallback for files the project service assigns to an inferred
+ * project (whose compilerOptions do not carry the plugins array).
+ */
+export const getEffectLspOptionsFromTsConfig = Effect.fn("getEffectLspOptionsFromTsConfig")(
+  function*(tsconfigPath: string) {
+    const path = yield* Path.Path
+    const tsInstance = yield* TypeScriptContext
+    const resolved = path.resolve(tsconfigPath)
+    const tsconfigAbsolutePath = resolved.endsWith("tsconfig.json") ? resolved : path.resolve(resolved, "tsconfig.json")
+    const configFile = tsInstance.readConfigFile(tsconfigAbsolutePath, tsInstance.sys.readFile)
+    if (configFile.error) return undefined
+    const parsedConfig = tsInstance.parseJsonConfigFileContent(
+      configFile.config,
+      tsInstance.sys,
+      path.dirname(tsconfigAbsolutePath)
+    )
+    return extractEffectLspOptions(parsedConfig.options)
+  }
+)
+
 export const getFileNamesInTsConfig = Effect.fn("getFileNamesInTsConfig")(function*(tsconfigPath: string) {
   const path = yield* Path.Path
   const tsInstance = yield* TypeScriptContext

--- a/packages/language-service/test/cli-diagnostics.test.ts
+++ b/packages/language-service/test/cli-diagnostics.test.ts
@@ -1,6 +1,7 @@
 import * as Option from "effect/Option"
 import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
+import { resolveEffectLspPluginConfig } from "../src/cli/utils"
 
 // Import the functions and types we're testing
 // Note: These would need to be exported from diagnostics.ts for testing
@@ -247,6 +248,37 @@ describe("CLI Diagnostics", () => {
       const filtered = applyFilter(diagnostics, undefined)
 
       expect(filtered.length).toBe(3)
+    })
+  })
+
+  describe("resolveEffectLspPluginConfig", () => {
+    const effectPlugin = { name: "@effect/language-service", diagnosticSeverity: { floatingEffect: "error" } }
+
+    it("uses the file's own plugin config when present", () => {
+      const fileOptions: ts.CompilerOptions = { plugins: [effectPlugin] }
+      const projectFallback: ts.PluginImport = { name: "@effect/language-service" }
+      expect(resolveEffectLspPluginConfig(fileOptions, projectFallback)).toBe(effectPlugin)
+    })
+
+    it("falls back to the project config when the file has no plugins entry", () => {
+      // A file the project service assigns to an inferred project carries no plugins.
+      const fileOptions: ts.CompilerOptions = {}
+      expect(resolveEffectLspPluginConfig(fileOptions, effectPlugin)).toBe(effectPlugin)
+    })
+
+    it("falls back to the project config when the file's plugins omit effect", () => {
+      const fileOptions: ts.CompilerOptions = {
+        plugins: [{ name: "some-other-plugin" }]
+      }
+      expect(resolveEffectLspPluginConfig(fileOptions, effectPlugin)).toBe(effectPlugin)
+    })
+
+    it("falls back to a bare default so the file is never skipped", () => {
+      // Neither the file nor the project carry an effect plugin config. Returning a
+      // config unconditionally is what stops the diagnostics command from silently
+      // skipping the file (the regression this guards against).
+      const fileOptions: ts.CompilerOptions = {}
+      expect(resolveEffectLspPluginConfig(fileOptions, undefined)).toEqual({ name: "@effect/language-service" })
     })
   })
 })


### PR DESCRIPTION
Fixes #748.

## Problem

`effect-language-service diagnostics --project tsconfig.json` reported `Checked 3 files out of 27` and 0 findings on a `moduleResolution: bundler` project (effect beta.88, an `effect` -> `.d.ts` `paths` remap, a few external files in `include`), while `overview --project` on the same tsconfig processed all 27 files with the same per-file machinery.

## Cause

`diagnostics` and `overview` open every file the same way (`getFileNamesInTsConfig` -> `createProjectService` -> `openClientFile` -> `getDefaultProject().getLanguageService().getProgram()`). The difference is two extra guards in `diagnostics`:

```ts
let pluginConfig = extractEffectLspOptions(program.getCompilerOptions())
// ...
if (!pluginConfig) continue
```

The plugin config is read from each file's program `compilerOptions`. When the project service assigns a file to an inferred project (which happens for the file shapes above), that program has no `plugins` entry, so `extractEffectLspOptions` returns `undefined` and the file is skipped without incrementing `checkedCount`. `overview` has no such guard, so it checks everything.

## Fix

Resolve the plugin config with a fallback chain instead of skipping:

1. the file's own program `compilerOptions` (so a file's `diagnosticSeverity` is still honored),
2. the plugin config parsed once from the `--project` tsconfig (`getEffectLspOptionsFromTsConfig`),
3. a bare `{ name: "@effect/language-service" }` default.

`resolveEffectLspPluginConfig` always returns a config, so the `if (!pluginConfig) continue` is removed and every file with a source file is checked. This also fixes the same under-reporting for `diagnostics --file <path>` in these projects.

## Verification

- New unit tests for `resolveEffectLspPluginConfig` (file config wins, project fallback, omitted-effect fallback, bare default). `test/cli-diagnostics.test.ts` green (24 tests).
- `tsc -b` and `eslint` clean.
- Built the CLI and ran it against the original repro project: `Checked 53 files out of 53` (was `Checked 3 of 27`), same 0 findings.

No new diagnostic/refactor/completion, so no README or metadata codegen change.
