### PR TITLE
fix: ignore declaratio file

### DIFF
--- a/packages/language-service/src/effect-lsp-patch-utils.ts
+++ b/packages/language-service/src/effect-lsp-patch-utils.ts
@@ -57,6 +57,8 @@ export function checkSourceFileWorker(
   const pluginOptions = extractEffectLspOptions(compilerOptions)
   if (!pluginOptions) return
 
+  if (sourceFile.isDeclarationFile) return
+
   const parsedOptions: LanguageServicePluginOptions.LanguageServicePluginOptions = {
     ...LanguageServicePluginOptions.parse(pluginOptions),
     diagnosticsName: true

--- a/packages/language-service/test/diagnostics.test.ts
+++ b/packages/language-service/test/diagnostics.test.ts
@@ -13,6 +13,8 @@ import * as fs from "fs"
 import * as path from "path"
 import * as ts from "typescript"
 import { describe, expect, it } from "vitest"
+
+import { checkSourceFileWorker } from "@effect/language-service/effect-lsp-patch-utils"
 import {
   getExamplesDir,
   getExamplesSubdir,
@@ -322,6 +324,34 @@ function testAllDagnostics() {
 }
 
 describe("Diagnostics", () => {
+  it("should not produce diagnostics on .d.ts declaration files", () => {
+    const sourceText = `// @effect-diagnostics extendsNativeError:warning
+export declare class DOMException extends Error {}
+`
+    const { program, sourceFile } = createServicesWithMockedVFS(
+      getHarnessDir(),
+      getExamplesDir(),
+      "extendsNativeError_declaration.d.ts",
+      sourceText,
+      {}
+    )
+
+    const collected: ts.Diagnostic[] = []
+    const compilerOptions = program.getCompilerOptions()
+    compilerOptions.plugins = [{ name: "@effect/language-service" }]
+
+    checkSourceFileWorker(
+      ts,
+      program,
+      sourceFile,
+      compilerOptions,
+      (d) => collected.push(d),
+      "tsc"
+    )
+
+    expect(collected).toEqual([])
+  })
+
   it("the diagnostic code should be unique among all diagnostics", () => {
     const codes = diagnostics.reduce((acc, d) => {
       acc[d.code] = (acc[d.code] || 0) + 1


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->
- [x] Bug Fix

## Description

<!--
Please add a brief summary/description of the pull request here.
-->
When the language service patches tsc via effect-language-service patch, it hooks into
checkSourceFileWorker and runs diagnostics on every file in the TypeScript program — including
.d.ts declaration files from node_modules. TypeScript's skipLibCheck correctly suppresses its
own errors for those files, but Effect diagnostics run independently and don't check
sourceFile.isDeclarationFile.

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Closes #752 
