### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,9 +12,9 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v6
     - name: Install node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         cache: pnpm
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,11 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install dependencies
         uses: ./.github/actions/setup
         with:
           registry-url: "https://registry.npmjs.org"
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
       - run: pnpm build
       - name: Check source state
         run: git add packages && git diff-index --cached HEAD --exit-code packages

--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install dependencies
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install dependencies
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         harness: [v3, v4]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install dependencies
         uses: ./.github/actions/setup
       - run: pnpm test:${{ matrix.harness }}


### PR DESCRIPTION
## Summary
- update checkout, setup-node, and pnpm setup actions to current major versions
- remove the manual npm upgrade step now that setup-node provides a newer npm toolchain

## Testing
- git diff --check