### PR TITLE
Update Effect v4 beta dependencies to 4.0.0-beta.94

### DIFF
--- a/.changeset/update-effect-v4-beta.md
+++ b/.changeset/update-effect-v4-beta.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Update the Effect v4 harness and language-service development dependencies to Effect 4.0.0-beta.94, including compatibility updates for the latest Effect API and Schema type output.

--- a/packages/harness-effect-v4/__snapshots__/refactors/toggleTypeAnnotation_schema.ts.ln11col15.output
+++ b/packages/harness-effect-v4/__snapshots__/refactors/toggleTypeAnnotation_schema.ts.ln11col15.output
@@ -8,5 +8,5 @@ class Person extends Schema.Class<Person>("Person")({
   name: Schema.NonEmptyString,
   age: Schema.Int
 }) {
-  static decode: (input: { readonly name: string; readonly age: number }, options?: ParseOption.ParseOptions) => Effect.Effect<Person, Schema.SchemaError> = Schema.decodeEffect(Person)
+  static decode: (input: Schema.Struct.ReadonlySide<{ readonly name: Schema.NonEmptyString; readonly age: Schema.Int }, "Encoded">, options?: ParseOption.ParseOptions) => Effect.Effect<Person, Schema.SchemaError> = Schema.decodeEffect(Person)
 }

--- a/packages/harness-effect-v4/__snapshots__/refactors/toggleTypeAnnotation_unnamed.ts.ln4col15.output
+++ b/packages/harness-effect-v4/__snapshots__/refactors/toggleTypeAnnotation_unnamed.ts.ln4col15.output
@@ -1,6 +1,6 @@
 // Result of running refactor toggleTypeAnnotation at position 4:15
 import * as Schema from "effect/Schema"
 
-export const debug: (input: { readonly id: import("node_modules/effect/dist/Option", { with: { "resolution-mode": "import" } }).Option<number> }, options?: Schema.MakeOptions) => { readonly id: import("node_modules/effect/dist/Option", { with: { "resolution-mode": "import" } }).Option<number> } = Schema.Struct({
+export const debug: (input: Schema.Struct.ReadonlyMakeIn<{ readonly id: Schema.Option<Schema.Number> }>, options?: Schema.MakeOptions) => Schema.Struct.ReadonlySide<{ readonly id: Schema.Option<Schema.Number> }, "Type"> = Schema.Struct({
   id: Schema.Option(Schema.Number)
 }).make

--- a/packages/harness-effect-v4/package.json
+++ b/packages/harness-effect-v4/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "effect": "^4.0.0-beta.68"
+    "effect": "^4.0.0-beta.94"
   },
   "devDependencies": {
     "@types/node": "^25.0.6"

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -43,10 +43,10 @@
     "perf": "tsx test/perf.ts"
   },
   "devDependencies": {
-    "@effect/platform-node": "^4.0.0-beta.68",
+    "@effect/platform-node": "^4.0.0-beta.94",
     "@types/pako": "^2.0.4",
     "@typescript-eslint/project-service": "^8.52.0",
-    "effect": "^4.0.0-beta.68",
+    "effect": "^4.0.0-beta.94",
     "pako": "^2.1.0",
     "ts-patch": "^3.3.0"
   }

--- a/packages/language-service/src/core/LayerGraph.ts
+++ b/packages/language-service/src/core/LayerGraph.ts
@@ -540,8 +540,8 @@ export interface LayerMagicResult {
   missingOutputTypes: Set<ts.Type>
 }
 
-export const dfsPostOrderWithOrder = <N, E, T extends Graph.Kind = "directed">(
-  graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>,
+export const dfsPostOrderWithOrder = <N, E>(
+  graph: Graph.Graph<N, E, "directed"> | Graph.MutableGraph<N, E, "directed">,
   config: Graph.SearchConfig & { order: Order.Order<N> }
 ): Graph.NodeWalker<N> => {
   const start = config.start ?? []
@@ -654,8 +654,8 @@ export const convertOutlineGraphToLayerMagic = Nano.fn("convertOutlineGraphToLay
 )
 
 // walk the graph and emit nodes matching the predicate, where no children match the predicate
-export const walkLeavesMatching = <N, E, T extends Graph.Kind = "directed">(
-  graph: Graph.Graph<N, E, T> | Graph.MutableGraph<N, E, T>,
+export const walkLeavesMatching = <N, E>(
+  graph: Graph.Graph<N, E, "directed"> | Graph.MutableGraph<N, E, "directed">,
   predicate: (node: N) => boolean,
   config: Graph.SearchConfig = {}
 ): Graph.NodeWalker<N> => {

--- a/packages/language-service/src/diagnostics/outdatedApi.db.ts
+++ b/packages/language-service/src/diagnostics/outdatedApi.db.ts
@@ -582,9 +582,7 @@ export const effectModuleMigrationDb: ModuleMigrationDb = {
   "transposeMapOption": asRemoved(
     "Use Effect.map with Option operations instead."
   ),
-  "transposeOption": asRemoved(
-    "Use Effect.option instead."
-  ),
+  "transposeOption": asUnchanged,
   "tryMap": asRemoved(
     "Use Effect.map inside Effect.try instead."
   ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       effect:
-        specifier: ^4.0.0-beta.68
-        version: 4.0.0-beta.68
+        specifier: ^4.0.0-beta.94
+        version: 4.0.0-beta.94
     devDependencies:
       '@types/node':
         specifier: ^25.0.6
@@ -134,8 +134,8 @@ importers:
   packages/language-service:
     devDependencies:
       '@effect/platform-node':
-        specifier: ^4.0.0-beta.68
-        version: 4.0.0-beta.68(effect@4.0.0-beta.68)(ioredis@5.10.0)
+        specifier: ^4.0.0-beta.94
+        version: 4.0.0-beta.94(effect@4.0.0-beta.94)(ioredis@5.10.0)
       '@types/pako':
         specifier: ^2.0.4
         version: 2.0.4
@@ -143,8 +143,8 @@ importers:
         specifier: ^8.52.0
         version: 8.52.0(typescript@5.9.3)
       effect:
-        specifier: ^4.0.0-beta.68
-        version: 4.0.0-beta.68
+        specifier: ^4.0.0-beta.94
+        version: 4.0.0-beta.94
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -575,29 +575,29 @@ packages:
       uuid: 11.1.0
     dev: false
 
-  /@effect/platform-node-shared@4.0.0-beta.68(effect@4.0.0-beta.68):
-    resolution: {integrity: sha512-a6q/Rid2CQQBSoTIhBnT2oCozeaEvx5DXreSdT4jbvxPSC0j2l0EqcYdHgvEGDqvhocIAezgmSQbcHNcnyDg8w==}
+  /@effect/platform-node-shared@4.0.0-beta.94(effect@4.0.0-beta.94):
+    resolution: {integrity: sha512-8mCen8dhL4ockkkxevKdFOXqR8sksuZcPwyqkKZv3w30TIdj4TKXG5sQODmpPFI0+/quwm5T78kodqf/QlZwoA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.68
+      effect: ^4.0.0-beta.94
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.68
+      effect: 4.0.0-beta.94
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
     dev: true
 
-  /@effect/platform-node@4.0.0-beta.68(effect@4.0.0-beta.68)(ioredis@5.10.0):
-    resolution: {integrity: sha512-q2WakGBfZ5wIg9WdL4flbIwxC5TNFq1/qroT4HRT9yOl19dLg0khd2LE9ewOybOPrTQHV3PUyV3Sx6Y3eMYTWQ==}
+  /@effect/platform-node@4.0.0-beta.94(effect@4.0.0-beta.94)(ioredis@5.10.0):
+    resolution: {integrity: sha512-3WhV5ZN2pTPcOtEQlM66Ve0/B4EzF88sYBml97NnRV7BA5Kx0FYLSslc/4aWoaXj6XwuWOxmoXeGGeFzw4gbMQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.68
+      effect: ^4.0.0-beta.94
       ioredis: ^5.7.0
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.68(effect@4.0.0-beta.68)
-      effect: 4.0.0-beta.68
+      '@effect/platform-node-shared': 4.0.0-beta.94(effect@4.0.0-beta.94)
+      effect: 4.0.0-beta.94
       ioredis: 5.10.0
       mime: 4.1.0
       undici: 8.2.0
@@ -2835,8 +2835,8 @@ packages:
       fast-check: 3.23.2
     dev: false
 
-  /effect@4.0.0-beta.68:
-    resolution: {integrity: sha512-JVmKXJvpyKBzr4xEr9nRlA6wQoInsI2WCfu2F69On49hvyDAmAOMb5ACa51HJksvRdqbSg7Zf0d++NQebY9cFQ==}
+  /effect@4.0.0-beta.94:
+    resolution: {integrity: sha512-Q8BrCNbp/3Uh+7xQYHphZBkNfm2SJnl1frQ+8yWfd/j3SU3cL13D38cBMLcnULupwza2Nt4DrjZoMzHWL3CoxQ==}
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0


### PR DESCRIPTION
## Summary
- update Effect v4 dependencies to 4.0.0-beta.94
- adjust Effect v4 migration metadata for transposeOption returning to the API
- update graph helper types and v4 refactor snapshots for beta.94 type output

## Tests
- pnpm codegen
- pnpm lint-fix
- pnpm check
- pnpm test
- pnpm test:v4