### PR TITLE
Skip external libraries with skipLibCheck

### DIFF
--- a/.changeset/skip-external-libraries.md
+++ b/.changeset/skip-external-libraries.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Skip Effect diagnostics for external library files in patched tsc runs when TypeScript `skipLibCheck` is enabled.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Few options can be provided alongside the initialization of the Language Service
         "ignoreEffectErrorsInTscExitCode": false, // if set to true, effect-related errors won't change the exit code of tsc (default: false)
         "ignoreEffectSuggestionsInTscExitCode": true, // if set to true, effect-related suggestions won't change the exit code of tsc (default: true)
         "skipDisabledOptimization": false, // if set to true, disabled diagnostics are still processed so per-line or per-section overrides can be honored in patched tsc runs (default: false)
+        "excludeExternalLibrariesWhenSkipLibCheck": true, // when enabled with skipLibCheck, external library files are skipped by patched tsc diagnostics (default: true)
         "quickinfo": true, // controls Effect quickinfo (default: true)
         "quickinfoEffectParameters": "whenTruncated", // (default: "whenTruncated") controls when to display effect type parameters always,never,whenTruncated
         "quickinfoMaximumLength": -1, // controls how long can be the types in the quickinfo hover (helps with very long type to improve perfs, defaults to -1 for no truncation, can be any number eg. 1000 and TS will try to fit as much as possible in that budget, higher number means more info.)

--- a/packages/language-service/src/core/LanguageServicePluginOptions.ts
+++ b/packages/language-service/src/core/LanguageServicePluginOptions.ts
@@ -45,6 +45,7 @@ export interface LanguageServicePluginOptions {
   layerGraphFollowDepth: number
   mermaidProvider: "mermaid.com" | "mermaid.live" | ({} & string)
   skipDisabledOptimization: boolean
+  excludeExternalLibrariesWhenSkipLibCheck: boolean
 }
 
 export interface JsonSchema {
@@ -119,7 +120,8 @@ export const defaults: LanguageServicePluginOptions = {
   effectFn: ["span"],
   layerGraphFollowDepth: 0,
   mermaidProvider: "mermaid.live",
-  skipDisabledOptimization: false
+  skipDisabledOptimization: false,
+  excludeExternalLibrariesWhenSkipLibCheck: true
 }
 
 const booleanSchema = (description: string, defaultValue: boolean): JsonSchema => ({
@@ -268,6 +270,10 @@ export const languageServicePluginAdditionalPropertiesJsonSchema = {
   skipDisabledOptimization: booleanSchema(
     "When enabled, disabled diagnostics are still processed so comment-based overrides can be honored.",
     defaults.skipDisabledOptimization
+  ),
+  excludeExternalLibrariesWhenSkipLibCheck: booleanSchema(
+    "When enabled with skipLibCheck, external library files are skipped by patched tsc diagnostics.",
+    defaults.excludeExternalLibrariesWhenSkipLibCheck
   )
 } satisfies Record<LanguageServicePluginAdditionalProperty, JsonSchema>
 
@@ -404,6 +410,11 @@ export function parse(config: any): LanguageServicePluginOptions {
     skipDisabledOptimization: isObject(config) && hasProperty(config, "skipDisabledOptimization") &&
         isBoolean(config.skipDisabledOptimization)
       ? config.skipDisabledOptimization
-      : defaults.skipDisabledOptimization
+      : defaults.skipDisabledOptimization,
+    excludeExternalLibrariesWhenSkipLibCheck:
+      isObject(config) && hasProperty(config, "excludeExternalLibrariesWhenSkipLibCheck") &&
+        isBoolean(config.excludeExternalLibrariesWhenSkipLibCheck)
+        ? config.excludeExternalLibrariesWhenSkipLibCheck
+        : defaults.excludeExternalLibrariesWhenSkipLibCheck
   }
 }

--- a/packages/language-service/src/effect-lsp-patch-utils.ts
+++ b/packages/language-service/src/effect-lsp-patch-utils.ts
@@ -62,6 +62,12 @@ export function checkSourceFileWorker(
     diagnosticsName: true
   }
 
+  if (
+    program.getCompilerOptions().skipLibCheck &&
+    parsedOptions.excludeExternalLibrariesWhenSkipLibCheck &&
+    program.isSourceFileFromExternalLibrary(sourceFile)
+  ) return
+
   // run the diagnostics and pipe them into addDiagnostic
   pipe(
     LSP.getSemanticDiagnosticsWithCodeFixes(diagnostics, sourceFile),

--- a/schema.json
+++ b/schema.json
@@ -1369,6 +1369,11 @@
                         "description": "When enabled, disabled diagnostics are still processed so comment-based overrides can be honored.",
                         "default": false
                       },
+                      "excludeExternalLibrariesWhenSkipLibCheck": {
+                        "type": "boolean",
+                        "description": "When enabled with skipLibCheck, external library files are skipped by patched tsc diagnostics.",
+                        "default": true
+                      },
                       "diagnosticSeverity": {
                         "$ref": "#/definitions/effectLanguageServicePluginDiagnosticSeverityDefinition"
                       }


### PR DESCRIPTION
## Summary
- add excludeExternalLibrariesWhenSkipLibCheck plugin option, enabled by default
- skip Effect diagnostics for external library files during patched tsc runs when TypeScript skipLibCheck is enabled
- document the option, regenerate schema, and add a patch changeset

## Example
```jsonc
{
  "compilerOptions": {
    "skipLibCheck": true,
    "plugins": [{
      "name": "@effect/language-service",
      "excludeExternalLibrariesWhenSkipLibCheck": true
    }]
  }
}
```

## Validation
- pnpm codegen
- pnpm lint-fix
- pnpm check
- pnpm test
- pnpm test:v4