### PR TITLE
Guard unsupported TypeScript versions

### DIFF
--- a/.changeset/green-snakes-patch.md
+++ b/.changeset/green-snakes-patch.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Reject unsupported TypeScript versions when loading or patching TypeScript, directing TypeScript 7 users to @effect/tsgo.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: The version of Node.js to install
     required: true
-    default: 23.7.0
+    default: 24.15.0
   registry-url:
     description: Optional registry to set up for auth
 

--- a/packages/language-service/src/cli/patch.ts
+++ b/packages/language-service/src/cli/patch.ts
@@ -13,7 +13,8 @@ import {
   getTypeScriptApisUtils,
   getUnpatchedSourceFile,
   makeEffectLspPatchChange,
-  TypeScriptContext
+  TypeScriptContext,
+  TypeScriptFoundIsNot5Or6
 } from "./utils"
 
 export class UnableToFindPositionToPatchError extends Data.TaggedError("UnableToFindPositionToPatchError")<{
@@ -350,6 +351,14 @@ export const patch = Command.make(
     yield* Effect.logDebug(`Searching for typescript in ${dirPath}...`)
     const { version: typescriptVersion } = yield* getPackageJsonData(dirPath)
     yield* Effect.logDebug(`Found typescript version ${typescriptVersion}!`)
+
+    // confirm that's 5 or 6
+    if (!typescriptVersion.startsWith("5") && !typescriptVersion.startsWith("6")) {
+      yield* Effect.logError(
+        "@effect/language-service supports only typescript 5 or 6, for 7 support look into @effect/tsgo."
+      )
+      return yield* new TypeScriptFoundIsNot5Or6()
+    }
 
     const modulesToPatch = moduleNames.length === 0 ? ["typescript", "tsc"] as const : moduleNames
     for (const moduleName of modulesToPatch) {

--- a/packages/language-service/src/cli/utils.ts
+++ b/packages/language-service/src/cli/utils.ts
@@ -52,6 +52,12 @@ export class UnableToFindInstalledTypeScriptPackage extends Data.TaggedError("Un
   }
 }
 
+export class TypeScriptFoundIsNot5Or6 extends Data.TaggedError("TypeScriptFoundIsNot5Or6")<{}> {
+  get message(): string {
+    return `@effect/language-service supports TypeScript 5.x and 6.x; for TypeScript 7.x and forward use @effect/tsgo or refer to side-by-side usage on https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0.`
+  }
+}
+
 export type TypeScriptApi = typeof ts
 
 /**
@@ -69,19 +75,29 @@ export class TypeScriptContext extends Context.Service<TypeScriptContext, TypeSc
   static live = (cwd: string) =>
     Layer.effect(
       TypeScriptContext,
-      Effect.try({
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        try: () => require(require.resolve("typescript", { paths: [cwd] })) as typeof ts,
-        catch: (cause) => new UnableToFindInstalledTypeScriptPackage({ cause })
-      }).pipe(
-        Effect.catch(() =>
-          Effect.try({
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            try: () => require("typescript") as typeof ts,
-            catch: (cause) => new UnableToFindInstalledTypeScriptPackage({ cause })
-          })
+      Effect.gen(function*() {
+        const tsModule = yield* Effect.try({
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          try: () => require(require.resolve("typescript", { paths: [cwd] })) as typeof ts,
+          catch: (cause) => new UnableToFindInstalledTypeScriptPackage({ cause })
+        }).pipe(
+          Effect.catch(() =>
+            Effect.try({
+              // eslint-disable-next-line @typescript-eslint/no-require-imports
+              try: () => require("typescript") as typeof ts,
+              catch: (cause) => new UnableToFindInstalledTypeScriptPackage({ cause })
+            })
+          )
         )
-      )
+
+        const tsVersion = tsModule.versionMajorMinor || "N"
+
+        if (!tsVersion.startsWith("5") && !tsVersion.startsWith("6")) {
+          return yield* new TypeScriptFoundIsNot5Or6()
+        }
+
+        return tsModule
+      })
     )
 }
 


### PR DESCRIPTION
## Summary
- Reject TypeScript versions outside 5.x/6.x when loading the TypeScript API.
- Reject unsupported TypeScript versions in the patch command with guidance for TypeScript 7 users.
- Add a patch changeset.

## Tests
- pnpm codegen
- pnpm lint-fix
- pnpm check
- pnpm test
- pnpm test:v4