### PR TITLE
Handle local Effect.provide calls

### DIFF
--- a/.changeset/local-effect-provides.md
+++ b/.changeset/local-effect-provides.md
@@ -1,0 +1,5 @@
+---
+"@effect/language-service": patch
+---
+
+Ignore Effect v4 local `Effect.provide(..., { local: true })` calls when reporting chained provides with the `multipleEffectProvide` diagnostic.

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.codefixes
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.codefixes
@@ -10,3 +10,6 @@ multipleEffectProvide_skipFile from 819 to 853
 multipleEffectProvide_fix from 949 to 983
 multipleEffectProvide_skipNextLine from 949 to 983
 multipleEffectProvide_skipFile from 949 to 983
+multipleEffectProvide_fix from 1339 to 1373
+multipleEffectProvide_skipNextLine from 1339 to 1373
+multipleEffectProvide_skipFile from 1339 to 1373

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from1339to1373.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from1339to1373.output
@@ -1,4 +1,4 @@
-// code fix multipleEffectProvide_fix  output for range 592 - 626
+// code fix multipleEffectProvide_fix  output for range 1339 - 1373
 import { Context, Effect, Layer } from "effect"
 
 class MyService1 extends Context.Service<MyService1>()("MyService1", {
@@ -20,7 +20,8 @@ class MyService3 extends Context.Service<MyService3>()("MyService3", {
 }
 
 export const shouldReport = Effect.void.pipe(
-  Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default))
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default)
 )
 
 export const shouldReportSeparately = Effect.void.pipe(
@@ -44,6 +45,5 @@ export const shouldNotReportLocalProvide = Effect.void.pipe(
 
 export const shouldReportAfterLocalProvide = Effect.void.pipe(
   Effect.provide(MyService1.Default, { local: true }),
-  Effect.provide(MyService2.Default),
-  Effect.provide(MyService3.Default)
+  Effect.provide(Layer.mergeAll(MyService2.Default, MyService3.Default))
 )

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from726to760.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from726to760.output
@@ -36,3 +36,14 @@ export const shouldReportSingle = Effect.void.pipe(
   Effect.provide(MyService2.Default),
   Effect.provide(MyService3.Default)
 )
+
+export const shouldNotReportLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default, { local: true })
+)
+
+export const shouldReportAfterLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default, { local: true }),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from819to853.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from819to853.output
@@ -36,3 +36,14 @@ export const shouldReportSingle = Effect.void.pipe(
   Effect.provide(MyService2.Default),
   Effect.provide(MyService3.Default)
 )
+
+export const shouldNotReportLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default, { local: true })
+)
+
+export const shouldReportAfterLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default, { local: true }),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from949to983.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.multipleEffectProvide_fix.from949to983.output
@@ -35,3 +35,14 @@ export const shouldReportSeparately = Effect.void.pipe(
 export const shouldReportSingle = Effect.void.pipe(
   Effect.provide(Layer.mergeAll(MyService1.Default, MyService2.Default, MyService3.Default))
 )
+
+export const shouldNotReportLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default, { local: true })
+)
+
+export const shouldReportAfterLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default, { local: true }),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.output
+++ b/packages/harness-effect-v4/__snapshots__/diagnostics/multipleEffectProvide.ts.output
@@ -9,3 +9,6 @@ Effect.provide(MyService1.Default)
 
 Effect.provide(MyService1.Default)
 35:2 - 35:36 | 0 | This expression chains multiple `Effect.provide` calls. Providing Layers in multiple calls in a chain can break service lifecycle behavior compared with a single combined provide with merged layers.    effect(multipleEffectProvide)
+
+Effect.provide(MyService2.Default)
+47:2 - 47:36 | 0 | This expression chains multiple `Effect.provide` calls. Providing Layers in multiple calls in a chain can break service lifecycle behavior compared with a single combined provide with merged layers.    effect(multipleEffectProvide)

--- a/packages/harness-effect-v4/examples/diagnostics/multipleEffectProvide.ts
+++ b/packages/harness-effect-v4/examples/diagnostics/multipleEffectProvide.ts
@@ -36,3 +36,14 @@ export const shouldReportSingle = Effect.void.pipe(
   Effect.provide(MyService2.Default),
   Effect.provide(MyService3.Default)
 )
+
+export const shouldNotReportLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default),
+  Effect.provide(MyService2.Default, { local: true })
+)
+
+export const shouldReportAfterLocalProvide = Effect.void.pipe(
+  Effect.provide(MyService1.Default, { local: true }),
+  Effect.provide(MyService2.Default),
+  Effect.provide(MyService3.Default)
+)

--- a/packages/language-service/src/diagnostics/multipleEffectProvide.ts
+++ b/packages/language-service/src/diagnostics/multipleEffectProvide.ts
@@ -21,6 +21,7 @@ export const multipleEffectProvide = LSP.createDiagnostic({
     const tsUtils = yield* Nano.service(TypeScriptUtils.TypeScriptUtils)
     const typeCheckerUtils = yield* Nano.service(TypeCheckerUtils.TypeCheckerUtils)
     const typeParser = yield* Nano.service(TypeParser.TypeParser)
+    const supportedEffect = typeParser.supportedEffect()
 
     const effectModuleIdentifier = tsUtils.findImportedModuleIdentifierByPackageAndNameOrBarrel(
       sourceFile,
@@ -58,6 +59,23 @@ export const multipleEffectProvide = LSP.createDiagnostic({
         )
 
         if (Option.isSome(isProvideCall)) {
+          const options = transformation.args[1]
+          const isLocalProvide = supportedEffect === "v4" &&
+            options !== undefined &&
+            ts.isObjectLiteralExpression(options) &&
+            options.properties.some((property) =>
+              ts.isPropertyAssignment(property) &&
+              ts.isIdentifier(property.name) &&
+              ts.idText(property.name) === "local" &&
+              property.initializer.kind === ts.SyntaxKind.TrueKeyword
+            )
+
+          if (isLocalProvide) {
+            currentChunk++
+            previousLayers.push([])
+            continue
+          }
+
           const layer = transformation.args[0]
           const type = typeCheckerUtils.getTypeAtLocation(layer)
           const node = ts.findAncestor(transformation.callee, ts.isCallExpression)


### PR DESCRIPTION
## Summary

- Treat Effect v4 `Effect.provide(layer, { local: true })` transformations as boundaries in `multipleEffectProvide`
- Continue reporting and fixing chains of two or more non-local provides after a local provide
- Add v4 fixtures, snapshots, and a patch changeset

## Example

```ts
Effect.void.pipe(
  Effect.provide(LocalLayer, { local: true }),
  Effect.provide(LayerA),
  Effect.provide(LayerB)
)
```

The local provide is preserved, while the diagnostic and fix target only `LayerA` and `LayerB`.

## Testing

- `pnpm codegen`
- `pnpm lint-fix`
- `pnpm check`
- `pnpm test`
- `pnpm test:v4`