### PR TITLE
Speed up diagnostics tests

### DIFF
--- a/.changeset/fast-diagnostics-tests.md
+++ b/.changeset/fast-diagnostics-tests.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Enable `skipLibCheck` in the diagnostics test harness to reduce test runtime and memory usage.

--- a/packages/language-service/test/diagnostics.test.ts
+++ b/packages/language-service/test/diagnostics.test.ts
@@ -27,6 +27,7 @@ const getExamplesDiagnosticsDir = () => getExamplesSubdir("diagnostics")
 
 function compilerOptionsFromSourceComment(sourceText: string): ts.CompilerOptions {
   return {
+    skipLibCheck: true,
     ...(sourceText.includes("// @strict") ? { strict: true } : {})
   }
 }


### PR DESCRIPTION
## Summary

- enable `skipLibCheck` for mocked TypeScript programs in the diagnostics test harness
- apply the option to initial diagnostics, quick-fix checks, and post-fix validation programs
- reduce time and memory spent checking dependency declaration files that are outside the diagnostic fixtures

## Performance

A controlled v4 run over 14 diagnostic and quick-fix tests measured:

| Configuration | Wall time | Test time | Peak RSS |
| --- | ---: | ---: | ---: |
| `skipLibCheck: true` | 25.95s | 23.78s | 1.81 GB |
| `skipLibCheck: false` | 61.09s | 58.78s | 2.82 GB |
| `skipLibCheck: true` | 25.99s | 23.68s | 1.78 GB |

This is approximately 57.5% lower wall time and 36% lower peak memory.

## Validation

- `pnpm codegen`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test`
- `pnpm test:v4`