### PR TITLE
Update setup command VS Code settings

### DIFF
--- a/.changeset/modern-vscode-setup.md
+++ b/.changeset/modern-vscode-setup.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Update the setup command to configure VS Code with the unified `js/ts` TypeScript settings.

--- a/packages/harness-effect-v3/__snapshots__/setup-cli.test.ts.snap
+++ b/packages/harness-effect-v3/__snapshots__/setup-cli.test.ts.snap
@@ -96,8 +96,8 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig
 
 exports[`Setup CLI > should add LSP with VS Code editor selected and configure VS Code settings > .vscode/settings.json 1`] = `
 "{
-	"typescript.tsdk": "./node_modules/typescript/lib",
-	"typescript.enablePromptUseWorkspaceTsdk": true
+	"js/ts.tsdk.path": "./node_modules/typescript/lib",
+	"js/ts.tsdk.promptToUseWorkspaceVersion": true
 }"
 `;
 
@@ -112,7 +112,7 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and configure V
     "file": "tsconfig.json",
   },
   {
-    "description": "Add typescript.tsdk setting; Add typescript.enablePromptUseWorkspaceTsdk setting",
+    "description": "Add js/ts.tsdk.path setting; Add js/ts.tsdk.promptToUseWorkspaceVersion setting",
     "file": ".vscode/settings.json",
   },
 ]
@@ -568,8 +568,8 @@ exports[`Setup CLI > should preserve existing VSCode settings when adding LSP-sp
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "files.autoSave": "onFocusChange",
-"typescript.enablePromptUseWorkspaceTsdk": true,
-"typescript.tsdk": "./node_modules/typescript/lib"
+"js/ts.tsdk.promptToUseWorkspaceVersion": true,
+"js/ts.tsdk.path": "./node_modules/typescript/lib"
 }"
 `;
 
@@ -584,7 +584,7 @@ exports[`Setup CLI > should preserve existing VSCode settings when adding LSP-sp
     "file": "tsconfig.json",
   },
   {
-    "description": "Add typescript.tsdk setting; Add typescript.enablePromptUseWorkspaceTsdk setting",
+    "description": "Add js/ts.tsdk.path setting; Add js/ts.tsdk.promptToUseWorkspaceVersion setting",
     "file": ".vscode/settings.json",
   },
 ]

--- a/packages/harness-effect-v4/__snapshots__/setup-cli.test.ts.snap
+++ b/packages/harness-effect-v4/__snapshots__/setup-cli.test.ts.snap
@@ -96,8 +96,8 @@ exports[`Setup CLI > should add LSP plugin alongside existing plugins > tsconfig
 
 exports[`Setup CLI > should add LSP with VS Code editor selected and configure VS Code settings > .vscode/settings.json 1`] = `
 "{
-	"typescript.tsdk": "./node_modules/typescript/lib",
-	"typescript.enablePromptUseWorkspaceTsdk": true
+	"js/ts.tsdk.path": "./node_modules/typescript/lib",
+	"js/ts.tsdk.promptToUseWorkspaceVersion": true
 }"
 `;
 
@@ -112,7 +112,7 @@ exports[`Setup CLI > should add LSP with VS Code editor selected and configure V
     "file": "tsconfig.json",
   },
   {
-    "description": "Add typescript.tsdk setting; Add typescript.enablePromptUseWorkspaceTsdk setting",
+    "description": "Add js/ts.tsdk.path setting; Add js/ts.tsdk.promptToUseWorkspaceVersion setting",
     "file": ".vscode/settings.json",
   },
 ]
@@ -568,8 +568,8 @@ exports[`Setup CLI > should preserve existing VSCode settings when adding LSP-sp
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "files.autoSave": "onFocusChange",
-"typescript.enablePromptUseWorkspaceTsdk": true,
-"typescript.tsdk": "./node_modules/typescript/lib"
+"js/ts.tsdk.promptToUseWorkspaceVersion": true,
+"js/ts.tsdk.path": "./node_modules/typescript/lib"
 }"
 `;
 
@@ -584,7 +584,7 @@ exports[`Setup CLI > should preserve existing VSCode settings when adding LSP-sp
     "file": "tsconfig.json",
   },
   {
-    "description": "Add typescript.tsdk setting; Add typescript.enablePromptUseWorkspaceTsdk setting",
+    "description": "Add js/ts.tsdk.path setting; Add js/ts.tsdk.promptToUseWorkspaceVersion setting",
     "file": ".vscode/settings.json",
   },
 ]

--- a/packages/language-service/src/cli/setup/changes.ts
+++ b/packages/language-service/src/cli/setup/changes.ts
@@ -73,8 +73,8 @@ export const computeChanges = (
       if (Option.isSome(target.packageJson.lspVersion) && Option.isSome(assessment.vscodeSettings)) {
         const vscodeTarget: Target.VSCodeSettings = {
           settings: {
-            "typescript.tsdk": "./node_modules/typescript/lib",
-            "typescript.enablePromptUseWorkspaceTsdk": true
+            "js/ts.tsdk.path": "./node_modules/typescript/lib",
+            "js/ts.tsdk.promptToUseWorkspaceVersion": true
           }
         }
 

--- a/packages/language-service/test/setup-cli.test.ts
+++ b/packages/language-service/test/setup-cli.test.ts
@@ -754,9 +754,9 @@ describe("Setup CLI", () => {
         }
       },
       {
-        "typescript.tsdk": "./packages/core/node_modules/typescript/lib",
+        "js/ts.tsdk.path": "./packages/core/node_modules/typescript/lib",
         "typescript.preferences.importModuleSpecifier": "non-relative",
-        "typescript.enablePromptUseWorkspaceTsdk": true,
+        "js/ts.tsdk.promptToUseWorkspaceVersion": true,
         "editor.formatOnSave": true,
         "eslint.format.enable": true,
         "editor.acceptSuggestionOnCommitCharacter": true,


### PR DESCRIPTION
## Summary

- configure VS Code with `js/ts.tsdk.path` and `js/ts.tsdk.promptToUseWorkspaceVersion` from the setup command
- preserve existing unified VS Code setting values
- update Effect v3 and v4 setup snapshots

## Testing

- `pnpm codegen`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test`
- `pnpm test:v4`